### PR TITLE
Add boilerplate for caching the build image on circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,14 @@ machine:
     PATH: /usr/local/go/bin:$HOME/bin:$PATH
 
 dependencies:
+  cache_directories:
+    - "~/docker"
   override:
     - go get -u github.com/weaveworks/build-tools/cmd/wcloud
+    - |
+        cd cortex-build && \
+        ../tools/rebuild-image weaveworks/cortex-build . build.sh Dockerfile && \
+        touch .uptodate
 
 test:
   override:


### PR DESCRIPTION
To speed up builds, so I can haz faster iterations