### PR TITLE
Fix ingester readiness handler, that was completely broken.

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -66,7 +66,7 @@ type Ingester struct {
 	cfg        Config
 	chunkStore cortex_chunk.Store
 	userStates userStates
-	ring       ring.Ring
+	ring       *ring.Ring
 
 	stopLock sync.RWMutex
 	stopped  bool
@@ -138,6 +138,7 @@ func New(cfg Config, chunkStore cortex_chunk.Store, ring *ring.Ring) (*Ingester,
 		cfg:        cfg,
 		chunkStore: chunkStore,
 		quit:       make(chan struct{}),
+		ring:       ring,
 
 		userStates:  newUserStates(cfg.RateUpdatePeriod),
 		flushQueues: make([]*util.PriorityQueue, cfg.ConcurrentFlushes, cfg.ConcurrentFlushes),

--- a/ring/ingester_lifecycle.go
+++ b/ring/ingester_lifecycle.go
@@ -36,7 +36,6 @@ func init() {
 // IngesterRegistrationConfig is the config for an IngesterRegistration
 type IngesterRegistrationConfig struct {
 	Config
-	mock *Ring
 
 	ListenPort *int
 	NumTokens  int
@@ -45,6 +44,7 @@ type IngesterRegistrationConfig struct {
 	Addr           string
 	Hostname       string
 	skipUnregister bool
+	mock           *Ring
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -74,10 +74,8 @@ type IngesterRegistration struct {
 
 // RegisterIngester registers an ingester with Consul.
 func RegisterIngester(cfg IngesterRegistrationConfig) (*IngesterRegistration, error) {
-	var ring *Ring
-	if cfg.mock != nil {
-		ring = cfg.mock
-	} else {
+	ring := cfg.mock
+	if ring == nil {
 		var err error
 		ring, err = New(cfg.Config)
 		if err != nil {


### PR DESCRIPTION
- Forgot to actually instantiate the ring in the ingester struct
- Was a copy of the struct, not a pointer
- Proto ring can be nil at startup (is a pointer to a proto), so make all the functions deal with this gracefully.

Tested locally, have successfully transitioned a ingester to ready state.