### PR TITLE
Spelling fix

### DIFF
--- a/server.go
+++ b/server.go
@@ -261,7 +261,7 @@ func IngesterUserStatsHandler(statsFn func(context.Context) (*ingester.UserStats
 }
 
 // IngesterReadinessHandler returns 204 when the ingester is ready,
-// 500 otherwise.  Its use by kubernetes to indicate if the ingester
+// 500 otherwise.  It's used by kubernetes to indicate if the ingester
 // pool is ready to have ingesters added / removed.
 func IngesterReadinessHandler(i *ingester.Ingester) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Post-merge review for #92.

Couldn't think of a place to say "All ingesters are considered not ready if one ingester is considered not ready. This is so Kubernetes will only roll out one ingester at a time, and more importantly, only shut ingesters down one at a time, as our ring consistency depends on graceful shutdown."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/cortex/109)
<!-- Reviewable:end -->
