### PR TITLE
Provide a do-nothing notifier for alerts

### DIFF
--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
+	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"golang.org/x/net/context"
@@ -90,6 +91,7 @@ func (r *Ruler) newGroup(ctx context.Context, rs []rules.Rule) *rules.Group {
 		QueryEngine:    r.engine,
 		Context:        ctx,
 		ExternalURL:    r.alertURL,
+		Notifier:       notifier.New(&notifier.Options{}),
 	}
 	delay := 0 * time.Second // Unused, so 0 value is fine.
 	return rules.NewGroup("default", delay, rs, opts)


### PR DESCRIPTION
Fixes #253. Tested locally.

Introduces a new warning in the logs:

```
time="2017-02-01T11:54:00Z" level=warning msg="Alert batch larger than queue capacity, dropping 21 alerts" source="notifier.go:230"
```

But that's OK, because we _are_ dropping alerts and that is worthy of warning.

Time to fix: 5m
Time to test locally: 95m