### PR TITLE
Tweak histogram buckets as chunks are bigger than previously

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -155,12 +155,12 @@ func New(cfg Config, chunkStore cortex_chunk.Store) (*Ingester, error) {
 		chunkLength: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_length",
 			Help:    "Distribution of stored chunk lengths (when stored).",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+			Buckets: prometheus.ExponentialBuckets(10, 2, 8), // biggest bucket is 10*2^(8-1) = 1280
 		}),
 		chunkAge: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_age_seconds",
 			Help:    "Distribution of chunk ages (when stored).",
-			Buckets: prometheus.ExponentialBuckets(60, 2, 9),
+			Buckets: prometheus.ExponentialBuckets(60, 2, 10), // biggest bucket is 60*2^(10-1) = 30720 = 8:32 hrs
 		}),
 		memoryChunks: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_chunks",


### PR DESCRIPTION
With varbit, we'll get ~800 samples per chunk, or 3:20hrs sized-chunks (at 15s scrape periods).