### PR TITLE
Ensure desc.LastTime is always up to date

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -33,14 +33,14 @@ type Chunk struct {
 }
 
 // NewChunk creates a new chunk
-func NewChunk(fp model.Fingerprint, metric model.Metric, c *prom_chunk.Desc) Chunk {
+func NewChunk(fp model.Fingerprint, metric model.Metric, c prom_chunk.Chunk, firstTime, lastTime model.Time) Chunk {
 	return Chunk{
-		ID:       fmt.Sprintf("%d:%d:%d", fp, c.ChunkFirstTime, c.ChunkLastTime),
-		From:     c.ChunkFirstTime,
-		Through:  c.ChunkLastTime,
+		ID:       fmt.Sprintf("%d:%d:%d", fp, firstTime, lastTime),
+		From:     firstTime,
+		Through:  lastTime,
 		Metric:   metric,
-		Encoding: c.C.Encoding(),
-		Data:     c.C,
+		Encoding: c.Encoding(),
+		Data:     c,
 	}
 }
 

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -52,11 +52,9 @@ func TestChunkStoreUnprocessed(t *testing.T) {
 			"bar":  "baz",
 			"toms": "code",
 		},
-		&chunk.Desc{
-			ChunkFirstTime: now.Add(-time.Hour),
-			ChunkLastTime:  now,
-			C:              chunks[0],
-		},
+		chunks[0],
+		now.Add(-time.Hour),
+		now,
 	)
 	want := []Chunk{chunk}
 	if err := store.Put(ctx, want); err != nil {
@@ -91,11 +89,9 @@ func TestChunkStore(t *testing.T) {
 			"bar":  "baz",
 			"toms": "code",
 		},
-		&chunk.Desc{
-			ChunkFirstTime: now.Add(-time.Hour),
-			ChunkLastTime:  now,
-			C:              chunks[0],
-		},
+		chunks[0],
+		now.Add(-time.Hour),
+		now,
 	)
 	chunk2 := NewChunk(
 		model.Fingerprint(2),
@@ -104,11 +100,9 @@ func TestChunkStore(t *testing.T) {
 			"bar":  "beep",
 			"toms": "code",
 		},
-		&chunk.Desc{
-			ChunkFirstTime: now.Add(-time.Hour),
-			ChunkLastTime:  now,
-			C:              chunks[0],
-		},
+		chunks[0],
+		now.Add(-time.Hour),
+		now,
 	)
 
 	if err := store.Put(ctx, []Chunk{chunk1, chunk2}); err != nil {

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -2,14 +2,12 @@ package ingester
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
-	prom_chunk "github.com/prometheus/prometheus/storage/local/chunk"
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/storage/remote"
 	"golang.org/x/net/context"
@@ -75,7 +73,6 @@ type Ingester struct {
 	flushQueues []*util.PriorityQueue
 
 	ingestedSamples  prometheus.Counter
-	discardedSamples *prometheus.CounterVec
 	chunkUtilization prometheus.Histogram
 	chunkLength      prometheus.Histogram
 	chunkAge         prometheus.Histogram
@@ -147,13 +144,6 @@ func New(cfg Config, chunkStore cortex_chunk.Store) (*Ingester, error) {
 			Name: "cortex_ingester_ingested_samples_total",
 			Help: "The total number of samples ingested.",
 		}),
-		discardedSamples: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "cortex_ingester_out_of_order_samples_total",
-				Help: "The total number of samples that were discarded because their timestamps were at or before the last received sample for a series.",
-			},
-			[]string{discardReasonLabel},
-		),
 		chunkUtilization: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_utilization",
 			Help:    "Distribution of stored chunk utilization (when stored).",
@@ -236,35 +226,18 @@ func (i *Ingester) append(ctx context.Context, sample *model.Sample) error {
 		state.fpLocker.Unlock(fp)
 	}()
 
-	if sample.Timestamp == series.lastTime {
-		// Don't report "no-op appends", i.e. where timestamp and sample
-		// value are the same as for the last append, as they are a
-		// common occurrence when using client-side timestamps
-		// (e.g. Pushgateway or federation).
-		if sample.Timestamp == series.lastTime &&
-			series.lastSampleValueSet &&
-			sample.Value.Equal(series.lastSampleValue) {
-			return nil
-		}
-		i.discardedSamples.WithLabelValues(duplicateSample).Inc()
-		return ErrDuplicateSampleForTimestamp // Caused by the caller.
-	}
-	if sample.Timestamp < series.lastTime {
-		i.discardedSamples.WithLabelValues(outOfOrderTimestamp).Inc()
-		return ErrOutOfOrderSample // Caused by the caller.
-	}
 	prevNumChunks := len(series.chunkDescs)
-	_, err = series.add(model.SamplePair{
+	if err := series.add(model.SamplePair{
 		Value:     sample.Value,
 		Timestamp: sample.Timestamp,
-	})
-	i.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
-
-	if err == nil {
-		// TODO: Track append failures too (unlikely to happen).
-		i.ingestedSamples.Inc()
-		state.ingestedSamples.inc()
+	}); err != nil {
+		return err
 	}
+
+	i.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
+	i.ingestedSamples.Inc()
+	state.ingestedSamples.inc()
+
 	return err
 }
 
@@ -347,7 +320,7 @@ func (i *Ingester) query(ctx context.Context, from, through model.Time, matchers
 			continue
 		}
 
-		values, err := samplesForRange(series, from, through)
+		values, err := series.samplesForRange(from, through)
 		state.fpLocker.Unlock(fp)
 		if err != nil {
 			return nil, err
@@ -363,48 +336,6 @@ func (i *Ingester) query(ctx context.Context, from, through model.Time, matchers
 	i.queriedSamples.Add(float64(queriedSamples))
 
 	return result, nil
-}
-
-func samplesForRange(s *memorySeries, from, through model.Time) ([]model.SamplePair, error) {
-	// Find first chunk with start time after "from".
-	fromIdx := sort.Search(len(s.chunkDescs), func(i int) bool {
-		return s.chunkDescs[i].FirstTime().After(from)
-	})
-	// Find first chunk with start time after "through".
-	throughIdx := sort.Search(len(s.chunkDescs), func(i int) bool {
-		return s.chunkDescs[i].FirstTime().After(through)
-	})
-	if fromIdx == len(s.chunkDescs) {
-		// Even the last chunk starts before "from". Find out if the
-		// series ends before "from" and we don't need to do anything.
-		lt, err := s.chunkDescs[len(s.chunkDescs)-1].LastTime()
-		if err != nil {
-			return nil, err
-		}
-		if lt.Before(from) {
-			return nil, nil
-		}
-	}
-	if fromIdx > 0 {
-		fromIdx--
-	}
-	if throughIdx == len(s.chunkDescs) {
-		throughIdx--
-	}
-	var values []model.SamplePair
-	in := metric.Interval{
-		OldestInclusive: from,
-		NewestInclusive: through,
-	}
-	for idx := fromIdx; idx <= throughIdx; idx++ {
-		cd := s.chunkDescs[idx]
-		chValues, err := prom_chunk.RangeValues(cd.C.NewIterator(), in)
-		if err != nil {
-			return nil, err
-		}
-		values = append(values, chValues...)
-	}
-	return values, nil
 }
 
 // LabelValues returns all label values that are associated with a given label name.
@@ -547,7 +478,7 @@ func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memo
 		return
 	}
 
-	lastTime := series.lastTime
+	lastTime := series.firstTime()
 	flush := i.shouldFlushSeries(series, immediate)
 
 	if flush {
@@ -570,14 +501,14 @@ func (i *Ingester) shouldFlushSeries(series *memorySeries, immediate bool) bool 
 	return false
 }
 
-func (i *Ingester) shouldFlushChunk(c *prom_chunk.Desc) bool {
+func (i *Ingester) shouldFlushChunk(c *desc) bool {
 	// Chunks should be flushed if their oldest entry is older than MaxChunkAge
-	if model.Now().Sub(c.ChunkFirstTime) > i.cfg.MaxChunkAge {
+	if model.Now().Sub(c.FirstTime) > i.cfg.MaxChunkAge {
 		return true
 	}
 
 	// Chunk should be flushed if their last entry is older then MaxChunkIdle
-	if model.Now().Sub(c.ChunkLastTime) > i.cfg.MaxChunkIdle {
+	if model.Now().Sub(c.LastTime) > i.cfg.MaxChunkIdle {
 		return true
 	}
 
@@ -624,7 +555,7 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 
 	// Assume we're going to flush everything, and maybe don't flush the head chunk if it doesn't need it.
 	chunks := series.chunkDescs
-	if immediate || (len(chunks) > 0 && i.shouldFlushChunk(chunks[0])) {
+	if immediate || (len(chunks) > 0 && i.shouldFlushChunk(series.head())) {
 		series.closeHead()
 	} else {
 		chunks = chunks[:len(chunks)-1]
@@ -654,13 +585,13 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 	return nil
 }
 
-func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric model.Metric, chunkDescs []*prom_chunk.Desc) error {
+func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric model.Metric, chunkDescs []*desc) error {
 	wireChunks := make([]cortex_chunk.Chunk, 0, len(chunkDescs))
 	for _, chunkDesc := range chunkDescs {
 		i.chunkUtilization.Observe(chunkDesc.C.Utilization())
 		i.chunkLength.Observe(float64(chunkDesc.C.Len()))
-		i.chunkAge.Observe(model.Now().Sub(chunkDesc.ChunkFirstTime).Seconds())
-		wireChunks = append(wireChunks, cortex_chunk.NewChunk(fp, metric, chunkDesc))
+		i.chunkAge.Observe(model.Now().Sub(chunkDesc.FirstTime).Seconds())
+		wireChunks = append(wireChunks, cortex_chunk.NewChunk(fp, metric, chunkDesc.C, chunkDesc.FirstTime, chunkDesc.LastTime))
 	}
 	return i.chunkStore.Put(ctx, wireChunks)
 }
@@ -680,7 +611,6 @@ func (i *Ingester) Describe(ch chan<- *prometheus.Desc) {
 	ch <- memoryUsersDesc
 	ch <- flushQueueLengthDesc
 	ch <- i.ingestedSamples.Desc()
-	i.discardedSamples.Describe(ch)
 	ch <- i.chunkUtilization.Desc()
 	ch <- i.chunkLength.Desc()
 	ch <- i.chunkAge.Desc()
@@ -720,7 +650,6 @@ func (i *Ingester) Collect(ch chan<- prometheus.Metric) {
 		float64(flushQueueLength),
 	)
 	ch <- i.ingestedSamples
-	i.discardedSamples.Collect(ch)
 	ch <- i.chunkUtilization
 	ch <- i.chunkLength
 	ch <- i.chunkAge

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -478,12 +478,12 @@ func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memo
 		return
 	}
 
-	lastTime := series.firstTime()
+	firstTime := series.firstTime()
 	flush := i.shouldFlushSeries(series, immediate)
 
 	if flush {
 		flushQueueIndex := int(uint64(fp) % uint64(i.cfg.ConcurrentFlushes))
-		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{lastTime, userID, fp, immediate})
+		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate})
 	}
 }
 

--- a/ingester/series.go
+++ b/ingester/series.go
@@ -86,7 +86,8 @@ func (s *memorySeries) add(v model.SamplePair) error {
 	switch len(chunks) {
 	case 1: // noop, sample added to the chunk
 	case 2:
-		// new overflow chunk - in practice there is only ever 1
+		// new overflow chunk - in practice there is only ever 1 overflow chunk,
+		// thats how the chunk code is constructed.
 		s.chunkDescs = append(s.chunkDescs, newDesc(chunks[1], v.Timestamp))
 	default:
 		panic(fmt.Sprintf("Unexpected: got %d chunks from chunk.Add", len(chunks)))
@@ -99,7 +100,7 @@ func (s *memorySeries) closeHead() {
 	s.headChunkClosed = true
 }
 
-// firstTime returns the earliest know time for the series. The caller must have
+// firstTime returns the earliest known time for the series. The caller must have
 // locked the fingerprint of the memorySeries. This method will panic if this
 // series has no chunk descriptors.
 func (s *memorySeries) firstTime() model.Time {

--- a/ingester/series.go
+++ b/ingester/series.go
@@ -1,109 +1,42 @@
 package ingester
 
 import (
-	"sync"
+	"fmt"
+	"sort"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-
 	"github.com/prometheus/prometheus/storage/local/chunk"
+	"github.com/prometheus/prometheus/storage/metric"
 )
 
-// fingerprintSeriesPair pairs a fingerprint with a memorySeries pointer.
-type fingerprintSeriesPair struct {
-	fp     model.Fingerprint
-	series *memorySeries
-}
+var discardedSamples = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cortex_ingester_out_of_order_samples_total",
+		Help: "The total number of samples that were discarded because their timestamps were at or before the last received sample for a series.",
+	},
+	[]string{discardReasonLabel},
+)
 
-// seriesMap maps fingerprints to memory series. All its methods are
-// goroutine-safe. A seriesMap is effectively is a goroutine-safe version of
-// map[model.Fingerprint]*memorySeries.
-type seriesMap struct {
-	mtx sync.RWMutex
-	m   map[model.Fingerprint]*memorySeries
-}
-
-// newSeriesMap returns a newly allocated empty seriesMap. To create a seriesMap
-// based on a prefilled map, use an explicit initializer.
-func newSeriesMap() *seriesMap {
-	return &seriesMap{m: make(map[model.Fingerprint]*memorySeries)}
-}
-
-// length returns the number of mappings in the seriesMap.
-func (sm *seriesMap) length() int {
-	sm.mtx.RLock()
-	defer sm.mtx.RUnlock()
-
-	return len(sm.m)
-}
-
-// get returns a memorySeries for a fingerprint. Return values have the same
-// semantics as the native Go map.
-func (sm *seriesMap) get(fp model.Fingerprint) (s *memorySeries, ok bool) {
-	sm.mtx.RLock()
-	s, ok = sm.m[fp]
-	// Note that the RUnlock is not done via defer for performance reasons.
-	// TODO(beorn7): Once https://github.com/golang/go/issues/14939 is
-	// fixed, revert to the usual defer idiom.
-	sm.mtx.RUnlock()
-	return
-}
-
-// put adds a mapping to the seriesMap. It panics if s == nil.
-func (sm *seriesMap) put(fp model.Fingerprint, s *memorySeries) {
-	sm.mtx.Lock()
-	defer sm.mtx.Unlock()
-
-	if s == nil {
-		panic("tried to add nil pointer to seriesMap")
-	}
-	sm.m[fp] = s
-}
-
-// del removes a mapping from the series Map.
-func (sm *seriesMap) del(fp model.Fingerprint) {
-	sm.mtx.Lock()
-	defer sm.mtx.Unlock()
-
-	delete(sm.m, fp)
-}
-
-// iter returns a channel that produces all mappings in the seriesMap. The
-// channel will be closed once all fingerprints have been received. Not
-// consuming all fingerprints from the channel will leak a goroutine. The
-// semantics of concurrent modification of seriesMap is the similar as the one
-// for iterating over a map with a 'range' clause. However, if the next element
-// in iteration order is removed after the current element has been received
-// from the channel, it will still be produced by the channel.
-func (sm *seriesMap) iter() <-chan fingerprintSeriesPair {
-	ch := make(chan fingerprintSeriesPair)
-	go func() {
-		sm.mtx.RLock()
-		for fp, s := range sm.m {
-			sm.mtx.RUnlock()
-			ch <- fingerprintSeriesPair{fp, s}
-			sm.mtx.RLock()
-		}
-		sm.mtx.RUnlock()
-		close(ch)
-	}()
-	return ch
+func init() {
+	prometheus.MustRegister(discardedSamples)
 }
 
 type memorySeries struct {
 	metric model.Metric
+
 	// Sorted by start time, overlapping chunk ranges are forbidden.
-	chunkDescs []*chunk.Desc
-	// The timestamp of the last sample in this series. Needed to
-	// ensure timestamp monotonicity during ingestion.
-	lastTime model.Time
-	// The value of the last sample in this series. Needed to
-	// ensure timestamp monotonicity during ingestion.
-	lastSampleValue model.SampleValue
-	// Whether lastSampleValue has been set already.
-	lastSampleValueSet bool
+	chunkDescs []*desc
+
 	// Whether the current head chunk has already been finished.  If true,
 	// the current head chunk must not be modified anymore.
 	headChunkClosed bool
+
+	// The timestamp & value of the last sample in this series. Needed to
+	// ensure timestamp monotonicity during ingestion.
+	lastSampleValueSet bool
+	lastTime           model.Time
+	lastSampleValue    model.SampleValue
 }
 
 // newMemorySeries returns a pointer to a newly allocated memorySeries for the
@@ -119,42 +52,132 @@ func newMemorySeries(m model.Metric) *memorySeries {
 // completed chunks (which are now eligible for persistence).
 //
 // The caller must have locked the fingerprint of the series.
-func (s *memorySeries) add(v model.SamplePair) (int, error) {
+func (s *memorySeries) add(v model.SamplePair) error {
+	// Don't report "no-op appends", i.e. where timestamp and sample
+	// value are the same as for the last append, as they are a
+	// common occurrence when using client-side timestamps
+	// (e.g. Pushgateway or federation).
+	if s.lastSampleValueSet &&
+		v.Timestamp == s.lastTime &&
+		v.Value.Equal(s.lastSampleValue) {
+		return nil
+	}
+	if v.Timestamp == s.lastTime {
+		discardedSamples.WithLabelValues(duplicateSample).Inc()
+		return ErrDuplicateSampleForTimestamp // Caused by the caller.
+	}
+	if v.Timestamp < s.lastTime {
+		discardedSamples.WithLabelValues(outOfOrderTimestamp).Inc()
+		return ErrOutOfOrderSample // Caused by the caller.
+	}
+
 	if len(s.chunkDescs) == 0 || s.headChunkClosed {
-		newHead := chunk.NewDesc(chunk.New(), v.Timestamp)
+		newHead := newDesc(chunk.New(), v.Timestamp)
 		s.chunkDescs = append(s.chunkDescs, newHead)
 		s.headChunkClosed = false
 	}
 
-	chunks, err := s.head().Add(v)
+	chunks, err := s.head().add(v)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	s.head().C = chunks[0]
 
-	for _, c := range chunks[1:] {
-		s.chunkDescs = append(s.chunkDescs, chunk.NewDesc(c, c.FirstTime()))
+	switch len(chunks) {
+	case 1: // noop, sample added to the chunk
+	case 2:
+		// new overflow chunk - in practice there is only ever 1
+		s.chunkDescs = append(s.chunkDescs, newDesc(chunks[1], v.Timestamp))
+	default:
+		panic(fmt.Sprintf("Unexpected: got %d chunks from chunk.Add", len(chunks)))
 	}
 
-	// Populate lastTime of now-closed chunks.
-	for _, cd := range s.chunkDescs[len(s.chunkDescs)-len(chunks) : len(s.chunkDescs)-1] {
-		cd.MaybePopulateLastTime()
-	}
-
-	s.lastTime = v.Timestamp
-	s.lastSampleValue = v.Value
-	s.lastSampleValueSet = true
-	return len(chunks) - 1, nil
+	return nil
 }
 
 func (s *memorySeries) closeHead() {
 	s.headChunkClosed = true
-	s.head().MaybePopulateLastTime()
+}
+
+// firstTime returns the earliest know time for the series. The caller must have
+// locked the fingerprint of the memorySeries. This method will panic if this
+// series has no chunk descriptors.
+func (s *memorySeries) firstTime() model.Time {
+	return s.chunkDescs[0].FirstTime
 }
 
 // head returns a pointer to the head chunk descriptor. The caller must have
 // locked the fingerprint of the memorySeries. This method will panic if this
 // series has no chunk descriptors.
-func (s *memorySeries) head() *chunk.Desc {
+func (s *memorySeries) head() *desc {
 	return s.chunkDescs[len(s.chunkDescs)-1]
+}
+
+func (s *memorySeries) samplesForRange(from, through model.Time) ([]model.SamplePair, error) {
+	// Find first chunk with start time after "from".
+	fromIdx := sort.Search(len(s.chunkDescs), func(i int) bool {
+		return s.chunkDescs[i].FirstTime.After(from)
+	})
+	// Find first chunk with start time after "through".
+	throughIdx := sort.Search(len(s.chunkDescs), func(i int) bool {
+		return s.chunkDescs[i].FirstTime.After(through)
+	})
+	if fromIdx == len(s.chunkDescs) {
+		// Even the last chunk starts before "from". Find out if the
+		// series ends before "from" and we don't need to do anything.
+		lt := s.chunkDescs[len(s.chunkDescs)-1].LastTime
+		if lt.Before(from) {
+			return nil, nil
+		}
+	}
+	if fromIdx > 0 {
+		fromIdx--
+	}
+	if throughIdx == len(s.chunkDescs) {
+		throughIdx--
+	}
+	var values []model.SamplePair
+	in := metric.Interval{
+		OldestInclusive: from,
+		NewestInclusive: through,
+	}
+	for idx := fromIdx; idx <= throughIdx; idx++ {
+		cd := s.chunkDescs[idx]
+		chValues, err := chunk.RangeValues(cd.C.NewIterator(), in)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, chValues...)
+	}
+	return values, nil
+}
+
+type desc struct {
+	C         chunk.Chunk // nil if chunk is evicted.
+	FirstTime model.Time  // Populated at creation. Immutable.
+	LastTime  model.Time  // Populated at creation & on append.
+}
+
+func newDesc(c chunk.Chunk, firstTime model.Time) *desc {
+	return &desc{
+		C:         c,
+		FirstTime: firstTime,
+		LastTime:  firstTime,
+	}
+}
+
+// Add adds a sample pair to the underlying chunk. For safe concurrent access,
+// The chunk must be pinned, and the caller must have locked the fingerprint of
+// the series.
+func (d *desc) add(s model.SamplePair) ([]chunk.Chunk, error) {
+	cs, err := d.C.Add(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cs) == 1 {
+		d.LastTime = s.Timestamp // sample was added to this chunk
+	}
+
+	return cs, nil
 }

--- a/ingester/series_map.go
+++ b/ingester/series_map.go
@@ -1,0 +1,88 @@
+package ingester
+
+import (
+	"sync"
+
+	"github.com/prometheus/common/model"
+)
+
+// fingerprintSeriesPair pairs a fingerprint with a memorySeries pointer.
+type fingerprintSeriesPair struct {
+	fp     model.Fingerprint
+	series *memorySeries
+}
+
+// seriesMap maps fingerprints to memory series. All its methods are
+// goroutine-safe. A seriesMap is effectively is a goroutine-safe version of
+// map[model.Fingerprint]*memorySeries.
+type seriesMap struct {
+	mtx sync.RWMutex
+	m   map[model.Fingerprint]*memorySeries
+}
+
+// newSeriesMap returns a newly allocated empty seriesMap. To create a seriesMap
+// based on a prefilled map, use an explicit initializer.
+func newSeriesMap() *seriesMap {
+	return &seriesMap{m: make(map[model.Fingerprint]*memorySeries)}
+}
+
+// length returns the number of mappings in the seriesMap.
+func (sm *seriesMap) length() int {
+	sm.mtx.RLock()
+	defer sm.mtx.RUnlock()
+
+	return len(sm.m)
+}
+
+// get returns a memorySeries for a fingerprint. Return values have the same
+// semantics as the native Go map.
+func (sm *seriesMap) get(fp model.Fingerprint) (s *memorySeries, ok bool) {
+	sm.mtx.RLock()
+	s, ok = sm.m[fp]
+	// Note that the RUnlock is not done via defer for performance reasons.
+	// TODO(beorn7): Once https://github.com/golang/go/issues/14939 is
+	// fixed, revert to the usual defer idiom.
+	sm.mtx.RUnlock()
+	return
+}
+
+// put adds a mapping to the seriesMap. It panics if s == nil.
+func (sm *seriesMap) put(fp model.Fingerprint, s *memorySeries) {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+
+	if s == nil {
+		panic("tried to add nil pointer to seriesMap")
+	}
+	sm.m[fp] = s
+}
+
+// del removes a mapping from the series Map.
+func (sm *seriesMap) del(fp model.Fingerprint) {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+
+	delete(sm.m, fp)
+}
+
+// iter returns a channel that produces all mappings in the seriesMap. The
+// channel will be closed once all fingerprints have been received. Not
+// consuming all fingerprints from the channel will leak a goroutine. The
+// semantics of concurrent modification of seriesMap is the similar as the one
+// for iterating over a map with a 'range' clause. However, if the next element
+// in iteration order is removed after the current element has been received
+// from the channel, it will still be produced by the channel.
+func (sm *seriesMap) iter() <-chan fingerprintSeriesPair {
+	ch := make(chan fingerprintSeriesPair)
+	go func() {
+		sm.mtx.RLock()
+		for fp, s := range sm.m {
+			sm.mtx.RUnlock()
+			ch <- fingerprintSeriesPair{fp, s}
+			sm.mtx.RLock()
+		}
+		sm.mtx.RUnlock()
+		close(ch)
+	}()
+	return ch
+}


### PR DESCRIPTION
Fixes #201 

Also:
- stop using upstream chunk.Desc, use our own (slightly simplier) one
- move logic for detecting duplicate or historic appends into series.go, so it encapsulates with the required state
- more `samplesForRange` into series.go, where is seems to more naturally belong
- use series's first time as the sort key for the flush queue, not last time - should flush old chunks first!
- when flushing, consider the head (ie newest) chunk when deciding if to close the head...
- move seriesMap into its own file (series_map.go)