### PR TITLE
Populate grpc hostname on heartbeat.

### DIFF
--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -184,6 +184,7 @@ func (r *IngesterRegistration) heartbeat(tokens []uint32) {
 		} else {
 			ingesterDesc.Timestamp = time.Now()
 			ingesterDesc.State = r.state
+			ingesterDesc.GRPCHostname = r.grpcHostname
 			ringDesc.Ingesters[r.id] = ingesterDesc
 		}
 


### PR DESCRIPTION
On a previous upgrade, new ingesters came up, added itself (with grpc hostname), but existing ingesters (who didn't know about this field) rewrote the ring on heartbeat, erasing the grpchostname.

This PR adds the grpc hostname to the ingester desc on heartbeat, to pave the way for removing the old http interface.