### PR TITLE
Add distributor endpoint for validating PromQL expressions

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -310,6 +310,7 @@ func setupQuerier(
 	}).WithPrefix("/api/prom/api/v1")
 	api.Register(promRouter)
 	router.PathPrefix("/api/v1").Handler(promRouter)
+	router.Path("/validate_expr").Handler(http.HandlerFunc(distributor.ValidateExprHandler))
 	router.Path("/user_stats").Handler(http.HandlerFunc(distributor.UserStatsHandler))
 	router.Path("/graph").Handler(ui.GraphHandler())
 	router.PathPrefix("/static/").Handler(ui.StaticAssetsHandler("/api/prom/static/"))

--- a/distributor/http_server.go
+++ b/distributor/http_server.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/common/log"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/remote"
 
 	"github.com/weaveworks/cortex/util"
@@ -53,4 +54,11 @@ func (d *Distributor) UserStatsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.WriteJSONResponse(w, stats)
+}
+
+// ValidateExprHandler validates a PromQL expression.
+func (d *Distributor) ValidateExprHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := promql.ParseExpr(r.FormValue("expr"))
+	valid := (err == nil)
+	util.WriteJSONResponse(w, map[string]bool{"valid": valid})
 }

--- a/distributor/http_server.go
+++ b/distributor/http_server.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/common/log"
@@ -59,6 +60,39 @@ func (d *Distributor) UserStatsHandler(w http.ResponseWriter, r *http.Request) {
 // ValidateExprHandler validates a PromQL expression.
 func (d *Distributor) ValidateExprHandler(w http.ResponseWriter, r *http.Request) {
 	_, err := promql.ParseExpr(r.FormValue("expr"))
-	valid := (err == nil)
-	util.WriteJSONResponse(w, map[string]bool{"valid": valid})
+
+	// We mimick the response format of Prometheus's official API here for
+	// consistency, but unfortunately its private types (string consts etc.)
+	// aren't reusable.
+	if err == nil {
+		util.WriteJSONResponse(w, map[string]string{
+			"status": "success",
+		})
+		return
+	}
+
+	parseErr, ok := err.(*promql.ParseErr)
+	if !ok {
+		// This should always be a promql.ParseErr.
+		http.Error(w, fmt.Sprintf("unexpected error returned from PromQL parser: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// If the parsing input was a single line, parseErr.Line is 0
+	// and the generated error string omits the line entirely. But we
+	// want to report line numbers consistently, no matter how many
+	// lines there are (starting at 1).
+	if parseErr.Line == 0 {
+		parseErr.Line = 1
+	}
+	w.WriteHeader(http.StatusBadRequest)
+	util.WriteJSONResponse(w, map[string]interface{}{
+		"status":    "error",
+		"errorType": "bad_data",
+		"error":     err.Error(),
+		"location": map[string]int{
+			"line": parseErr.Line,
+			"pos":  parseErr.Pos,
+		},
+	})
 }


### PR DESCRIPTION
**Update:** Now the response looks like this:

In case of a good expression:

HTTP status code: 200 OK.

```json
{
  "status": "success"
}
```

In case of an error:

HTTP status code: 400 Bad Request.

```json
{
  "error": "parse error at line 1, char 4: could not parse remaining input \",expr\"...",
  "errorType": "bad_data",
  "location": {
    "line": 1,
    "pos": 4
  },
  "status": "error"
}
```

Fixes https://github.com/weaveworks/cortex/issues/176