### PR TITLE
Allow switching to daily instead of hourly index buckets

### DIFF
--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -139,9 +140,10 @@ type Store interface {
 
 // StoreConfig specifies config for a ChunkStore
 type StoreConfig struct {
-	S3URL       string
-	DynamoDBURL string
-	ChunkCache  *Cache
+	S3URL            string
+	DynamoDBURL      string
+	ChunkCache       *Cache
+	DailyBucketsFrom model.Time
 
 	// Not exported as only used by tests to inject mocks
 	dynamodb dynamodbClient
@@ -205,6 +207,10 @@ type AWSStore struct {
 	chunkCache *Cache
 	tableName  string
 	bucketName string
+
+	// Around which time to start bucketing indexes by day instead of by hour.
+	// Only the day matters, not the time within the day.
+	dailyBucketsFrom model.Time
 
 	dynamoRequests     chan dynamoOp
 	dynamoRequestsDone sync.WaitGroup
@@ -332,16 +338,36 @@ func (c *AWSStore) CreateTables() error {
 	return err
 }
 
-func bigBuckets(from, through model.Time) []int64 {
+func bigBuckets(from, through model.Time, dailyBucketsFrom model.Time) []string {
 	var (
 		secondsInHour = int64(time.Hour / time.Second)
 		fromHour      = from.Unix() / secondsInHour
 		throughHour   = through.Unix() / secondsInHour
-		result        []int64
+
+		secondsInDay = int64(24 * time.Hour / time.Second)
+		fromDay      = from.Unix() / secondsInDay
+		throughDay   = through.Unix() / secondsInDay
+
+		firstDailyBucket = dailyBucketsFrom.Unix() / secondsInDay
+		lastHourlyBucket = firstDailyBucket * 24
+
+		result []string
 	)
+
 	for i := fromHour; i <= throughHour; i++ {
-		result = append(result, i)
+		if i > lastHourlyBucket {
+			break
+		}
+		result = append(result, strconv.Itoa(int(i)))
 	}
+
+	for i := fromDay; i <= throughDay; i++ {
+		if i < firstDailyBucket {
+			continue
+		}
+		result = append(result, fmt.Sprintf("d%d", int(i)))
+	}
+
 	return result
 }
 
@@ -349,8 +375,8 @@ func chunkName(userID, chunkID string) string {
 	return fmt.Sprintf("%s/%s", userID, chunkID)
 }
 
-func hashValue(userID string, hour int64, metricName model.LabelValue) string {
-	return fmt.Sprintf("%s:%d:%s", userID, hour, metricName)
+func hashValue(userID string, bucket string, metricName model.LabelValue) string {
+	return fmt.Sprintf("%s:%s:%s", userID, bucket, metricName)
 }
 
 func rangeValue(label model.LabelName, value model.LabelValue, chunkID string) []byte {
@@ -456,8 +482,8 @@ func (c *AWSStore) calculateDynamoWrites(userID string, chunks []Chunk) ([]*dyna
 		}
 
 		entries := 0
-		for _, hour := range bigBuckets(chunk.From, chunk.Through) {
-			hashValue := hashValue(userID, hour, metricName)
+		for _, bucket := range bigBuckets(chunk.From, chunk.Through, c.dailyBucketsFrom) {
+			hashValue := hashValue(userID, bucket, metricName)
 			for label, value := range chunk.Metric {
 				if label == model.MetricNameLabel {
 					continue
@@ -556,18 +582,18 @@ func (c *AWSStore) lookupChunks(ctx context.Context, userID string, from, throug
 
 	incomingChunkSets := make(chan ByID)
 	incomingErrors := make(chan error)
-	buckets := bigBuckets(from, through)
+	buckets := bigBuckets(from, through, c.dailyBucketsFrom)
 	totalLookups := int32(0)
-	for _, hour := range buckets {
-		go func(hour int64) {
-			incoming, lookups, err := c.lookupChunksFor(ctx, userID, hour, metricName, matchers)
+	for _, b := range buckets {
+		go func(bucket string) {
+			incoming, lookups, err := c.lookupChunksFor(ctx, userID, bucket, metricName, matchers)
 			atomic.AddInt32(&totalLookups, lookups)
 			if err != nil {
 				incomingErrors <- err
 			} else {
 				incomingChunkSets <- incoming
 			}
-		}(hour)
+		}(b)
 	}
 
 	var chunks ByID
@@ -592,9 +618,9 @@ func next(s string) string {
 	return result
 }
 
-func (c *AWSStore) lookupChunksFor(ctx context.Context, userID string, hour int64, metricName model.LabelValue, matchers []*metric.LabelMatcher) (ByID, int32, error) {
+func (c *AWSStore) lookupChunksFor(ctx context.Context, userID string, bucket string, metricName model.LabelValue, matchers []*metric.LabelMatcher) (ByID, int32, error) {
 	if len(matchers) == 0 {
-		return c.lookupChunksForMetricName(ctx, userID, hour, metricName)
+		return c.lookupChunksForMetricName(ctx, userID, bucket, metricName)
 	}
 
 	incomingChunkSets := make(chan ByID)
@@ -602,7 +628,7 @@ func (c *AWSStore) lookupChunksFor(ctx context.Context, userID string, hour int6
 
 	for _, matcher := range matchers {
 		go func(matcher *metric.LabelMatcher) {
-			incoming, err := c.lookupChunksForMatcher(ctx, userID, hour, metricName, matcher)
+			incoming, err := c.lookupChunksForMatcher(ctx, userID, bucket, metricName, matcher)
 			if err != nil {
 				incomingErrors <- err
 			} else {
@@ -624,8 +650,8 @@ func (c *AWSStore) lookupChunksFor(ctx context.Context, userID string, hour int6
 	return nWayIntersect(chunkSets), int32(len(matchers)), lastErr
 }
 
-func (c *AWSStore) lookupChunksForMetricName(ctx context.Context, userID string, hour int64, metricName model.LabelValue) (ByID, int32, error) {
-	hashValue := hashValue(userID, hour, metricName)
+func (c *AWSStore) lookupChunksForMetricName(ctx context.Context, userID string, bucket string, metricName model.LabelValue) (ByID, int32, error) {
+	hashValue := hashValue(userID, bucket, metricName)
 	input := &dynamodb.QueryInput{
 		TableName: aws.String(c.tableName),
 		KeyConditions: map[string]*dynamodb.Condition{
@@ -665,8 +691,8 @@ func (c *AWSStore) lookupChunksForMetricName(ctx context.Context, userID string,
 	return chunkSet, 1, nil
 }
 
-func (c *AWSStore) lookupChunksForMatcher(ctx context.Context, userID string, hour int64, metricName model.LabelValue, matcher *metric.LabelMatcher) (ByID, error) {
-	hashValue := hashValue(userID, hour, metricName)
+func (c *AWSStore) lookupChunksForMatcher(ctx context.Context, userID string, bucket string, metricName model.LabelValue, matcher *metric.LabelMatcher) (ByID, error) {
+	hashValue := hashValue(userID, bucket, metricName)
 	var rangeMinValue, rangeMaxValue []byte
 	if matcher.Type == metric.Equal {
 		nextValue := model.LabelValue(next(string(matcher.Value)))

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -338,7 +338,7 @@ func (c *AWSStore) CreateTables() error {
 	return err
 }
 
-func bigBuckets(from, through model.Time, dailyBucketsFrom model.Time) []string {
+func (c *AWSStore) bigBuckets(from, through model.Time) []string {
 	var (
 		secondsInHour = int64(time.Hour / time.Second)
 		fromHour      = from.Unix() / secondsInHour
@@ -348,7 +348,7 @@ func bigBuckets(from, through model.Time, dailyBucketsFrom model.Time) []string 
 		fromDay      = from.Unix() / secondsInDay
 		throughDay   = through.Unix() / secondsInDay
 
-		firstDailyBucket = dailyBucketsFrom.Unix() / secondsInDay
+		firstDailyBucket = c.dailyBucketsFrom.Unix() / secondsInDay
 		lastHourlyBucket = firstDailyBucket * 24
 
 		result []string
@@ -482,7 +482,7 @@ func (c *AWSStore) calculateDynamoWrites(userID string, chunks []Chunk) ([]*dyna
 		}
 
 		entries := 0
-		for _, bucket := range bigBuckets(chunk.From, chunk.Through, c.dailyBucketsFrom) {
+		for _, bucket := range c.bigBuckets(chunk.From, chunk.Through) {
 			hashValue := hashValue(userID, bucket, metricName)
 			for label, value := range chunk.Metric {
 				if label == model.MetricNameLabel {
@@ -582,7 +582,7 @@ func (c *AWSStore) lookupChunks(ctx context.Context, userID string, from, throug
 
 	incomingChunkSets := make(chan ByID)
 	incomingErrors := make(chan error)
-	buckets := bigBuckets(from, through, c.dailyBucketsFrom)
+	buckets := c.bigBuckets(from, through)
 	totalLookups := int32(0)
 	for _, b := range buckets {
 		go func(bucket string) {

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -146,3 +146,41 @@ func diff(want, have interface{}) string {
 	})
 	return "\n" + text
 }
+
+func TestBigBuckets(t *testing.T) {
+	scenarios := []struct {
+		from, through, dayEpochFrom model.Time
+		buckets                     []string
+	}{
+		{
+			from:         model.TimeFromUnix(0),
+			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dayEpochFrom: model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
+			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
+		},
+		{
+			from:         model.TimeFromUnix(0),
+			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dayEpochFrom: model.TimeFromUnix(0).Add(2*24*time.Hour) - 1, // Only the day matters for the epoch start time, not the time.
+			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
+		},
+		{
+			from:         model.TimeFromUnix(0),
+			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dayEpochFrom: model.TimeFromUnix(0).Add(1*24*time.Hour) - 1,
+			buckets:      []string{"0", "d0", "d1", "d2"},
+		},
+		{
+			from:         model.TimeFromUnix(0),
+			through:      model.TimeFromUnix(0).Add(2 * 24 * time.Hour),
+			dayEpochFrom: model.TimeFromUnix(0).Add(99 * 24 * time.Hour),
+			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48"},
+		},
+	}
+	for i, s := range scenarios {
+		buckets := bigBuckets(s.from, s.through, s.dayEpochFrom)
+		if !reflect.DeepEqual(buckets, s.buckets) {
+			t.Fatalf("%d. unexpected buckets; want %v, got %v", i, s.buckets, buckets)
+		}
+	}
+}

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -149,36 +149,39 @@ func diff(want, have interface{}) string {
 
 func TestBigBuckets(t *testing.T) {
 	scenarios := []struct {
-		from, through, dayEpochFrom model.Time
-		buckets                     []string
+		from, through, dailyBucketsFrom model.Time
+		buckets                         []string
 	}{
 		{
-			from:         model.TimeFromUnix(0),
-			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dayEpochFrom: model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
-			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
+			from:             model.TimeFromUnix(0),
+			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dailyBucketsFrom: model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
+			buckets:          []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
 		},
 		{
-			from:         model.TimeFromUnix(0),
-			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dayEpochFrom: model.TimeFromUnix(0).Add(2*24*time.Hour) - 1, // Only the day matters for the epoch start time, not the time.
-			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
+			from:             model.TimeFromUnix(0),
+			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dailyBucketsFrom: model.TimeFromUnix(0).Add(2*24*time.Hour) - 1, // Only the day matters for the epoch start time, not the time.
+			buckets:          []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "d1", "d2"},
 		},
 		{
-			from:         model.TimeFromUnix(0),
-			through:      model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dayEpochFrom: model.TimeFromUnix(0).Add(1*24*time.Hour) - 1,
-			buckets:      []string{"0", "d0", "d1", "d2"},
+			from:             model.TimeFromUnix(0),
+			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
+			dailyBucketsFrom: model.TimeFromUnix(0).Add(1*24*time.Hour) - 1,
+			buckets:          []string{"0", "d0", "d1", "d2"},
 		},
 		{
-			from:         model.TimeFromUnix(0),
-			through:      model.TimeFromUnix(0).Add(2 * 24 * time.Hour),
-			dayEpochFrom: model.TimeFromUnix(0).Add(99 * 24 * time.Hour),
-			buckets:      []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48"},
+			from:             model.TimeFromUnix(0),
+			through:          model.TimeFromUnix(0).Add(2 * 24 * time.Hour),
+			dailyBucketsFrom: model.TimeFromUnix(0).Add(99 * 24 * time.Hour),
+			buckets:          []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48"},
 		},
 	}
 	for i, s := range scenarios {
-		buckets := bigBuckets(s.from, s.through, s.dayEpochFrom)
+		cs := &AWSStore{
+			dailyBucketsFrom: s.dailyBucketsFrom,
+		}
+		buckets := cs.bigBuckets(s.from, s.through)
 		if !reflect.DeepEqual(buckets, s.buckets) {
 			t.Fatalf("%d. unexpected buckets; want %v, got %v", i, s.buckets, buckets)
 		}


### PR DESCRIPTION
There can be slight overlap around the switchover time, but I deemed it
safer (and not incorrect) than risking gaps due to some calculation
error.