### PR TITLE
Don't completely fail the cache lookup if we fail to decode one chunk.

### DIFF
--- a/chunk/chunk_cache.go
+++ b/chunk/chunk_cache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"github.com/weaveworks/scope/common/instrument"
 	"golang.org/x/net/context"
 )

--- a/chunk/chunk_cache.go
+++ b/chunk/chunk_cache.go
@@ -97,7 +97,9 @@ func (c *Cache) FetchChunkData(ctx context.Context, userID string, chunks []Chun
 		}
 
 		if err := chunk.decode(bytes.NewReader(item.Value)); err != nil {
-			return nil, nil, err
+			log.Errorf("Failed to decode chunk from cache: %v", err)
+			missing = append(missing, chunk)
+			continue
 		}
 		found = append(found, chunk)
 	}


### PR DESCRIPTION
Also works around the issue where returning `nil, nil, err` was the wrong thing to do here, should have been `nil, chunks, err`.

Fixes #215 