### PR TITLE
Add more chunk metrics

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -68,6 +68,7 @@ type Ingester struct {
 	ingestedSamples    prometheus.Counter
 	discardedSamples   *prometheus.CounterVec
 	chunkUtilization   prometheus.Histogram
+	chunkLength        prometheus.Histogram
 	chunkStoreFailures prometheus.Counter
 	queries            prometheus.Counter
 	queriedSamples     prometheus.Counter
@@ -133,6 +134,11 @@ func New(cfg Config, chunkStore cortex.Store) (*Ingester, error) {
 			Name:    "cortex_ingester_chunk_utilization",
 			Help:    "Distribution of stored chunk utilization.",
 			Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9},
+		}),
+		chunkLength: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_chunk_length",
+			Help:    "Distribution of stored chunk lengths.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
 		}),
 		memoryChunks: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_chunks",
@@ -523,6 +529,7 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 		}
 
 		i.chunkUtilization.Observe(chunk.C.Utilization())
+		i.chunkLength.Observe(chunk.C.Len())
 
 		wireChunks = append(wireChunks, cortex.Chunk{
 			ID:      fmt.Sprintf("%d:%d:%d", fp, chunk.ChunkFirstTime, chunk.ChunkLastTime),

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -69,6 +69,7 @@ type Ingester struct {
 	discardedSamples   *prometheus.CounterVec
 	chunkUtilization   prometheus.Histogram
 	chunkLength        prometheus.Histogram
+	chunkAge           prometheus.Histogram
 	chunkStoreFailures prometheus.Counter
 	queries            prometheus.Counter
 	queriedSamples     prometheus.Counter
@@ -132,13 +133,18 @@ func New(cfg Config, chunkStore cortex.Store) (*Ingester, error) {
 		),
 		chunkUtilization: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_utilization",
-			Help:    "Distribution of stored chunk utilization.",
+			Help:    "Distribution of stored chunk utilization (when stored).",
 			Buckets: []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9},
 		}),
 		chunkLength: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_length",
-			Help:    "Distribution of stored chunk lengths.",
+			Help:    "Distribution of stored chunk lengths (when stored).",
 			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+		}),
+		chunkAge: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_chunk_age_seconds",
+			Help:    "Distribution of chunk ages (when stored).",
+			Buckets: prometheus.ExponentialBuckets(0.1, 4, 8),
 		}),
 		memoryChunks: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_chunks",
@@ -530,6 +536,7 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 
 		i.chunkUtilization.Observe(chunk.C.Utilization())
 		i.chunkLength.Observe(chunk.C.Len())
+		i.chunkAge.Observe(model.Now().Sub(chunk.ChunkFirstTime).Seconds())
 
 		wireChunks = append(wireChunks, cortex.Chunk{
 			ID:      fmt.Sprintf("%d:%d:%d", fp, chunk.ChunkFirstTime, chunk.ChunkLastTime),

--- a/vendor/github.com/prometheus/prometheus/storage/local/chunk/chunk.go
+++ b/vendor/github.com/prometheus/prometheus/storage/local/chunk/chunk.go
@@ -276,6 +276,9 @@ type Chunk interface {
 	UnmarshalFromBuf([]byte) error
 	Encoding() Encoding
 	Utilization() float64
+
+	// Len estimates the number of samples in the chunk.  Must run in constant time.
+	Len() float64
 }
 
 // Iterator enables efficient access to the content of a chunk. It is

--- a/vendor/github.com/prometheus/prometheus/storage/local/chunk/delta.go
+++ b/vendor/github.com/prometheus/prometheus/storage/local/chunk/delta.go
@@ -303,6 +303,10 @@ func (c deltaEncodedChunk) len() int {
 	return (len(c) - deltaHeaderBytes) / c.sampleSize()
 }
 
+func (c deltaEncodedChunk) Len() float64 {
+	return float64(c.len())
+}
+
 // deltaEncodedIndexAccessor implements indexAccessor.
 type deltaEncodedIndexAccessor struct {
 	c              deltaEncodedChunk

--- a/vendor/github.com/prometheus/prometheus/storage/local/chunk/doubledelta.go
+++ b/vendor/github.com/prometheus/prometheus/storage/local/chunk/doubledelta.go
@@ -346,6 +346,10 @@ func (c doubleDeltaEncodedChunk) len() int {
 	return (len(c)-doubleDeltaHeaderBytes)/c.sampleSize() + 2
 }
 
+func (c doubleDeltaEncodedChunk) Len() float64 {
+	return float64(c.len())
+}
+
 func (c doubleDeltaEncodedChunk) isInt() bool {
 	return c[doubleDeltaHeaderIsIntOffset] == 1
 }

--- a/vendor/github.com/prometheus/prometheus/storage/local/chunk/varbit.go
+++ b/vendor/github.com/prometheus/prometheus/storage/local/chunk/varbit.go
@@ -328,6 +328,19 @@ func (c varbitChunk) Utilization() float64 {
 	return math.Min(float64(c.nextSampleOffset()/8+15)/float64(cap(c)), 1)
 }
 
+// Len implements chunk.
+func (c varbitChunk) Len() float64 {
+	offset := c.nextSampleOffset()
+	switch {
+	case offset == varbitFirstSampleBitOffset:
+		return 0
+	case offset == varbitSecondSampleBitOffset:
+		return 1
+	}
+
+	return float64(int(offset)-varbitFirstValueDeltaOffset) / float64(varbitWorstCaseBitsPerSample[c.valueEncoding()])
+}
+
 // FirstTime implements chunk.
 func (c varbitChunk) FirstTime() model.Time {
 	return model.Time(

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -547,10 +547,10 @@
 		},
 		{
 			"importpath": "github.com/prometheus/prometheus",
-			"repository": "https://github.com/prometheus/prometheus",
+			"repository": "https://github.com/tomwilkie/prometheus",
 			"vcs": "git",
-			"revision": "a94a8807f9e5cc241c4c679f8cec5c1dc86028d9",
-			"branch": "master",
+			"revision": "2561b8565cab4a844a68ef2b7da7c34e8480eaba",
+			"branch": "chunk-len",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
Add `cortex_ingester_chunk_length` (the number of samples per chunk) and `cortex_ingester_chunk_age_seconds` (the age in seconds of the chunk, where ages is now - first sample).

Should help with #11 and #84.  Will need post-merge review #97.