### PR TITLE
Initialise ruler's cfg.ExternalURL to a valid, empty URL.

### DIFF
--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -63,6 +63,7 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ConfigsAPIURL, "ruler.configs.url", "URL of configs API server.")
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")


### PR DESCRIPTION
Should hopefully fix this:
```
$ kubectl logs --namespace=cortex ruler-3206392647-mx1tj 
time="2017-01-24T15:21:19Z" level=info msg="Ruler up and running" source="ruler.go:140" 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x730b04]

goroutine 168 [running]:
panic(0xab2f20, 0xc420016050)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules.(*Group).Eval.func1(0xc42037cd10, 0xb7ac25, 0x9, 0xc4203d9720, 0x159d1112813, 0x10f4de0, 0xc4203db290)
    /go/src/github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules/manager.go:263 +0x194
created by github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules.(*Group).Eval
    /go/src/github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules/manager.go:301 +0x147
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x730b04]

goroutine 153 [running]:
panic(0xab2f20, 0xc420016050)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules.(*Group).Eval.func1(0xc42037cd10, 0xb7ac25, 0x9, 0xc4203d9720, 0x159d1112813, 0x10f4de0, 0xc4203dafc0)
    /go/src/github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules/manager.go:263 +0x194
created by github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules.(*Group).Eval
    /go/src/github.com/weaveworks/cortex/vendor/github.com/prometheus/prometheus/rules/manager.go:301 +0x147
```