### PR TITLE
Refactor chunks-to-matrix code and its deps

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -4,6 +4,9 @@ package chunk
 
 import (
 	"github.com/prometheus/common/model"
+	prom_chunk "github.com/prometheus/prometheus/storage/local/chunk"
+
+	"github.com/weaveworks/cortex/util"
 )
 
 // Chunk contains encoded timeseries data
@@ -21,3 +24,50 @@ type ByID []Chunk
 func (cs ByID) Len() int           { return len(cs) }
 func (cs ByID) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
 func (cs ByID) Less(i, j int) bool { return cs[i].ID < cs[j].ID }
+
+// ChunksToMatrix converts a slice of chunks into a model.Matrix.
+func ChunksToMatrix(chunks []Chunk) (model.Matrix, error) {
+	// Group chunks by series, sort and dedupe samples.
+	sampleStreams := map[model.Fingerprint]*model.SampleStream{}
+
+	for _, c := range chunks {
+		fp := c.Metric.Fingerprint()
+		ss, ok := sampleStreams[fp]
+		if !ok {
+			ss = &model.SampleStream{
+				Metric: c.Metric,
+			}
+			sampleStreams[fp] = ss
+		}
+
+		samples, err := decodeChunk(c.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		ss.Values = util.MergeSamples(ss.Values, samples)
+	}
+
+	matrix := make(model.Matrix, 0, len(sampleStreams))
+	for _, ss := range sampleStreams {
+		matrix = append(matrix, ss)
+	}
+
+	return matrix, nil
+}
+
+func decodeChunk(buf []byte) ([]model.SamplePair, error) {
+	lc, err := prom_chunk.NewForEncoding(prom_chunk.DoubleDelta)
+	if err != nil {
+		return nil, err
+	}
+	lc.UnmarshalFromBuf(buf)
+	it := lc.NewIterator()
+	// TODO(juliusv): Pre-allocate this with the right length again once we
+	// add a method upstream to get the number of samples in a chunk.
+	var samples []model.SamplePair
+	for it.Scan() {
+		samples = append(samples, it.Value())
+	}
+	return samples, nil
+}

--- a/distributor.go
+++ b/distributor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaveworks/cortex/ingester"
 	"github.com/weaveworks/cortex/ring"
 	"github.com/weaveworks/cortex/user"
+	"github.com/weaveworks/cortex/util"
 )
 
 var (
@@ -294,7 +295,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 						Values: ss.Values,
 					}
 				} else {
-					mss.Values = mergeSamples(fpToSampleStream[fp].Values, ss.Values)
+					mss.Values = util.MergeSamples(fpToSampleStream[fp].Values, ss.Values)
 				}
 			}
 		}
@@ -311,31 +312,6 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 		return nil
 	})
 	return result, err
-}
-
-func mergeSamples(a, b []model.SamplePair) []model.SamplePair {
-	result := make([]model.SamplePair, 0, len(a)+len(b))
-	i, j := 0, 0
-	for i < len(a) && j < len(b) {
-		if a[i].Timestamp < b[j].Timestamp {
-			result = append(result, a[i])
-			i++
-		} else if a[i].Timestamp > b[j].Timestamp {
-			result = append(result, b[j])
-			j++
-		} else {
-			result = append(result, a[i])
-			i++
-			j++
-		}
-	}
-	for ; i < len(a); i++ {
-		result = append(result, a[i])
-	}
-	for ; j < len(b); j++ {
-		result = append(result, b[j])
-	}
-	return result
 }
 
 // LabelValuesForLabelName returns all of the label values that are associated with a given label name.

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,29 @@
+package util
+
+import "github.com/prometheus/common/model"
+
+// MergeSamples merges and dedupes two sets of already sorted sample pairs.
+func MergeSamples(a, b []model.SamplePair) []model.SamplePair {
+	result := make([]model.SamplePair, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i].Timestamp < b[j].Timestamp {
+			result = append(result, a[i])
+			i++
+		} else if a[i].Timestamp > b[j].Timestamp {
+			result = append(result, b[j])
+			j++
+		} else {
+			result = append(result, a[i])
+			i++
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		result = append(result, a[i])
+	}
+	for ; j < len(b); j++ {
+		result = append(result, b[j])
+	}
+	return result
+}


### PR DESCRIPTION
As promised in https://github.com/weaveworks/cortex/pull/78...

This also gets rid of any `sort.Sort` usage for merging&sorting incoming samples, which *should* be ok if we can assume that the samples in any chunks we read (as well as data from the ingesters) are already sorted. Then we just merge their samples together linearly, which includes deduplication.

Since `MergeSamples` is now being used by different packages and there was no natural other home for it, I started a `util` package.