### PR TITLE
[WIP] Move time filter to second loop. Randomize.

### DIFF
--- a/ring/consul_client.go
+++ b/ring/consul_client.go
@@ -31,10 +31,11 @@ const (
 // such as CAS and Watch which take callbacks.  It also deals with serialisation
 // by having an instance factory passed in to methods and deserialising into that.
 type ConsulClient interface {
-	Get(key string, factory InstanceFactory) error
 	CAS(key string, factory InstanceFactory, f CASCallback) error
-	WatchPrefix(path string, factory InstanceFactory, done <-chan struct{}, f func(string, interface{}) bool)
 	WatchKey(key string, factory InstanceFactory, done <-chan struct{}, f func(interface{}) bool)
+	// XXX: The following three are unused in the code-base. Can we delete them?
+	Get(key string, factory InstanceFactory) error
+	WatchPrefix(path string, factory InstanceFactory, done <-chan struct{}, f func(string, interface{}) bool)
 	PutBytes(key string, buf []byte) error
 }
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -96,7 +96,7 @@ func (r *Ring) Stop() {
 
 func (r *Ring) loop() {
 	defer close(r.done)
-	r.client.WatchKey(consulKey, descFactory, r.quit, func(value interface{}) bool {
+	r.client.WatchKey(registryKey, descFactory, r.quit, func(value interface{}) bool {
 		if value == nil {
 			log.Infof("Ring doesn't exist in consul yet.")
 			return true

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -1,0 +1,43 @@
+package ring_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaveworks/cortex/ring"
+)
+
+const (
+	// XXX: This leads to a race condition in the tests. We should instead either:
+	// a) pass in "Now"
+	// b) separate the timeout layer from the selection layer
+	forever = 24 * time.Hour
+)
+
+type FakeStateClient struct {
+	values chan interface{}
+}
+
+// WatchKey implements CoordinationStateClient.
+//
+// Pulls from the 'values' channel.
+func (c FakeStateClient) WatchKey(key string, factory ring.InstanceFactory, done <-chan struct{}, f func(interface{}) bool) {
+	for {
+		select {
+		case <-done:
+			return
+		case value := <-c.values:
+			if !f(value) {
+				return
+			}
+		}
+	}
+}
+
+func Test_NewRingIsEmptyRing(t *testing.T) {
+	r := ring.New(FakeStateClient{})
+	defer r.Stop()
+	assert.Equal(t, len(r.GetAll(forever)), 0)
+}


### PR DESCRIPTION
@tomwilkie and I talked about this in the office. I thought I'd do it to check my own understanding.

I think the existing logic is right, btw. The `continue` happens after `distinctHosts` has been accumulated, so it doesn't cause the list to go past the boundary of the algorithm.

I don't know how to idiomatically shuffle a slice in Go. This seems plausible.

We should have tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/cortex/74)

<!-- Reviewable:end -->
