### PR TITLE
Add per-token state, and use it to not write to Leaving ingesters

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -93,7 +93,6 @@ func main() {
 	flag.IntVar(&cfg.numTokens, "ingester.num-tokens", 128, "Number of tokens for each ingester.")
 	flag.IntVar(&cfg.distributorConfig.ReplicationFactor, "distributor.replication-factor", 3, "The number of ingesters to write to and read from.")
 	flag.IntVar(&cfg.distributorConfig.MinReadSuccesses, "distributor.min-read-successes", 2, "The minimum number of ingesters from which a read must succeed.")
-	flag.IntVar(&cfg.distributorConfig.MinWriteSuccesses, "distributor.min-write-successes", 2, "The minimum number of ingesters to which a write must succeed.")
 	flag.DurationVar(&cfg.distributorConfig.HeartbeatTimeout, "distributor.heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes.")
 	flag.BoolVar(&cfg.logSuccess, "log.success", false, "Log successful requests")
 	flag.Parse()
@@ -125,7 +124,6 @@ func main() {
 			// network errors.
 			log.Fatalf("Could not register ingester: %v", err)
 		}
-		prometheus.MustRegister(registration)
 		ing := setupIngester(chunkStore, cfg.ingesterConfig, cfg.logSuccess)
 
 		// Deferring a func to make ordering obvious
@@ -134,6 +132,8 @@ func main() {
 			ing.Stop()
 			registration.Unregister()
 		}()
+
+		prometheus.MustRegister(registration)
 	default:
 		log.Fatalf("Mode %s not supported!", cfg.mode)
 	}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -125,10 +125,14 @@ func main() {
 			// network errors.
 			log.Fatalf("Could not register ingester: %v", err)
 		}
-		defer registration.Unregister()
 		prometheus.MustRegister(registration)
 		ing := setupIngester(chunkStore, cfg.ingesterConfig, cfg.logSuccess)
-		defer ing.Stop()
+
+		defer func() {
+			registration.ChangeState(ring.Leaving)
+			ing.Stop()
+			registration.Unregister()
+		}()
 	default:
 		log.Fatalf("Mode %s not supported!", cfg.mode)
 	}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -128,6 +128,7 @@ func main() {
 		prometheus.MustRegister(registration)
 		ing := setupIngester(chunkStore, cfg.ingesterConfig, cfg.logSuccess)
 
+		// Deferring a func to make ordering obvious
 		defer func() {
 			registration.ChangeState(ring.Leaving)
 			ing.Stop()

--- a/cortex-build/Dockerfile
+++ b/cortex-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.3
+FROM golang:1.7.3
 RUN apt-get update && apt-get install -y python-requests python-yaml file jq && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \

--- a/distributor.go
+++ b/distributor.go
@@ -192,7 +192,7 @@ func (d *Distributor) Append(ctx context.Context, samples []*model.Sample) error
 		}
 
 		// Skip those that have not heartbeated in a while. NB these are still
-		// included in the calculation of minSuccess, so too many failed ingesters
+		// included in the calculation of minSuccess, so if too many failed ingesters
 		// will cause the whole write to fail.
 		liveIngesters := make([]string, len(ingesters[i]))
 		for _, ingester := range ingesters[i] {
@@ -201,7 +201,7 @@ func (d *Distributor) Append(ctx context.Context, samples []*model.Sample) error
 			}
 		}
 		if len(liveIngesters) < sampleTrackers[i].minSuccess {
-			return fmt.Errorf("Wanted at least %d live ingesters to process write, had %d.",
+			return fmt.Errorf("wanted at least %d live ingesters to process write, had %d.",
 				sampleTrackers[i].minSuccess, len(liveIngesters))
 		}
 

--- a/distributor.go
+++ b/distributor.go
@@ -201,7 +201,7 @@ func (d *Distributor) Append(ctx context.Context, samples []*model.Sample) error
 			}
 		}
 		if len(liveIngesters) < sampleTrackers[i].minSuccess {
-			return fmt.Errorf("wanted at least %d live ingesters to process write, had %d.",
+			return fmt.Errorf("wanted at least %d live ingesters to process write, had %d",
 				sampleTrackers[i].minSuccess, len(liveIngesters))
 		}
 

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -61,6 +61,7 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*In
 		hostname: fmt.Sprintf("%s:%d", addr, listenPort),
 		quit:     make(chan struct{}),
 
+		// Only read/written on actor goroutine.
 		state:       Active,
 		stateChange: make(chan TokenState),
 
@@ -76,7 +77,7 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*In
 }
 
 func (r *IngesterRegistration) ChangeState(state TokenState) {
-	log.Info("Leaving the ring")
+	log.Info("Changing token state to: %v", state)
 	r.stateChange <- state
 }
 

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -76,6 +76,8 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*In
 	return r, nil
 }
 
+// ChangeState changes the state of all tokens owned by this
+// ingester in the ring.
 func (r *IngesterRegistration) ChangeState(state TokenState) {
 	log.Info("Changing token state to: %v", state)
 	r.stateChange <- state

--- a/ring/model.go
+++ b/ring/model.go
@@ -7,8 +7,10 @@ import (
 	"github.com/prometheus/common/log"
 )
 
+// TokenState describes the state of a token
 type TokenState int
 
+// Values for TokenState
 const (
 	Active TokenState = iota
 	Leaving

--- a/ring/model.go
+++ b/ring/model.go
@@ -7,6 +7,13 @@ import (
 	"github.com/prometheus/common/log"
 )
 
+type TokenState int
+
+const (
+	Active TokenState = iota
+	Leaving
+)
+
 // Desc is the serialised state in Consul representing
 // all ingesters (ie, the ring).
 type Desc struct {
@@ -29,8 +36,9 @@ func (ts TokenDescs) Less(i, j int) bool { return ts[i].Token < ts[j].Token }
 
 // TokenDesc describes an individual token in the ring.
 type TokenDesc struct {
-	Token    uint32 `json:"tokens"`
-	Ingester string `json:"ingester"`
+	Token    uint32     `json:"tokens"`
+	Ingester string     `json:"ingester"`
+	State    TokenState `json:"state"`
 }
 
 func descFactory() interface{} {
@@ -43,7 +51,7 @@ func newDesc() *Desc {
 	}
 }
 
-func (d *Desc) addIngester(id, hostname string, tokens []uint32) {
+func (d *Desc) addIngester(id, hostname string, tokens []uint32, state TokenState) {
 	d.Ingesters[id] = IngesterDesc{
 		Hostname:  hostname,
 		Timestamp: time.Now(),
@@ -53,6 +61,7 @@ func (d *Desc) addIngester(id, hostname string, tokens []uint32) {
 		d.Tokens = append(d.Tokens, TokenDesc{
 			Token:    token,
 			Ingester: id,
+			State:    state,
 		})
 	}
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -18,6 +18,15 @@ const (
 	unhealthyLabel = "unhealthy"
 )
 
+// Operation can be Read or Write
+type Operation int
+
+// Values for Operation
+const (
+	Read Operation = iota
+	Write
+)
+
 type uint32s []uint32
 
 func (x uint32s) Len() int           { return len(x) }
@@ -96,13 +105,6 @@ func (r *Ring) loop() {
 	})
 }
 
-type Operation int
-
-const (
-	Read Operation = iota
-	Write
-)
-
 // Get returns n (or more) ingesters which form the replicas for the given key.
 func (r *Ring) Get(key uint32, n int, op Operation) ([]IngesterDesc, error) {
 	r.mtx.RLock()
@@ -110,6 +112,8 @@ func (r *Ring) Get(key uint32, n int, op Operation) ([]IngesterDesc, error) {
 	return r.getInternal(key, n, op)
 }
 
+// BatchGet returns n (or more) ingesters which form the replicas for the given key.
+// The order of the result matches the order of the input.
 func (r *Ring) BatchGet(keys []uint32, n int, op Operation) ([][]IngesterDesc, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()


### PR DESCRIPTION
Fixes #87

- Mark tokens as Active or Leaving
- Do not include Leaving tokens in a write operations replica set
- For any operation, if you hit a Leaving token, increase size of replication group by 1.