### PR TITLE
Move querier to separate package

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/weaveworks/cortex"
 	"github.com/weaveworks/cortex/chunk"
 	"github.com/weaveworks/cortex/ingester"
+	"github.com/weaveworks/cortex/querier"
 	"github.com/weaveworks/cortex/ring"
 	"github.com/weaveworks/cortex/ui"
 	"github.com/weaveworks/cortex/user"
@@ -207,10 +208,10 @@ func setupQuerier(
 	prefix string,
 	logSuccess bool,
 ) {
-	querier := cortex.MergeQuerier{
-		Queriers: []cortex.Querier{
+	querier := querier.MergeQuerier{
+		Queriers: []querier.Querier{
 			distributor,
-			&cortex.ChunkQuerier{
+			&querier.ChunkQuerier{
 				Store: chunkStore,
 			},
 		},

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -125,18 +125,15 @@ func main() {
 		}
 		defer ring.Stop()
 		setupDistributor(cfg.distributorConfig, chunkStore, cfg.logSuccess)
-		if err != nil {
-			log.Fatalf("Error initializing distributor: %v", err)
-		}
 	case modeIngester:
 		registration, err := ring.RegisterIngester(consul, cfg.listenPort, cfg.numTokens)
-		prometheus.MustRegister(registration)
 		if err != nil {
 			// This only happens for errors in configuration & set-up, not for
 			// network errors.
 			log.Fatalf("Could not register ingester: %v", err)
 		}
 		defer registration.Unregister()
+		prometheus.MustRegister(registration)
 		ing := setupIngester(chunkStore, cfg.ingesterConfig, cfg.logSuccess)
 		defer ing.Stop()
 	default:

--- a/querier/iterator.go
+++ b/querier/iterator.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cortex
+package querier
 
 import (
 	"sort"

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cortex
+package querier
 
 import (
 	"fmt"

--- a/server.go
+++ b/server.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/weaveworks/cortex/ingester"
+	"github.com/weaveworks/cortex/querier"
 	"github.com/weaveworks/cortex/user"
 )
 
@@ -151,7 +152,7 @@ func AppenderHandler(appender SampleAppender) http.Handler {
 
 // QueryHandler returns a http.Handler that accepts protobuf formatted
 // query requests and serves them.
-func QueryHandler(querier Querier) http.Handler {
+func QueryHandler(querier querier.Querier) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := &ReadRequest{}
 		ctx, abort := parseRequest(w, r, req)
@@ -217,7 +218,7 @@ func QueryHandler(querier Querier) http.Handler {
 }
 
 // LabelValuesHandler handles label values
-func LabelValuesHandler(querier Querier) http.Handler {
+func LabelValuesHandler(querier querier.Querier) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := &LabelValuesRequest{}
 		ctx, abort := parseRequest(w, r, req)


### PR DESCRIPTION
Started working on recording rules, wanted to:
- put it in a separate package to `cortex`
- use querier

Thus, split it to `querier` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/cortex/76)
<!-- Reviewable:end -->
