### PR TITLE
Switch to snappy/proto for encoding ring in consul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 cmd/cortex/cortex
 .uptodate
 .pkg
-cortex.pb.go
+*.pb.go
 ui/bindata.go

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,19 @@ IMAGE_NAMES=$(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)/%,$(
 images:
 	$(info $(IMAGE_NAMES))
 
+PROTO_DEFS := $(shell find . -type f -name "*.proto" ! -path "./tools/*" ! -path "./vendor/*")
+PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
+
 # List of exes please
 CORTEX_EXE := ./cmd/cortex/cortex
 EXES = $(CORTEX_EXE)
 
 all: $(UPTODATE_FILES)
+test: $(PROTO_GOS)
 
 # And what goes into each exe
-$(CORTEX_EXE): $(shell find . -name '*.go') ui/bindata.go cortex.pb.go
-cortex.pb.go: cortex.proto
+$(CORTEX_EXE): $(shell find . -name '*.go' ! -path "./tools/*" ! -path "./vendor/*") ui/bindata.go $(PROTO_GOS)
+%.pb.go: %.proto
 ui/bindata.go: $(shell find ui/static ui/templates)
 
 # And now what goes into each image
@@ -55,7 +59,7 @@ NETGO_CHECK = @strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
-$(EXES) cortex.pb.go ui/bindata.go lint test shell: cortex-build/$(UPTODATE)
+$(EXES) $(PROTO_GOS) ui/bindata.go lint test shell: cortex-build/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	$(SUDO) docker run $(RM) -ti \
 		-v $(shell pwd)/.pkg:/go/pkg \
@@ -68,8 +72,8 @@ $(EXES): cortex-build/$(UPTODATE)
 	go build $(GO_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
-cortex.pb.go: cortex-build/$(UPTODATE)
-	protoc -I ./vendor:. --go_out=plugins=grpc:. ./cortex.proto
+%.pb.go: cortex-build/$(UPTODATE)
+	protoc -I ./vendor:./$(@D) --go_out=plugins=grpc:./$(@D) ./$(patsubst %.pb.go,%.proto,$@)
 
 ui/bindata.go: cortex-build/$(UPTODATE)
 	go-bindata -pkg ui -o ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  ui/templates/... ui/static/...
@@ -77,7 +81,7 @@ ui/bindata.go: cortex-build/$(UPTODATE)
 lint: cortex-build/$(UPTODATE)
 	./tools/lint -notestpackage -ignorespelling queriers -ignorespelling Queriers .
 
-test: cortex-build/$(UPTODATE) cortex.pb.go
+test: cortex-build/$(UPTODATE)
 	./tools/test -no-go-get
 
 shell: cortex-build/$(UPTODATE)
@@ -87,7 +91,7 @@ endif
 
 clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
-	rm -rf $(UPTODATE_FILES) $(EXES) cortex.pb.go ui/bindata.go
+	rm -rf $(UPTODATE_FILES) $(EXES) $(PROTO_GOS) ui/bindata.go
 	go clean ./...
 
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -138,11 +138,11 @@ func main() {
 		prometheus.MustRegister(resourceWatcher)
 	}
 
-	ringSerDes := ring.NewDynamicSerDes(
-		ring.JSONSerDes{Factory: ring.DescFactory},
-		ring.ProtoSerDes{Factory: ring.ProtoDescFactory},
+	ringCodec := ring.NewDynamicCodec(
+		ring.JSONCodec{Factory: ring.DescFactory},
+		ring.ProtoCodec{Factory: ring.ProtoDescFactory},
 	)
-	consul, err := ring.NewConsulClient(cfg.consulHost, ringSerDes)
+	consul, err := ring.NewConsulClient(cfg.consulHost, ringCodec)
 	if err != nil {
 		log.Fatalf("Error initializing Consul client: %v", err)
 	}
@@ -160,7 +160,7 @@ func main() {
 
 	case modeIngester:
 		cfg.ingesterConfig.Ring = r
-		registration, err := ring.RegisterIngester(consul, cfg.ingesterConfig.GRPCListenPort, cfg.numTokens, ringSerDes)
+		registration, err := ring.RegisterIngester(consul, cfg.ingesterConfig.GRPCListenPort, cfg.numTokens, ringCodec)
 		if err != nil {
 			// This only happens for errors in configuration & set-up, not for
 			// network errors.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -138,7 +138,11 @@ func main() {
 		prometheus.MustRegister(resourceWatcher)
 	}
 
-	consul, err := ring.NewConsulClient(cfg.consulHost)
+	ringSerDes := ring.NewDynamicSerDes(
+		ring.JSONSerDes{Factory: ring.DescFactory},
+		ring.ProtoSerDes{Factory: ring.ProtoDescFactory},
+	)
+	consul, err := ring.NewConsulClient(cfg.consulHost, ringSerDes)
 	if err != nil {
 		log.Fatalf("Error initializing Consul client: %v", err)
 	}
@@ -156,7 +160,7 @@ func main() {
 
 	case modeIngester:
 		cfg.ingesterConfig.Ring = r
-		registration, err := ring.RegisterIngester(consul, cfg.listenPort, cfg.ingesterConfig.GRPCListenPort, cfg.numTokens)
+		registration, err := ring.RegisterIngester(consul, cfg.ingesterConfig.GRPCListenPort, cfg.numTokens, ringSerDes)
 		if err != nil {
 			// This only happens for errors in configuration & set-up, not for
 			// network errors.
@@ -183,7 +187,7 @@ func main() {
 
 		// Deferring a func to make ordering obvious
 		defer func() {
-			registration.ChangeState(ring.Leaving)
+			registration.ChangeState(ring.IngesterState_LEAVING)
 			ing.Stop()
 			registration.Unregister()
 		}()

--- a/ring/consul_client.go
+++ b/ring/consul_client.go
@@ -1,11 +1,13 @@
 package ring
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
 	consul "github.com/hashicorp/consul/api"
 	"github.com/prometheus/common/log"
 )
@@ -18,18 +20,20 @@ const (
 // such as CAS and Watch which take callbacks.  It also deals with serialisation
 // by having an instance factory passed in to methods and deserialising into that.
 type ConsulClient interface {
-	Get(key string, factory InstanceFactory) error
-	CAS(key string, factory InstanceFactory, f CASCallback) error
-	WatchPrefix(path string, factory InstanceFactory, done <-chan struct{}, f func(string, interface{}) bool)
-	WatchKey(key string, factory InstanceFactory, done <-chan struct{}, f func(interface{}) bool)
+	CAS(key string, f CASCallback) error
+	WatchPrefix(path string, done <-chan struct{}, f func(string, interface{}) bool)
+	WatchKey(key string, done <-chan struct{}, f func(interface{}) bool)
 	PutBytes(key string, buf []byte) error
 }
 
 // CASCallback is the type of the callback to CAS.  If err is nil, out must be non-nil.
 type CASCallback func(in interface{}) (out interface{}, retry bool, err error)
 
-// InstanceFactory type creates empty instances for use when deserialising
-type InstanceFactory func() interface{}
+// SerDes allows the consult client to serialise and deserialise values.
+type SerDes interface {
+	Decode([]byte) (interface{}, error)
+	Encode(interface{}) ([]byte, error)
+}
 
 type kv interface {
 	CAS(p *consul.KVPair, q *consul.WriteOptions) (bool, *consul.WriteMeta, error)
@@ -40,10 +44,11 @@ type kv interface {
 
 type consulClient struct {
 	kv
+	serdes SerDes
 }
 
 // NewConsulClient returns a new ConsulClient.
-func NewConsulClient(addr string) (ConsulClient, error) {
+func NewConsulClient(addr string, serdes SerDes) (ConsulClient, error) {
 	client, err := consul.NewClient(&consul.Config{
 		Address: addr,
 		Scheme:  "http",
@@ -51,7 +56,10 @@ func NewConsulClient(addr string) (ConsulClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &consulClient{client.KV()}, nil
+	return &consulClient{
+		kv:     client.KV(),
+		serdes: serdes,
+	}, nil
 }
 
 var (
@@ -64,25 +72,112 @@ var (
 	ErrNotFound = fmt.Errorf("Not found")
 )
 
-// Get and deserialise a JSON value from Consul.
-func (c *consulClient) Get(key string, factory InstanceFactory) error {
-	kvp, _, err := c.kv.Get(key, queryOptions)
+// ProtoSerDes is a SerDes for proto/snappy
+type ProtoSerDes struct {
+	Factory func() proto.Message
+}
+
+// Decode implements SerDes
+func (p ProtoSerDes) Decode(bytes []byte) (interface{}, error) {
+	out := p.Factory()
+	bytes, err := snappy.Decode(nil, bytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if kvp == nil {
-		return ErrNotFound
+	if err := proto.Unmarshal(bytes, out); err != nil {
+		return nil, err
 	}
-	out := factory()
-	if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
-		return err
+	return out, nil
+}
+
+// Encode implements SerDes
+func (p ProtoSerDes) Encode(msg interface{}) ([]byte, error) {
+	bytes, err := proto.Marshal(msg.(proto.Message))
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return snappy.Encode(nil, bytes), nil
+}
+
+// JSONSerDes is a SerDes for JSON
+type JSONSerDes struct {
+	Factory func() interface{}
+}
+
+// Decode implements SerDes
+func (j JSONSerDes) Decode(bytes []byte) (interface{}, error) {
+	out := j.Factory()
+	if err := json.Unmarshal(bytes, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Encode implemenrs SerDes
+func (j JSONSerDes) Encode(msg interface{}) ([]byte, error) {
+	return json.Marshal(msg)
+}
+
+// DynamicSerDes is a SerDes that can read json and proto, and
+// that can serialise to either (selectively).
+// Once it fails to decode JSON, it will start decoding (and
+// writing) protos.
+type DynamicSerDes struct {
+	mtx      sync.Mutex
+	useProto bool
+	json     SerDes
+	proto    SerDes
+}
+
+// NewDynamicSerDes makes a new DynamicSerDes
+func NewDynamicSerDes(json, proto SerDes) *DynamicSerDes {
+	return &DynamicSerDes{
+		useProto: false,
+		json:     json,
+		proto:    proto,
+	}
+}
+
+// UseProto allow you to change the SerDes at runtime.
+func (d *DynamicSerDes) UseProto(useProto bool) {
+	log.Infof("Switching to proto serialization: %v", useProto)
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	d.useProto = useProto
+}
+
+// Decode implements SerDes
+func (d *DynamicSerDes) Decode(bytes []byte) (interface{}, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	out, err := d.json.Decode(bytes)
+	if err == nil {
+		return out, nil
+	}
+
+	if !d.useProto {
+		log.Infof("Error decoding json, switching to writing proto: %v", err)
+		d.useProto = true
+	}
+
+	return d.proto.Decode(bytes)
+}
+
+// Encode implemenrs SerDes
+func (d *DynamicSerDes) Encode(msg interface{}) ([]byte, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	if d.useProto {
+		return d.proto.Encode(msg)
+	}
+	return d.json.Encode(msg)
 }
 
 // CAS atomically modifies a value in a callback.
 // If value doesn't exist you'll get nil as an argument to your callback.
-func (c *consulClient) CAS(key string, factory InstanceFactory, f CASCallback) error {
+func (c *consulClient) CAS(key string, f CASCallback) error {
 	var (
 		index   = uint64(0)
 		retries = 10
@@ -96,9 +191,9 @@ func (c *consulClient) CAS(key string, factory InstanceFactory, f CASCallback) e
 		}
 		var intermediate interface{}
 		if kvp != nil {
-			out := factory()
-			if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
-				log.Errorf("Error deserialising %s: %v", key, err)
+			out, err := c.serdes.Decode(kvp.Value)
+			if err != nil {
+				log.Errorf("Error decoding %s: %v", key, err)
 				continue
 			}
 			// If key doesn't exist, index will be 0.
@@ -119,14 +214,14 @@ func (c *consulClient) CAS(key string, factory InstanceFactory, f CASCallback) e
 			panic("Callback must instantiate value!")
 		}
 
-		value := bytes.Buffer{}
-		if err := json.NewEncoder(&value).Encode(intermediate); err != nil {
+		bytes, err := c.serdes.Encode(intermediate)
+		if err != nil {
 			log.Errorf("Error serialising value for %s: %v", key, err)
 			continue
 		}
 		ok, _, err := c.kv.CAS(&consul.KVPair{
 			Key:         key,
-			Value:       value.Bytes(),
+			Value:       bytes,
 			ModifyIndex: index,
 		}, writeOptions)
 		if err != nil {
@@ -189,7 +284,7 @@ func isClosed(done <-chan struct{}) bool {
 // supplied which generates an empty struct for WatchPrefix to deserialise
 // into. Values in Consul are assumed to be JSON. This function blocks until
 // the done channel is closed.
-func (c *consulClient) WatchPrefix(prefix string, factory InstanceFactory, done <-chan struct{}, f func(string, interface{}) bool) {
+func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(string, interface{}) bool) {
 	var (
 		backoff = newBackoff(done)
 		index   = uint64(0)
@@ -218,9 +313,9 @@ func (c *consulClient) WatchPrefix(prefix string, factory InstanceFactory, done 
 		index = meta.LastIndex
 
 		for _, kvp := range kvps {
-			out := factory()
-			if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
-				log.Errorf("Error deserialising %s: %v", kvp.Key, err)
+			out, err := c.serdes.Decode(kvp.Value)
+			if err != nil {
+				log.Errorf("Error decoding %s: %v", kvp.Key, err)
 				continue
 			}
 			if !f(kvp.Key, out) {
@@ -236,7 +331,7 @@ func (c *consulClient) WatchPrefix(prefix string, factory InstanceFactory, done 
 // supplied which generates an empty struct for WatchKey to deserialise
 // into. Values in Consul are assumed to be JSON. This function blocks until
 // the done channel is closed.
-func (c *consulClient) WatchKey(key string, factory InstanceFactory, done <-chan struct{}, f func(interface{}) bool) {
+func (c *consulClient) WatchKey(key string, done <-chan struct{}, f func(interface{}) bool) {
 	var (
 		backoff = newBackoff(done)
 		index   = uint64(0)
@@ -266,9 +361,10 @@ func (c *consulClient) WatchKey(key string, factory InstanceFactory, done <-chan
 
 		var out interface{}
 		if kvp != nil {
-			out = factory()
-			if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
-				log.Errorf("Error deserialising %s: %v", kvp.Key, err)
+			var err error
+			out, err = c.serdes.Decode(kvp.Value)
+			if err != nil {
+				log.Errorf("Error decoding %s: %v", key, err)
 				continue
 			}
 		}
@@ -296,25 +392,20 @@ func PrefixClient(client ConsulClient, prefix string) ConsulClient {
 	return &prefixedConsulClient{prefix, client}
 }
 
-// Get and deserialise a JSON value from Consul.
-func (c *prefixedConsulClient) Get(key string, factory InstanceFactory) error {
-	return c.consul.Get(c.prefix+key, factory)
-}
-
 // CAS atomically modifies a value in a callback. If the value doesn't exist,
 // you'll get 'nil' as an argument to your callback.
-func (c *prefixedConsulClient) CAS(key string, factory InstanceFactory, f CASCallback) error {
-	return c.consul.CAS(c.prefix+key, factory, f)
+func (c *prefixedConsulClient) CAS(key string, f CASCallback) error {
+	return c.consul.CAS(c.prefix+key, f)
 }
 
 // WatchPrefix watches a prefix. This is in addition to the prefix we already have.
-func (c *prefixedConsulClient) WatchPrefix(path string, factory InstanceFactory, done <-chan struct{}, f func(string, interface{}) bool) {
-	c.consul.WatchPrefix(c.prefix+path, factory, done, f)
+func (c *prefixedConsulClient) WatchPrefix(path string, done <-chan struct{}, f func(string, interface{}) bool) {
+	c.consul.WatchPrefix(c.prefix+path, done, f)
 }
 
 // WatchKey watches a key.
-func (c *prefixedConsulClient) WatchKey(key string, factory InstanceFactory, done <-chan struct{}, f func(interface{}) bool) {
-	c.consul.WatchKey(c.prefix+key, factory, done, f)
+func (c *prefixedConsulClient) WatchKey(key string, done <-chan struct{}, f func(interface{}) bool) {
+	c.consul.WatchKey(c.prefix+key, done, f)
 }
 
 // PutBytes writes bytes to Consul.

--- a/ring/consul_client.go
+++ b/ring/consul_client.go
@@ -140,11 +140,12 @@ func NewDynamicSerDes(json, proto SerDes) *DynamicSerDes {
 
 // UseProto allow you to change the SerDes at runtime.
 func (d *DynamicSerDes) UseProto(useProto bool) {
-	log.Infof("Switching to proto serialization: %v", useProto)
-
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	d.useProto = useProto
+	if d.useProto != useProto {
+		log.Infof("Switching to proto serialization: %v", useProto)
+		d.useProto = useProto
+	}
 }
 
 // Decode implements SerDes

--- a/ring/http.go
+++ b/ring/http.go
@@ -52,7 +52,7 @@ func init() {
 	tmpl, err = template.New("webpage").
 		Funcs(template.FuncMap{
 			"time": func(in interface{}) string {
-				return in.(time.Time).String()
+				return time.Unix(in.(int64), 0).String()
 			},
 		}).
 		Parse(tpl)
@@ -71,7 +71,7 @@ func (r *Ring) forget(id string) error {
 		ringDesc.removeIngester(id)
 		return ringDesc, true, nil
 	}
-	return r.consul.CAS(consulKey, descFactory, unregister)
+	return r.consul.CAS(consulKey, unregister)
 }
 
 func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -88,7 +88,7 @@ func (r *Ring) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	if err := tmpl.Execute(w, struct {
-		Ring    Desc
+		Ring    *Desc
 		Message string
 		Now     time.Time
 	}{

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -25,7 +25,7 @@ const (
 type IngesterRegistration struct {
 	consul    ConsulClient
 	numTokens int
-	serdes    *DynamicSerDes
+	codec     *DynamicCodec
 
 	id       string
 	hostname string
@@ -41,7 +41,7 @@ type IngesterRegistration struct {
 }
 
 // RegisterIngester registers an ingester with Consul.
-func RegisterIngester(consulClient ConsulClient, grpcPort, numTokens int, serdes *DynamicSerDes) (*IngesterRegistration, error) {
+func RegisterIngester(consulClient ConsulClient, grpcPort, numTokens int, codec *DynamicCodec) (*IngesterRegistration, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func RegisterIngester(consulClient ConsulClient, grpcPort, numTokens int, serdes
 	r := &IngesterRegistration{
 		consul:    consulClient,
 		numTokens: numTokens,
-		serdes:    serdes,
+		codec:     codec,
 
 		id: hostname,
 		// hostname is the ip+port of this instance, written to consul so
@@ -153,7 +153,7 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 			}
 		}
 		if allIngestersCanReadProtos {
-			r.serdes.UseProto(true)
+			r.codec.UseProto(true)
 		}
 
 		ingesterDesc, ok := ringDesc.Ingesters[r.id]
@@ -165,7 +165,7 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 			ingesterDesc.Timestamp = time.Now().Unix()
 			ingesterDesc.State = r.state
 
-			// Set ProtoRing back to true for the case where an existing ingester that didn't understand this field removed it whilst updating the ring.
+			// Set ProtoRing back to true for the case where an existing ingestser that didn't understand this field removed it whilst updating the ring.
 			ingesterDesc.ProtoRing = true
 			ringDesc.Ingesters[r.id] = ingesterDesc
 		}

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -165,7 +165,7 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 			ingesterDesc.Timestamp = time.Now().Unix()
 			ingesterDesc.State = r.state
 
-			// Set ProtoRing back to true for the case where an existing ingestser that didn't understand this field removed it whilst updating the ring.
+			// Set ProtoRing back to true for the case where an existing ingester that didn't understand this field removed it whilst updating the ring.
 			ingesterDesc.ProtoRing = true
 			ringDesc.Ingesters[r.id] = ingesterDesc
 		}

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -25,12 +25,12 @@ const (
 type IngesterRegistration struct {
 	consul    ConsulClient
 	numTokens int
+	serdes    *DynamicSerDes
 
-	id           string
-	hostname     string
-	grpcHostname string
-	quit         chan struct{}
-	wait         sync.WaitGroup
+	id       string
+	hostname string
+	quit     chan struct{}
+	wait     sync.WaitGroup
 
 	// We need to remember the ingester state just in case consul goes away and comes
 	// back empty.  Channel is used to tell the actor to update consul on state changes.
@@ -41,7 +41,7 @@ type IngesterRegistration struct {
 }
 
 // RegisterIngester registers an ingester with Consul.
-func RegisterIngester(consulClient ConsulClient, listenPort, grpcPort, numTokens int) (*IngesterRegistration, error) {
+func RegisterIngester(consulClient ConsulClient, grpcPort, numTokens int, serdes *DynamicSerDes) (*IngesterRegistration, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -55,16 +55,16 @@ func RegisterIngester(consulClient ConsulClient, listenPort, grpcPort, numTokens
 	r := &IngesterRegistration{
 		consul:    consulClient,
 		numTokens: numTokens,
+		serdes:    serdes,
 
 		id: hostname,
 		// hostname is the ip+port of this instance, written to consul so
 		// the distributors know where to connect.
-		hostname:     fmt.Sprintf("%s:%d", addr, listenPort),
-		grpcHostname: fmt.Sprintf("%s:%d", addr, grpcPort),
-		quit:         make(chan struct{}),
+		hostname: fmt.Sprintf("%s:%d", addr, grpcPort),
+		quit:     make(chan struct{}),
 
 		// Only read/written on actor goroutine.
-		state:       Active,
+		state:       IngesterState_ACTIVE,
 		stateChange: make(chan IngesterState),
 
 		consulHeartbeats: prometheus.NewCounter(prometheus.CounterOpts{
@@ -125,16 +125,18 @@ func (r *IngesterRegistration) pickTokens() []uint32 {
 			tokens = append(tokens, newTokens...)
 		}
 		sort.Sort(sortableUint32(tokens))
-		ringDesc.addIngester(r.id, r.hostname, r.grpcHostname, tokens, r.state)
+		ringDesc.addIngester(r.id, r.hostname, tokens, r.state)
 		return ringDesc, true, nil
 	}
-	if err := r.consul.CAS(consulKey, descFactory, pickTokens); err != nil {
+	if err := r.consul.CAS(consulKey, pickTokens); err != nil {
 		log.Fatalf("Failed to pick tokens in consul: %v", err)
 	}
 	return tokens
 }
 
 func (r *IngesterRegistration) heartbeat(tokens []uint32) {
+	allIngestersCanReadProtos := false
+
 	updateConsul := func(in interface{}) (out interface{}, retry bool, err error) {
 		var ringDesc *Desc
 		if in == nil {
@@ -143,14 +145,27 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 			ringDesc = in.(*Desc)
 		}
 
+		// See if all ingesters can read protos; if so start writing them
+		protoRing := true
+		for _, ing := range ringDesc.Ingesters {
+			if !ing.ProtoRing {
+				allIngestersCanReadProtos = false
+				break
+			}
+		}
+		allIngestersCanReadProtos = protoRing
+
 		ingesterDesc, ok := ringDesc.Ingesters[r.id]
 		if !ok {
 			// consul must have restarted
 			log.Infof("Found empty ring, inserting tokens!")
-			ringDesc.addIngester(r.id, r.hostname, r.grpcHostname, tokens, r.state)
+			ringDesc.addIngester(r.id, r.hostname, tokens, r.state)
 		} else {
-			ingesterDesc.Timestamp = time.Now()
+			ingesterDesc.Timestamp = time.Now().Unix()
 			ingesterDesc.State = r.state
+
+			// Set ProtoRing back to true for the case where an existing ingester that didn't understand this field removed it whilst updating the ring.
+			ingesterDesc.ProtoRing = true
 			ringDesc.Ingesters[r.id] = ingesterDesc
 		}
 
@@ -162,13 +177,15 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 	for {
 		select {
 		case r.state = <-r.stateChange:
-			if err := r.consul.CAS(consulKey, descFactory, updateConsul); err != nil {
+			if err := r.consul.CAS(consulKey, updateConsul); err != nil {
 				log.Errorf("Failed to write to consul, sleeping: %v", err)
 			}
 		case <-ticker.C:
 			r.consulHeartbeats.Inc()
-			if err := r.consul.CAS(consulKey, descFactory, updateConsul); err != nil {
+			if err := r.consul.CAS(consulKey, updateConsul); err != nil {
 				log.Errorf("Failed to write to consul, sleeping: %v", err)
+			} else if allIngestersCanReadProtos {
+				r.serdes.UseProto(true)
 			}
 		case <-r.quit:
 			return
@@ -186,7 +203,7 @@ func (r *IngesterRegistration) unregister() {
 		ringDesc.removeIngester(r.id)
 		return ringDesc, true, nil
 	}
-	if err := r.consul.CAS(consulKey, descFactory, unregister); err != nil {
+	if err := r.consul.CAS(consulKey, unregister); err != nil {
 		log.Fatalf("Failed to unregister from consul: %v", err)
 	}
 }

--- a/ring/model.go
+++ b/ring/model.go
@@ -1,89 +1,97 @@
 package ring
 
 import (
+	"encoding/json"
 	"sort"
 	"time"
+
+	"github.com/golang/protobuf/proto"
 )
 
-// IngesterState describes the state of an ingester
-type IngesterState int
+// ByToken is a sortable list of TokenDescs
+type ByToken []*TokenDesc
 
-// Values for IngesterState
-const (
-	Active IngesterState = iota
-	Leaving
-)
+func (ts ByToken) Len() int           { return len(ts) }
+func (ts ByToken) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
+func (ts ByToken) Less(i, j int) bool { return ts[i].Token < ts[j].Token }
 
-func (s IngesterState) String() string {
-	switch s {
-	case Active:
-		return "Active"
-	case Leaving:
-		return "Leaving"
-	}
-	return ""
+// ProtoDescFactory makes new Descs
+func ProtoDescFactory() proto.Message {
+	return newDesc()
 }
 
-// Desc is the serialised state in Consul representing
-// all ingesters (ie, the ring).
-type Desc struct {
-	Ingesters map[string]IngesterDesc `json:"ingesters"`
-	Tokens    TokenDescs              `json:"tokens"`
-}
-
-// IngesterDesc describes a single ingester.
-type IngesterDesc struct {
-	Hostname  string        `json:"hostname"`
-	Timestamp time.Time     `json:"timestamp"`
-	State     IngesterState `json:"state"`
-
-	GRPCHostname string `json:"grpc_hostname"`
-}
-
-// TokenDescs is a sortable list of TokenDescs
-type TokenDescs []TokenDesc
-
-func (ts TokenDescs) Len() int           { return len(ts) }
-func (ts TokenDescs) Swap(i, j int)      { ts[i], ts[j] = ts[j], ts[i] }
-func (ts TokenDescs) Less(i, j int) bool { return ts[i].Token < ts[j].Token }
-
-// TokenDesc describes an individual token in the ring.
-type TokenDesc struct {
-	Token    uint32 `json:"tokens"`
-	Ingester string `json:"ingester"`
-}
-
-func descFactory() interface{} {
+// DescFactory makes new Descs
+func DescFactory() interface{} {
 	return newDesc()
 }
 
 func newDesc() *Desc {
 	return &Desc{
-		Ingesters: map[string]IngesterDesc{},
+		Ingesters: map[string]*IngesterDesc{},
 	}
 }
 
-func (d *Desc) addIngester(id, hostname, grpcHostname string, tokens []uint32, state IngesterState) {
-	d.Ingesters[id] = IngesterDesc{
-		Hostname:     hostname,
-		GRPCHostname: grpcHostname,
-		Timestamp:    time.Now(),
-		State:        state,
+type oldIngesterDesc struct {
+	Hostname     string        `json:"hostname"`
+	Timestamp    time.Time     `json:"timestamp"`
+	State        IngesterState `json:"state"`
+	GRPCHostname string        `json:"grpc_hostname"`
+	ProtoRing    bool          `json:"proto_ring"`
+}
+
+// UnmarshalJSON allows the new proto IngesterDescs to read the old JSON format.
+//
+// NB grpc_hostname in the old format is just hostname in the new.
+func (d *IngesterDesc) UnmarshalJSON(in []byte) error {
+	var tmp oldIngesterDesc
+	if err := json.Unmarshal(in, &tmp); err != nil {
+		return err
+	}
+
+	d.Hostname = tmp.GRPCHostname
+	d.Timestamp = tmp.Timestamp.Unix()
+	d.State = tmp.State
+	d.ProtoRing = tmp.ProtoRing
+	return nil
+}
+
+// MarshalJSON allows the new proto IngesterDescs to write the old JSON format.
+//
+// NB grpc_hostname in the old format is just hostname in the new.
+func (d *IngesterDesc) MarshalJSON() ([]byte, error) {
+	return json.Marshal(oldIngesterDesc{
+		Hostname:     "",
+		Timestamp:    time.Unix(d.Timestamp, 0),
+		State:        d.State,
+		GRPCHostname: d.Hostname,
+		ProtoRing:    d.ProtoRing,
+	})
+}
+
+func (d *Desc) addIngester(id, hostname string, tokens []uint32, state IngesterState) {
+	if d.Ingesters == nil {
+		d.Ingesters = map[string]*IngesterDesc{}
+	}
+	d.Ingesters[id] = &IngesterDesc{
+		Hostname:  hostname,
+		Timestamp: time.Now().Unix(),
+		State:     state,
+		ProtoRing: true,
 	}
 
 	for _, token := range tokens {
-		d.Tokens = append(d.Tokens, TokenDesc{
+		d.Tokens = append(d.Tokens, &TokenDesc{
 			Token:    token,
 			Ingester: id,
 		})
 	}
 
-	sort.Sort(d.Tokens)
+	sort.Sort(ByToken(d.Tokens))
 }
 
 func (d *Desc) removeIngester(id string) {
 	delete(d.Ingesters, id)
-	output := []TokenDesc{}
+	output := []*TokenDesc{}
 	for i := 0; i < len(d.Tokens); i++ {
 		if d.Tokens[i].Ingester != id {
 			output = append(output, d.Tokens[i])

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -42,7 +42,7 @@ type Ring struct {
 	heartbeatTimeout time.Duration
 
 	mtx      sync.RWMutex
-	ringDesc Desc
+	ringDesc *Desc
 
 	ingesterOwnershipDesc *prometheus.Desc
 	numIngestersDesc      *prometheus.Desc
@@ -84,7 +84,7 @@ func (r *Ring) Stop() {
 
 func (r *Ring) loop() {
 	defer close(r.done)
-	r.consul.WatchKey(consulKey, descFactory, r.quit, func(value interface{}) bool {
+	r.consul.WatchKey(consulKey, r.quit, func(value interface{}) bool {
 		if value == nil {
 			log.Infof("Ring doesn't exist in consul yet.")
 			return true
@@ -93,13 +93,13 @@ func (r *Ring) loop() {
 		ringDesc := value.(*Desc)
 		r.mtx.Lock()
 		defer r.mtx.Unlock()
-		r.ringDesc = *ringDesc
+		r.ringDesc = ringDesc
 		return true
 	})
 }
 
 // Get returns n (or more) ingesters which form the replicas for the given key.
-func (r *Ring) Get(key uint32, n int, op Operation) ([]IngesterDesc, error) {
+func (r *Ring) Get(key uint32, n int, op Operation) ([]*IngesterDesc, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	return r.getInternal(key, n, op)
@@ -107,11 +107,11 @@ func (r *Ring) Get(key uint32, n int, op Operation) ([]IngesterDesc, error) {
 
 // BatchGet returns n (or more) ingesters which form the replicas for the given key.
 // The order of the result matches the order of the input.
-func (r *Ring) BatchGet(keys []uint32, n int, op Operation) ([][]IngesterDesc, error) {
+func (r *Ring) BatchGet(keys []uint32, n int, op Operation) ([][]*IngesterDesc, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
-	result := make([][]IngesterDesc, len(keys), len(keys))
+	result := make([][]*IngesterDesc, len(keys), len(keys))
 	for i, key := range keys {
 		ingesters, err := r.getInternal(key, n, op)
 		if err != nil {
@@ -122,12 +122,12 @@ func (r *Ring) BatchGet(keys []uint32, n int, op Operation) ([][]IngesterDesc, e
 	return result, nil
 }
 
-func (r *Ring) getInternal(key uint32, n int, op Operation) ([]IngesterDesc, error) {
+func (r *Ring) getInternal(key uint32, n int, op Operation) ([]*IngesterDesc, error) {
 	if len(r.ringDesc.Tokens) == 0 {
 		return nil, ErrEmptyRing
 	}
 
-	ingesters := make([]IngesterDesc, 0, n)
+	ingesters := make([]*IngesterDesc, 0, n)
 	distinctHosts := map[string]struct{}{}
 	start := r.search(key)
 	iterations := 0
@@ -150,7 +150,7 @@ func (r *Ring) getInternal(key uint32, n int, op Operation) ([]IngesterDesc, err
 		// set of replicas for the key.  This means we have to also increase the
 		// size of the replica set for read, but we can read from Leaving ingesters,
 		// so don't skip it in this case.
-		if ingester.State == Leaving {
+		if ingester.State == IngesterState_LEAVING {
 			n++
 			if op == Write {
 				continue
@@ -163,13 +163,13 @@ func (r *Ring) getInternal(key uint32, n int, op Operation) ([]IngesterDesc, err
 }
 
 // GetAll returns all available ingesters in the circle.
-func (r *Ring) GetAll() []IngesterDesc {
+func (r *Ring) GetAll() []*IngesterDesc {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
-	ingesters := make([]IngesterDesc, 0, len(r.ringDesc.Ingesters))
+	ingesters := make([]*IngesterDesc, 0, len(r.ringDesc.Ingesters))
 	for _, ingester := range r.ringDesc.Ingesters {
-		if time.Now().Sub(ingester.Timestamp) > r.heartbeatTimeout {
+		if time.Now().Sub(time.Unix(ingester.Timestamp, 0)) > r.heartbeatTimeout {
 			continue
 		}
 		ingesters = append(ingesters, ingester)
@@ -183,9 +183,9 @@ func (r *Ring) Ready() bool {
 	defer r.mtx.RUnlock()
 
 	for _, ingester := range r.ringDesc.Ingesters {
-		if time.Now().Sub(ingester.Timestamp) > r.heartbeatTimeout {
+		if time.Now().Sub(time.Unix(ingester.Timestamp, 0)) > r.heartbeatTimeout {
 			return false
-		} else if ingester.State != Active {
+		} else if ingester.State != IngesterState_ACTIVE {
 			return false
 		}
 	}
@@ -237,12 +237,12 @@ func (r *Ring) Collect(ch chan<- prometheus.Metric) {
 
 	// Initialised to zero so we emit zero-metrics (instead of not emitting anything)
 	byState := map[string]int{
-		unhealthy:        0,
-		Active.String():  0,
-		Leaving.String(): 0,
+		unhealthy:                      0,
+		IngesterState_ACTIVE.String():  0,
+		IngesterState_LEAVING.String(): 0,
 	}
 	for _, ingester := range r.ringDesc.Ingesters {
-		if time.Now().Sub(ingester.Timestamp) > r.heartbeatTimeout {
+		if time.Now().Sub(time.Unix(ingester.Timestamp, 0)) > r.heartbeatTimeout {
 			byState[unhealthy]++
 		} else {
 			byState[ingester.State.String()]++

--- a/ring/ring.proto
+++ b/ring/ring.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package ring;
+
+message Desc {
+	map<string,IngesterDesc> ingesters = 1;
+	repeated TokenDesc tokens = 2;
+}
+
+message IngesterDesc {
+	string hostname = 1;
+	int64 timestamp = 2;
+	IngesterState state = 3;
+	bool protoRing = 5;
+}
+
+message TokenDesc {
+	uint32 token = 1;
+	string ingester = 2;
+}
+
+enum IngesterState {
+	ACTIVE = 0;
+	LEAVING = 1;
+}


### PR DESCRIPTION
Fixes #156 

<s>(Includes #162 and #161 for now, until they are merged)</s>

- The ring can read and write json and proto
- Internal representation is all proto, and there is a translation between the two (`ring.go:MarshalJSON`)
- Ingesters will always try to read json first, fallback to proto if that fails
- Once ingester fails to read json, it will always write proto
- Ingester will also start writing proto once it has detected all ingesters can read it

Have testing upgrades from master to this locally