### PR TITLE
Single-tenant recording rules server

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -171,7 +171,13 @@ func main() {
 			log.Fatalf("Could not set up ruler: %v", err)
 		}
 		// XXX: Single-tenanted as part of our initially super hacky way of dogfooding.
-		ruler.Execute(cfg.rulerConfig.UserID, cfg.rulerConfig.UserToken)
+		worker, err := ruler.Execute(cfg.rulerConfig.UserID, cfg.rulerConfig.UserToken)
+		if err != nil {
+			// XXX: Should *not* fail here. Instead should loop until it works, w/ backoff.
+			log.Fatalf("Could not apply config: %v", err)
+		}
+		go worker.Run()
+		defer worker.Stop()
 
 	default:
 		log.Fatalf("Mode %s not supported!", cfg.mode)

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -105,7 +105,6 @@ func main() {
 	flag.DurationVar(&cfg.distributorConfig.HeartbeatTimeout, "distributor.heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes.")
 	flag.StringVar(&cfg.rulerConfig.ConfigsAPIURL, "ruler.configs.url", "http://configs.default.svc.cluster.local:80/", "URL of configs API server.")
 	flag.StringVar(&cfg.rulerConfig.UserID, "ruler.userID", "", "Weave Cloud org to run rules for")
-	flag.StringVar(&cfg.rulerConfig.OrgExternalID, "ruler.orgExternalID", "", "Weave Cloud org to run rules for")
 	flag.DurationVar(&cfg.rulerConfig.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")
 	flag.BoolVar(&cfg.logSuccess, "log.success", false, "Log successful requests")
 	flag.BoolVar(&cfg.watchDynamo, "watch-dynamo", false, "Periodically collect DynamoDB provisioned throughput.")
@@ -177,7 +176,7 @@ func main() {
 			log.Fatalf("Could not set up ruler: %v", err)
 		}
 		// XXX: Single-tenanted as part of our initially super hacky way of dogfooding.
-		worker := ruler.GetWorkerFor(cfg.rulerConfig.UserID, cfg.rulerConfig.OrgExternalID)
+		worker := ruler.GetWorkerFor(cfg.rulerConfig.UserID)
 		go worker.Run()
 		defer worker.Stop()
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -165,6 +165,11 @@ func main() {
 		prometheus.MustRegister(registration)
 
 	case modeRuler:
+		// XXX: Too much duplication w/ distributor set up.
+		cfg.distributorConfig.Ring = r
+		cfg.distributorConfig.ClientFactory = func(address string) (*distributor.IngesterClient, error) {
+			return distributor.NewIngesterClient(address, cfg.remoteTimeout)
+		}
 		cfg.rulerConfig.DistributorConfig = cfg.distributorConfig
 		ruler, err := setupRuler(chunkStore, cfg.rulerConfig)
 		if err != nil {

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -103,7 +103,7 @@ func main() {
 	flag.IntVar(&cfg.distributorConfig.ReplicationFactor, "distributor.replication-factor", 3, "The number of ingesters to write to and read from.")
 	flag.IntVar(&cfg.distributorConfig.MinReadSuccesses, "distributor.min-read-successes", 2, "The minimum number of ingesters from which a read must succeed.")
 	flag.DurationVar(&cfg.distributorConfig.HeartbeatTimeout, "distributor.heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes.")
-	flag.StringVar(&cfg.rulerConfig.ConfigsAPIURL, "ruler.configs.url", "http://configs.default.svc.cluster.local:80/", "URL of configs API server.")
+	flag.StringVar(&cfg.rulerConfig.ConfigsAPIURL, "ruler.configs.url", "", "URL of configs API server.")
 	flag.StringVar(&cfg.rulerConfig.UserID, "ruler.userID", "", "Weave Cloud org to run rules for")
 	flag.DurationVar(&cfg.rulerConfig.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")
 	flag.BoolVar(&cfg.logSuccess, "log.success", false, "Log successful requests")

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -105,7 +105,7 @@ func main() {
 	flag.DurationVar(&cfg.distributorConfig.HeartbeatTimeout, "distributor.heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes.")
 	flag.StringVar(&cfg.rulerConfig.ConfigsAPIURL, "ruler.configs.url", "http://configs.default.svc.cluster.local:80/", "URL of configs API server.")
 	flag.StringVar(&cfg.rulerConfig.UserID, "ruler.userID", "", "Weave Cloud org to run rules for")
-	flag.StringVar(&cfg.rulerConfig.UserToken, "ruler.token", "", "Weave Cloud token for org to run rules for")
+	flag.StringVar(&cfg.rulerConfig.OrgExternalID, "ruler.orgExternalID", "", "Weave Cloud org to run rules for")
 	flag.DurationVar(&cfg.rulerConfig.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")
 	flag.BoolVar(&cfg.logSuccess, "log.success", false, "Log successful requests")
 	flag.BoolVar(&cfg.watchDynamo, "watch-dynamo", false, "Periodically collect DynamoDB provisioned throughput.")
@@ -177,7 +177,7 @@ func main() {
 			log.Fatalf("Could not set up ruler: %v", err)
 		}
 		// XXX: Single-tenanted as part of our initially super hacky way of dogfooding.
-		worker := ruler.GetWorkerFor(cfg.rulerConfig.UserID, cfg.rulerConfig.UserToken)
+		worker := ruler.GetWorkerFor(cfg.rulerConfig.UserID, cfg.rulerConfig.OrgExternalID)
 		go worker.Run()
 		defer worker.Stop()
 

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -13,6 +13,20 @@ import (
 	"github.com/weaveworks/cortex/util"
 )
 
+// NewQueryable creates a new promql.Engine for cortex.
+func NewQueryable(distributor Querier, chunkStore chunk.Store) Queryable {
+	return Queryable{
+		Q: MergeQuerier{
+			Queriers: []Querier{
+				distributor,
+				&ChunkQuerier{
+					Store: chunkStore,
+				},
+			},
+		},
+	}
+}
+
 // A Querier allows querying all samples in a given time range that match a set
 // of label matchers.
 type Querier interface {

--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -138,7 +138,7 @@ func (r *Ruler) getConfig(userID string) (*config.Config, error) {
 	ruleFiles := []string{}
 	for filename, rules := range cfg.RulesFiles {
 		filepath := path.Join(dir, filename)
-		err = ioutil.WriteFile(filepath, rules, 0644)
+		err = ioutil.WriteFile(filepath, []byte(rules), 0644)
 		if err != nil {
 			// XXX: Clean up already-written files
 			return nil, err
@@ -171,7 +171,7 @@ func (a appenderAdapter) NeedsThrottling() bool {
 }
 
 type cortexConfig struct {
-	RulesFiles map[string][]byte `json:"rules_files"`
+	RulesFiles map[string]string `json:"rules_files"`
 }
 
 // getOrgConfig gets the organization's cortex config from a configs api server.

--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -98,11 +98,11 @@ func (r *Ruler) getWorkerFor(userID, userToken string) (Worker, error) {
 	mgr := r.getManager(userToken)
 	conf, err := r.getConfig(userID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error fetching config: %v", err)
 	}
 	err = mgr.ApplyConfig(conf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error applying config: %v", err)
 	}
 	return mgr, nil
 }

--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -1,0 +1,168 @@
+package ruler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/rules"
+	"golang.org/x/net/context"
+
+	"github.com/weaveworks/cortex"
+	"github.com/weaveworks/cortex/chunk"
+	"github.com/weaveworks/cortex/distributor"
+	"github.com/weaveworks/cortex/querier"
+	"github.com/weaveworks/cortex/user"
+)
+
+// Config is the configuration for the recording rules server.
+type Config struct {
+	DistributorConfig distributor.Config
+	ConfigsAPIURL     string
+	ExternalURL       string
+	// XXX: Currently single tenant only (which is awful) as the most
+	// expedient way of getting *something* working.
+	UserID string
+	// XXX: UserID can be inferred from token if we have access to the users
+	// server, which we do. Just specifying both so I can get something
+	// running asap.
+	UserToken string
+}
+
+// Ruler is a recording rules server.
+type Ruler struct {
+	cfg         Config
+	chunkStore  chunk.Store
+	distributor *distributor.Distributor
+
+	configsAPIURL *url.URL
+	externalURL   *url.URL
+}
+
+// New returns a new Ruler.
+func New(chunkStore chunk.Store, cfg Config) (*Ruler, error) {
+	configsAPIURL, err := url.Parse(cfg.ConfigsAPIURL)
+	if err != nil {
+		return nil, err
+	}
+	externalURL, err := url.Parse(cfg.ExternalURL)
+	if err != nil {
+		return nil, err
+	}
+
+	d, err := distributor.New(cfg.DistributorConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &Ruler{
+		cfg:           cfg,
+		chunkStore:    chunkStore,
+		distributor:   d,
+		configsAPIURL: configsAPIURL,
+		externalURL:   externalURL,
+	}, nil
+}
+
+// Execute does the thing.
+func (r *Ruler) Execute(userID, userToken string) error {
+	mgr := r.getManager(userToken)
+	conf, err := r.getConfig(userID)
+	if err != nil {
+		return err
+	}
+	return mgr.ApplyConfig(conf)
+}
+
+func (r *Ruler) getManager(userID string) *rules.Manager {
+	ctx := user.WithID(context.Background(), userID)
+	appender := appenderAdapter{appender: r.distributor, ctx: ctx}
+	queryable := querier.NewQueryable(r.distributor, r.chunkStore)
+	engine := promql.NewEngine(queryable, nil)
+	return rules.NewManager(&rules.ManagerOptions{
+		SampleAppender: appender,
+		Notifier:       nil,
+		QueryEngine:    engine,
+		Context:        ctx,
+		ExternalURL:    r.externalURL,
+	})
+}
+
+func (r *Ruler) getConfig(userID string) (*config.Config, error) {
+	// TODO: Extract configs client logic into go client library (ala users)
+	// XXX: This is highly specific to Weave Cloud. Would be good to have a
+	// more pluggable way of expressing this for Cortex.
+	cfg, err := getOrgConfig(r.configsAPIURL, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	dir, err := ioutil.TempDir("", fmt.Sprintf("rules-%v", userID))
+	if err != nil {
+		return nil, err
+	}
+
+	ruleFiles := []string{}
+	for filename, rules := range cfg.RulesFiles {
+		filepath := path.Join(dir, filename)
+		err = ioutil.WriteFile(filepath, rules, 0644)
+		if err != nil {
+			// XXX: Clean up already-written files
+			return nil, err
+		}
+		ruleFiles = append(ruleFiles, filepath)
+	}
+
+	return &config.Config{
+		// XXX: Need to set recording interval here.
+		GlobalConfig: config.DefaultGlobalConfig,
+		RuleFiles:    ruleFiles,
+	}, nil
+}
+
+// appenderAdapter adapts cortex.SampleAppender to prometheus.SampleAppender
+type appenderAdapter struct {
+	appender cortex.SampleAppender
+	ctx      context.Context
+}
+
+func (a appenderAdapter) Append(sample *model.Sample) error {
+	return a.appender.Append(a.ctx, []*model.Sample{sample})
+}
+
+func (a appenderAdapter) NeedsThrottling() bool {
+	// XXX: Just a guess.
+	return false
+}
+
+type cortexConfig struct {
+	RulesFiles map[string][]byte `json:"rules_files"`
+}
+
+// getOrgConfig gets the organization's cortex config from a configs api server.
+func getOrgConfig(configsAPIURL *url.URL, userID string) (*cortexConfig, error) {
+	url := fmt.Sprintf("%s/api/configs/org/%s/cortex", configsAPIURL.String(), userID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("X-Scope-OrgID", userID)
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Invalid response from configs server: %v", res.StatusCode)
+	}
+	var config cortexConfig
+	if err := json.NewDecoder(res.Body).Decode(&config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}

--- a/user/id.go
+++ b/user/id.go
@@ -6,6 +6,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+// TODO(jml): typedef for userid
+
 // UserIDContextKey is the key used in contexts to find the userid
 const userIDContextKey = "CortexUserID" // TODO dedupe with storage/local
 

--- a/user/id.go
+++ b/user/id.go
@@ -6,7 +6,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TODO(jml): typedef for userid
+// TODO(jml): typedef for userid, maybe even put in a weaveworks library, so
+// that there's a shared language around the multiple ways of identifying
+// entitiies.
 
 // UserIDContextKey is the key used in contexts to find the userid
 const userIDContextKey = "CortexUserID" // TODO dedupe with storage/local


### PR DESCRIPTION
aka "jml and the terrible, horrible, no good, very bad single-tenancy recording rules server".

Part of #4 

Simplest thing I could come up with that got recording rules working. There are many, many things wrong with it, but hopefully enough there to start generating extra query traffic and dogfooding grafana.

Big problems are:
* not multi-tenant
* doesn't have any mechanism for updating rules once it gets them

After deploying this to dev, next coding steps are:

* fork and/or patch Prometheus `rules` module to let us:
  * evaluate a rule ourselves (rather than delegating to manager)
  * use an appender with a context (if query has one, why not appender?)
  * parse a rules file into its constituent rules
* change ruler to have a queueing model: one thing that pops rules/configs/whatever from a queue and then runs them; another thing that talks to config server and populates the queue 
* fix issues in configs server to allow getting rules for multiple users (probably means storing last evaluated time somewhere, either in config server or yet another data store)