### PR TITLE
Tweak chunk stats buckets

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -170,7 +170,7 @@ func New(cfg Config, chunkStore cortex.Store) (*Ingester, error) {
 		chunkUtilization: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_utilization",
 			Help:    "Distribution of stored chunk utilization (when stored).",
-			Buckets: prometheus.LinearBuckets(0.1, 0.1, 9),
+			Buckets: prometheus.LinearBuckets(0, 0.2, 6),
 		}),
 		chunkLength: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_length",
@@ -180,7 +180,7 @@ func New(cfg Config, chunkStore cortex.Store) (*Ingester, error) {
 		chunkAge: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_age_seconds",
 			Help:    "Distribution of chunk ages (when stored).",
-			Buckets: prometheus.ExponentialBuckets(0.1, 4, 8),
+			Buckets: prometheus.ExponentialBuckets(60, 2, 9),
 		}),
 		memoryChunks: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_chunks",


### PR DESCRIPTION
Fixes #121 

Buckets are capped/maxing out, as seen by the avg exceeding the 99th (but otherwise tracking the 50th):

<img width="1114" alt="screen shot 2016-11-09 at 13 30 22" src="https://cloud.githubusercontent.com/assets/444037/20155431/b14309b6-a680-11e6-92bb-6b92b73a4e9d.png">

Turns out `LinearBuckets` is exclusive, so `LinearBuckets(0.1, 0.1, 9) = [0.1 ... 0.9]`.  
