### PR TITLE
Use age of oldest chunk when deciding to flush

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -506,11 +506,15 @@ func (i *Ingester) flushUser(userID string, immediate bool) {
 }
 
 func (i *Ingester) flushSeries(u *userState, fp model.Fingerprint, series *memorySeries, immediate bool) {
-
 	// Enqueue this series flushing if the oldest chunk is older than the threshold
 
 	u.fpLocker.Lock(fp)
-	firstTime := series.head().FirstTime()
+	if len(series.chunkDescs) <= 0 {
+		u.fpLocker.Unlock(fp)
+		return
+	}
+
+	firstTime := series.chunkDescs[0].FirstTime()
 	flush := immediate || model.Now().Sub(firstTime) > i.cfg.MaxChunkAge
 	u.fpLocker.Unlock(fp)
 


### PR DESCRIPTION
Seeing # chunks back up and thing not getting scheduled for flush:

![screen shot 2016-11-07 at 10 29 12](https://cloud.githubusercontent.com/assets/444037/20070387/1019ca9a-a4d5-11e6-963b-8137fdcf4298.png)
