### PR TITLE
Add the new series to the seriesMap whilst holding the user state mutex.

### DIFF
--- a/ingester/user_state.go
+++ b/ingester/user_state.go
@@ -1,0 +1,170 @@
+package ingester
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+
+	"github.com/weaveworks/cortex/user"
+)
+
+type userStates struct {
+	mtx              sync.RWMutex
+	states           map[string]*userState
+	rateUpdatePeriod time.Duration
+}
+
+type userState struct {
+	userID          string
+	fpLocker        *fingerprintLocker
+	fpToSeries      *seriesMap
+	mapper          *fpMapper
+	index           *invertedIndex
+	ingestedSamples *ewmaRate
+}
+
+func newUserStates(rateUpdatePeriod time.Duration) userStates {
+	return userStates{
+		states:           map[string]*userState{},
+		rateUpdatePeriod: rateUpdatePeriod,
+	}
+}
+
+func (us *userStates) cp() map[string]*userState {
+	us.mtx.Lock()
+	states := make(map[string]*userState, len(us.states))
+	for id, state := range us.states {
+		states[id] = state
+	}
+	us.mtx.Unlock()
+	return states
+}
+
+func (us *userStates) gc() {
+	us.mtx.Lock()
+	for id, state := range us.states {
+		if state.fpToSeries.length() == 0 {
+			delete(us.states, id)
+		}
+	}
+	us.mtx.Unlock()
+}
+
+func (us *userStates) updateRates() {
+	us.mtx.RLock()
+	defer us.mtx.RUnlock()
+
+	for _, state := range us.states {
+		state.ingestedSamples.tick()
+	}
+}
+
+func (us *userStates) numUsers() int {
+	us.mtx.RLock()
+	defer us.mtx.RUnlock()
+	return len(us.states)
+}
+
+func (us *userStates) numSeries() int {
+	us.mtx.RLock()
+	defer us.mtx.RUnlock()
+	numSeries := 0
+	for _, state := range us.states {
+		numSeries += state.fpToSeries.length()
+	}
+	return numSeries
+}
+
+func (us *userStates) get(userID string) (*userState, bool) {
+	us.mtx.RLock()
+	state, ok := us.states[userID]
+	us.mtx.RUnlock()
+	return state, ok
+}
+
+func (us *userStates) getOrCreate(ctx context.Context) (*userState, error) {
+	userID, err := user.GetID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("no user id")
+	}
+
+	us.mtx.RLock()
+	state, ok := us.states[userID]
+	us.mtx.RUnlock()
+	if ok {
+		return state, nil
+	}
+
+	us.mtx.Lock()
+	defer us.mtx.Unlock()
+	return us.unlockedGetOrCreate(userID), nil
+}
+
+func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric) (*userState, model.Fingerprint, *memorySeries, error) {
+	userID, err := user.GetID(ctx)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("no user id")
+	}
+
+	var (
+		state  *userState
+		ok     bool
+		fp     model.Fingerprint
+		series *memorySeries
+	)
+
+	us.mtx.RLock()
+	state, ok = us.states[userID]
+	if ok {
+		fp, series = state.unlockedGet(metric)
+	}
+	us.mtx.RUnlock()
+	if ok {
+		return state, fp, series, nil
+	}
+
+	us.mtx.Lock()
+	defer us.mtx.Unlock()
+	state = us.unlockedGetOrCreate(userID)
+	fp, series = state.unlockedGet(metric)
+	return state, fp, series, nil
+}
+
+func (us *userStates) unlockedGetOrCreate(userID string) *userState {
+	state, ok := us.states[userID]
+	if !ok {
+		state = &userState{
+			userID:          userID,
+			fpToSeries:      newSeriesMap(),
+			fpLocker:        newFingerprintLocker(16),
+			index:           newInvertedIndex(),
+			ingestedSamples: newEWMARate(0.2, us.rateUpdatePeriod),
+		}
+		state.mapper = newFPMapper(state.fpToSeries)
+		us.states[userID] = state
+	}
+	return state
+}
+
+func (u *userState) unlockedGet(metric model.Metric) (model.Fingerprint, *memorySeries) {
+	rawFP := metric.FastFingerprint()
+	u.fpLocker.Lock(rawFP)
+	fp := u.mapper.mapFP(rawFP, metric)
+	if fp != rawFP {
+		u.fpLocker.Unlock(rawFP)
+		u.fpLocker.Lock(fp)
+	}
+
+	series, ok := u.fpToSeries.get(fp)
+	if ok {
+		return fp, series
+	}
+
+	series = newMemorySeries(metric)
+	u.fpToSeries.put(fp, series)
+	u.index.add(metric, fp)
+	return fp, series
+}


### PR DESCRIPTION
Fixes #183 

Previously, there was a race condition where `append` would get the user state, the user state could be GC'd, then `append` would create a new series in this user state that would get lost.

This change makes the creation and addition of new series to user states happen under the user state lock, as does GC.  To make this all clearer, the user state tracking has been broken out into a separate file.