### PR TITLE
Try and flush failed chunks repeatedly when we're shutting down.

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -481,8 +481,17 @@ func (i *Ingester) flushLoop(j int) {
 		}
 		op := o.(*flushOp)
 
-		if err := i.flushUserSeries(op.userID, op.fp, op.immediate); err != nil {
+		err := i.flushUserSeries(op.userID, op.fp, op.immediate)
+		if err != nil {
 			log.Errorf("Failed to flush user: %v", err)
+		}
+
+		// If we're exiting & we failed to flush, keep trying.
+		for op.immediate && err != nil {
+			err = i.flushUserSeries(op.userID, op.fp, op.immediate)
+			if err != nil {
+				log.Errorf("Failed to flush user: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #86 

This is a particularly naive solution, but I think simpler is better.  I considered only trying a fixed number of times; problem is we might still fail to flush some chunks but exit cleanly and never know, which I'd like to avoid.

The problem with this approach is if, because of some bug / logical error, the first chunk fails to flush and always fails to flush, we'll never try to flush any of the other chunks even if they might succeed.  I'm tempted to put all the failing flushes on a second list and try them at the end, in a loop, to work around this.  WDYT?

In the long run the real solution here is the WAL.