### PR TITLE
Make the schemas declarative, add a new schema for better load balancing.

### DIFF
--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -373,14 +373,16 @@ func (c *AWSStore) lookupEntry(ctx context.Context, entry IndexEntry, matcher *m
 				},
 				ComparisonOperator: aws.String("EQ"),
 			},
-			rangeKey: {
-				AttributeValueList: []*dynamodb.AttributeValue{
-					{B: entry.RangeKey},
-				},
-				ComparisonOperator: aws.String(dynamodb.ComparisonOperatorBeginsWith),
-			},
 		},
 		ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
+	}
+	if len(entry.RangeKey) > 0 {
+		input.KeyConditions[rangeKey] = &dynamodb.Condition{
+			AttributeValueList: []*dynamodb.AttributeValue{
+				{B: entry.RangeKey},
+			},
+			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorBeginsWith),
+		}
 	}
 
 	var chunkSet ByID

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -6,22 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/local/chunk"
 	"github.com/prometheus/prometheus/storage/metric"
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
+	"github.com/weaveworks/common/test"
 	"github.com/weaveworks/common/user"
-	"github.com/weaveworks/cortex/util"
 )
-
-func init() {
-	spew.Config.SortKeys = true // :\
-}
 
 func setupDynamodb(t *testing.T, dynamoDB DynamoDBClient) {
 	tableManager, err := NewDynamoTableManager(TableManagerConfig{
@@ -40,7 +33,7 @@ func setupDynamodb(t *testing.T, dynamoDB DynamoDBClient) {
 func TestChunkStoreUnprocessed(t *testing.T) {
 	dynamoDB := NewMockDynamoDB(2, 2)
 	setupDynamodb(t, dynamoDB)
-	store := NewAWSStore(StoreConfig{
+	store, err := NewAWSStore(StoreConfig{
 		DynamoDB: DynamoDBClientValue{
 			DynamoDBClient: dynamoDB,
 		},
@@ -48,6 +41,9 @@ func TestChunkStoreUnprocessed(t *testing.T) {
 			S3Client: NewMockS3(),
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx := user.WithID(context.Background(), "0")
 	now := model.Now()
@@ -72,26 +68,14 @@ func TestChunkStoreUnprocessed(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(want, have) {
-		t.Fatalf("wrong chunks - %s", diff(want, have))
+		t.Fatalf("wrong chunks - %s", test.Diff(want, have))
 	}
 }
 
 func TestChunkStore(t *testing.T) {
-	dynamoDB := NewMockDynamoDB(0, 0)
-	setupDynamodb(t, dynamoDB)
-	store := NewAWSStore(StoreConfig{
-		DynamoDB: DynamoDBClientValue{
-			DynamoDBClient: dynamoDB,
-		},
-		S3: S3ClientValue{
-			S3Client: NewMockS3(),
-		},
-	})
-
 	ctx := user.WithID(context.Background(), "0")
 	now := model.Now()
 	chunks, _ := chunk.New().Add(model.SamplePair{Timestamp: now, Value: 0})
-
 	chunk1 := NewChunk(
 		model.Fingerprint(1),
 		model.Metric{
@@ -116,33 +100,101 @@ func TestChunkStore(t *testing.T) {
 		now,
 	)
 
-	if err := store.Put(ctx, []Chunk{chunk1, chunk2}); err != nil {
-		t.Fatal(err)
-	}
-
-	test := func(name string, expect []Chunk, matchers ...*metric.LabelMatcher) {
-		log.Infof(">>> %s", name)
-		chunks, err := store.Get(ctx, now.Add(-time.Hour), now, matchers...)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !reflect.DeepEqual(expect, chunks) {
-			t.Fatalf("%s: wrong chunks - %s", name, diff(expect, chunks))
-		}
+	schemas := []struct {
+		name string
+		fn   func(cfg SchemaConfig) Schema
+	}{
+		{"v1 schema", v1Schema},
+		{"v2 schema", v2Schema},
+		{"v3 schema", v3Schema},
+		{"v4 schema", v4Schema},
 	}
 
 	nameMatcher := mustNewLabelMatcher(metric.Equal, model.MetricNameLabel, "foo")
 
-	test("Just name label", []Chunk{chunk1, chunk2}, nameMatcher)
-	test("Empty matcher", []Chunk{chunk2}, nameMatcher, mustNewLabelMatcher(metric.Equal, "flip", ""))
-	test("Equal bar=baz", []Chunk{chunk1}, nameMatcher, mustNewLabelMatcher(metric.Equal, "bar", "baz"))
-	test("Equal bar=beep", []Chunk{chunk2}, nameMatcher, mustNewLabelMatcher(metric.Equal, "bar", "beep"))
-	test("Equal toms=code", []Chunk{chunk1, chunk2}, nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code"))
-	test("Not equal", []Chunk{chunk2}, nameMatcher, mustNewLabelMatcher(metric.NotEqual, "bar", "baz"))
-	test("Regex match", []Chunk{chunk1, chunk2}, nameMatcher, mustNewLabelMatcher(metric.RegexMatch, "bar", "beep|baz"))
-	test("Multiple matchers", []Chunk{chunk1, chunk2}, nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code"), mustNewLabelMatcher(metric.RegexMatch, "bar", "beep|baz"))
-	test("Multiple matchers II", []Chunk{chunk1}, nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code"), mustNewLabelMatcher(metric.Equal, "bar", "baz"))
+	for _, tc := range []struct {
+		name     string
+		expect   []Chunk
+		matchers []*metric.LabelMatcher
+	}{
+		{
+			"Just name label",
+			[]Chunk{chunk1, chunk2},
+			[]*metric.LabelMatcher{nameMatcher},
+		},
+		{
+			"Empty matcher",
+			[]Chunk{chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "flip", "")},
+		},
+		{
+			"Equal bar=baz",
+			[]Chunk{chunk1},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "bar", "baz")},
+		},
+		{
+			"Equal bar=beep",
+			[]Chunk{chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "bar", "beep")},
+		},
+		{
+			"Equal toms=code",
+			[]Chunk{chunk1, chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code")},
+		},
+		{
+			"Not equal",
+			[]Chunk{chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.NotEqual, "bar", "baz")},
+		},
+		{
+			"Regex match",
+			[]Chunk{chunk1, chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.RegexMatch, "bar", "beep|baz")},
+		},
+		{
+			"Multiple matchers",
+			[]Chunk{chunk1, chunk2},
+			[]*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code"), mustNewLabelMatcher(metric.RegexMatch, "bar", "beep|baz")},
+		},
+		{
+			"Multiple matchers II",
+			[]Chunk{chunk1}, []*metric.LabelMatcher{nameMatcher, mustNewLabelMatcher(metric.Equal, "toms", "code"), mustNewLabelMatcher(metric.Equal, "bar", "baz")},
+		},
+	} {
+		for _, schema := range schemas {
+			t.Run(fmt.Sprintf("%s/%s", tc.name, schema.name), func(t *testing.T) {
+				log.Infoln("========= Running test", tc.name, "with schema", schema.name)
+				dynamoDB := NewMockDynamoDB(0, 0)
+				setupDynamodb(t, dynamoDB)
+				store, err := NewAWSStore(StoreConfig{
+					DynamoDB: DynamoDBClientValue{
+						DynamoDBClient: dynamoDB,
+					},
+					S3: S3ClientValue{
+						S3Client: NewMockS3(),
+					},
+					schemaFactory: schema.fn,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := store.Put(ctx, []Chunk{chunk1, chunk2}); err != nil {
+					t.Fatal(err)
+				}
+
+				chunks, err := store.Get(ctx, now.Add(-time.Hour), now, tc.matchers...)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(tc.expect, chunks) {
+					t.Fatalf("%s: wrong chunks - %s", tc.name, test.Diff(tc.expect, chunks))
+				}
+			})
+		}
+	}
 }
 
 func mustNewLabelMatcher(matchType metric.MatchType, name model.LabelName, value model.LabelValue) *metric.LabelMatcher {
@@ -151,183 +203,4 @@ func mustNewLabelMatcher(matchType metric.MatchType, name model.LabelName, value
 		panic(err)
 	}
 	return matcher
-}
-
-func diff(want, have interface{}) string {
-	text, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(spew.Sdump(want)),
-		B:        difflib.SplitLines(spew.Sdump(have)),
-		FromFile: "want",
-		ToFile:   "have",
-		Context:  3,
-	})
-	return "\n" + text
-}
-
-func TestBigBuckets(t *testing.T) {
-	const (
-		tableName      = "table"
-		periodicPrefix = "periodic"
-	)
-
-	buckets := func(tableName string, bs []string) []bucketSpec {
-		result := []bucketSpec{}
-		for _, b := range bs {
-			result = append(result, bucketSpec{
-				tableName: tableName,
-				bucket:    b,
-			})
-		}
-		return result
-	}
-
-	mergeBuckets := func(bss ...[]bucketSpec) []bucketSpec {
-		result := []bucketSpec{}
-		for _, bs := range bss {
-			result = append(result, bs...)
-		}
-		return result
-	}
-
-	firstDayBuckets := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"}
-
-	scenarios := []struct {
-		from, through, dailyBucketsFrom model.Time
-		periodicTablesFrom              model.Time
-		periodicTablesPeriod            time.Duration
-		usePeriodicTables               bool
-		buckets                         []bucketSpec
-	}{
-		// Buckets are by hour until we reach the `dailyBucketsFrom`, after which they are by day.
-		{
-			from:             model.TimeFromUnix(0),
-			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dailyBucketsFrom: model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
-			buckets:          buckets(tableName, append(firstDayBuckets, "d1", "d2")),
-		},
-
-		// Only the day part of `dailyBucketsFrom` matters, not the time part.
-		{
-			from:             model.TimeFromUnix(0),
-			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dailyBucketsFrom: model.TimeFromUnix(0).Add(2*24*time.Hour) - 1,
-			buckets:          buckets(tableName, append(firstDayBuckets, "d1", "d2")),
-		},
-
-		// Moving dailyBucketsFrom to the previous day compared to the above makes 24 1-hour buckets disappear.
-		{
-			from:             model.TimeFromUnix(0),
-			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dailyBucketsFrom: model.TimeFromUnix(0).Add(1*24*time.Hour) - 1,
-			buckets:          buckets(tableName, []string{"d0", "d1", "d2"}),
-		},
-
-		// If `dailyBucketsFrom` is after the interval, everything will be bucketed by hour.
-		{
-			from:             model.TimeFromUnix(0),
-			through:          model.TimeFromUnix(0).Add(2 * 24 * time.Hour),
-			dailyBucketsFrom: model.TimeFromUnix(0).Add(99 * 24 * time.Hour),
-			buckets:          buckets(tableName, append(firstDayBuckets, "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48")),
-		},
-
-		// Should only return daily buckets when dailyBucketsFrom is before the interval.
-		{
-			from:             model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
-			through:          model.TimeFromUnix(0).Add(3*24*time.Hour) - 1,
-			dailyBucketsFrom: model.TimeFromUnix(0),
-			buckets:          buckets(tableName, []string{"d1", "d2"}),
-		},
-
-		// Basic weekly- ables.
-		{
-			from:                 model.TimeFromUnix(0),
-			through:              model.TimeFromUnix(0).Add(4*24*time.Hour) - 1,
-			dailyBucketsFrom:     model.TimeFromUnix(0),
-			usePeriodicTables:    true,
-			periodicTablesFrom:   model.TimeFromUnix(0),
-			periodicTablesPeriod: 2 * 24 * time.Hour,
-			buckets: mergeBuckets(
-				buckets(periodicPrefix+"0", []string{"d0", "d1"}),
-				buckets(periodicPrefix+"1", []string{"d2", "d3"}),
-			),
-		},
-
-		// Daily buckets + weekly tables.
-		{
-			from:                 model.TimeFromUnix(0),
-			through:              model.TimeFromUnix(0).Add(4*24*time.Hour) - 1,
-			dailyBucketsFrom:     model.TimeFromUnix(0).Add(2*24*time.Hour) - 1,
-			usePeriodicTables:    true,
-			periodicTablesFrom:   model.TimeFromUnix(0).Add(1 * 24 * time.Hour),
-			periodicTablesPeriod: 2 * 24 * time.Hour,
-			buckets: mergeBuckets(
-				buckets(tableName, firstDayBuckets),
-				buckets(periodicPrefix+"0", []string{"d1"}),
-				buckets(periodicPrefix+"1", []string{"d2", "d3"}),
-			),
-		},
-	}
-	for i, s := range scenarios {
-		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
-			cs := AWSStore{
-				cfg: StoreConfig{
-					DynamoDB: DynamoDBClientValue{
-						TableName: tableName,
-					},
-					DailyBucketsFrom: util.DayValue{s.dailyBucketsFrom},
-					PeriodicTableConfig: PeriodicTableConfig{
-						UsePeriodicTables:    s.usePeriodicTables,
-						TablePeriod:          s.periodicTablesPeriod,
-						TablePrefix:          periodicPrefix,
-						PeriodicTableStartAt: util.DayValue{s.periodicTablesFrom},
-					},
-				},
-			}
-			buckets := cs.bigBuckets(s.from, s.through)
-			for i := range buckets {
-				buckets[i].startTime = 0
-			}
-			if !reflect.DeepEqual(buckets, s.buckets) {
-				t.Fatalf("%d. unexpected buckets; want %v, got %v", i, s.buckets, buckets)
-			}
-		})
-	}
-}
-
-func TestRangeValue(t *testing.T) {
-	for _, c := range []struct {
-		name, value, chunkID string
-		expected             []byte
-	}{
-		{"1", "2", "3", []byte{'1', 0, 'M', 'g', 0, '3', 0, 1, 0}},
-		{"1", "\x00", "3", []byte{'1', 0, 'A', 'A', 0, '3', 0, 1, 0}},
-	} {
-		encoded := rangeValue(model.LabelName(c.name), model.LabelValue(c.value), c.chunkID)
-		assert.Equal(t, c.expected, encoded, "encoded")
-
-		name, value, chunkID, err := parseRangeValue(encoded)
-		assert.Nil(t, err, "parseRangeValue error")
-		assert.Equal(t, model.LabelName(c.name), name, "name")
-		assert.Equal(t, model.LabelValue(c.value), value, "value")
-		assert.Equal(t, c.chunkID, chunkID, "chunkID")
-	}
-
-	// Test we can decode legacy range values
-	for _, c := range []struct {
-		encoded              []byte
-		name, value, chunkID string
-	}{
-		{[]byte{'1', 0, '2', 0, '3', 0}, "1", "2", "3"},
-		{[]byte{0x74, 0x6f, 0x6d, 0x73, 0x00, 0x59, 0x32, 0x39, 0x6b, 0x5a, 0x51,
-			0x00, 0x32, 0x3a, 0x31, 0x34, 0x38, 0x34, 0x36, 0x36, 0x31, 0x32, 0x37,
-			0x39, 0x33, 0x39, 0x34, 0x3a, 0x31, 0x34, 0x38, 0x34, 0x36, 0x36, 0x34,
-			0x38, 0x37, 0x39, 0x33, 0x39, 0x34, 0x00, 0x01, 0x00},
-			"toms", "code", "2:1484661279394:1484664879394"},
-	} {
-		name, value, chunkID, err := parseRangeValue(c.encoded)
-		assert.Nil(t, err, "parseRangeValue error")
-		assert.Equal(t, model.LabelName(c.name), name, "name")
-		assert.Equal(t, model.LabelValue(c.value), value, "value")
-		assert.Equal(t, c.chunkID, chunkID, "chunkID")
-	}
 }

--- a/chunk/chunk_test.go
+++ b/chunk/chunk_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/local/chunk"
+
+	"github.com/weaveworks/common/test"
 )
 
 func TestChunkCodec(t *testing.T) {
@@ -38,6 +40,6 @@ func TestChunkCodec(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(want, have) {
-		t.Fatalf("wrong chunks - " + diff(want, have))
+		t.Fatalf("wrong chunks - " + test.Diff(want, have))
 	}
 }

--- a/chunk/dynamo_table_manager.go
+++ b/chunk/dynamo_table_manager.go
@@ -14,6 +14,8 @@ import (
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/mtime"
 	"golang.org/x/net/context"
+
+	"github.com/weaveworks/cortex/util"
 )
 
 const (
@@ -67,6 +69,24 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.InactiveReadThroughput, "dynamodb.periodic-table.inactive-read-throughput", 300, "DynamoDB periodic tables read throughput for inactive tables")
 
 	cfg.PeriodicTableConfig.RegisterFlags(f)
+}
+
+// PeriodicTableConfig for the use of periodic tables (ie, weekly talbes).  Can
+// control when to start the periodic tables, how long the period should be,
+// and the prefix to give the tables.
+type PeriodicTableConfig struct {
+	UsePeriodicTables    bool
+	TablePrefix          string
+	TablePeriod          time.Duration
+	PeriodicTableStartAt util.DayValue
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *PeriodicTableConfig) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.UsePeriodicTables, "dynamodb.use-periodic-tables", true, "Should we user periodic tables.")
+	f.StringVar(&cfg.TablePrefix, "dynamodb.periodic-table.prefix", "cortex_", "DynamoDB table prefix for the periodic tables.")
+	f.DurationVar(&cfg.TablePeriod, "dynamodb.periodic-table.period", 7*24*time.Hour, "DynamoDB periodic tables period.")
+	f.Var(&cfg.PeriodicTableStartAt, "dynamodb.periodic-table.start", "DynamoDB periodic tables start time.")
 }
 
 // DynamoTableManager creates and manages the provisioned throughput on DynamoDB tables

--- a/chunk/dynamo_table_manager_test.go
+++ b/chunk/dynamo_table_manager_test.go
@@ -34,10 +34,12 @@ func TestDynamoTableManager(t *testing.T) {
 		},
 
 		PeriodicTableConfig: PeriodicTableConfig{
-			UsePeriodicTables:    true,
-			TablePrefix:          tablePrefix,
-			TablePeriod:          tablePeriod,
-			PeriodicTableStartAt: util.DayValue{model.TimeFromUnix(0)},
+			UsePeriodicTables: true,
+			TablePrefix:       tablePrefix,
+			TablePeriod:       tablePeriod,
+			PeriodicTableStartAt: util.DayValue{
+				Time: model.TimeFromUnix(0),
+			},
 		},
 
 		CreationGracePeriod:        gracePeriod,

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -148,8 +148,14 @@ func (c compositeSchema) forSchemas(from, through model.Time, callback func(from
 		if i+1 < len(c.schemas) {
 			nextSchemaStarts = c.schemas[i+1].start
 		}
-		end := min(through, nextSchemaStarts-1)
 
+		// If the next schema starts at the same time as this one,
+		// skip this one.
+		if nextSchemaStarts == c.schemas[i].start {
+			continue
+		}
+
+		end := min(through, nextSchemaStarts-1)
 		entries, err := callback(start, end, c.schemas[i].Schema)
 		if err != nil {
 			return nil, err

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -1,0 +1,492 @@
+package chunk
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/weaveworks/cortex/util"
+)
+
+const (
+	secondsInHour = int64(time.Hour / time.Second)
+	secondsInDay  = int64(24 * time.Hour / time.Second)
+)
+
+// Schema interface defines methods to calculate the hash and range keys needed
+// to write or read chunks from the external index.
+type Schema interface {
+	// When doing a write, use this method to return the list of entries you should write to.
+	GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
+
+	// When doing a read, use these methods to return the list of entries you should query
+	GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error)
+	GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error)
+	GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
+}
+
+// IndexEntry describes an entry in the chunk index
+type IndexEntry struct {
+	TableName string
+	HashKey   string
+	RangeKey  []byte
+}
+
+// SchemaConfig contains the config for our chunk index schemas
+type SchemaConfig struct {
+	PeriodicTableConfig
+	OriginalTableName string
+
+	// After midnight on this day, we start bucketing indexes by day instead of by
+	// hour.  Only the day matters, not the time within the day.
+	DailyBucketsFrom util.DayValue
+
+	// After this time, we will only query for base64-encoded label values.
+	Base64ValuesFrom util.DayValue
+
+	// After this time, we will read and write v4 schemas.
+	V4SchemaFrom util.DayValue
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.PeriodicTableConfig.RegisterFlags(f)
+
+	f.Var(&cfg.DailyBucketsFrom, "dynamodb.daily-buckets-from", "The date (in the format YYYY-MM-DD) of the first day for which DynamoDB index buckets should be day-sized vs. hour-sized.")
+	f.Var(&cfg.Base64ValuesFrom, "dynamodb.base64-buckets-from", "The date (in the format YYYY-MM-DD) after which we will stop querying to non-base64 encoded values.")
+	f.Var(&cfg.V4SchemaFrom, "dynamodb.v4-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v4 schema.")
+}
+
+func (cfg *SchemaConfig) tableForBucket(bucketStart int64) string {
+	if !cfg.UsePeriodicTables || bucketStart < (cfg.PeriodicTableStartAt.Unix()) {
+		return cfg.OriginalTableName
+	}
+	// TODO remove reference to time package here
+	return cfg.TablePrefix + strconv.Itoa(int(bucketStart/int64(cfg.TablePeriod/time.Second)))
+}
+
+// compositeSchema is a Schema which delegates to various schemas depending
+// on when they were activated.
+type compositeSchema struct {
+	schemas []compositeSchemaEntry
+}
+
+type compositeSchemaEntry struct {
+	start model.Time
+	Schema
+}
+
+type byStart []compositeSchemaEntry
+
+func (a byStart) Len() int           { return len(a) }
+func (a byStart) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byStart) Less(i, j int) bool { return a[i].start < a[j].start }
+
+func newCompositeSchema(cfg SchemaConfig) (Schema, error) {
+	schemas := []compositeSchemaEntry{
+		{0, v1Schema(cfg)},
+	}
+
+	if cfg.DailyBucketsFrom.IsSet() {
+		schemas = append(schemas, compositeSchemaEntry{cfg.DailyBucketsFrom.Time, v2Schema(cfg)})
+	}
+
+	if cfg.Base64ValuesFrom.IsSet() {
+		schemas = append(schemas, compositeSchemaEntry{cfg.Base64ValuesFrom.Time, v3Schema(cfg)})
+	}
+
+	if cfg.V4SchemaFrom.IsSet() {
+		schemas = append(schemas, compositeSchemaEntry{cfg.V4SchemaFrom.Time, v4Schema(cfg)})
+	}
+
+	if !sort.IsSorted(byStart(schemas)) {
+		return nil, fmt.Errorf("schemas not in time-sorted order")
+	}
+
+	return compositeSchema{schemas}, nil
+}
+
+func (c compositeSchema) forSchemas(from, through model.Time, callback func(from, through model.Time, schema Schema) ([]IndexEntry, error)) ([]IndexEntry, error) {
+	if len(c.schemas) == 0 {
+		return nil, nil
+	}
+
+	// first, find the schema with the highest start _before or at_ from
+	i := sort.Search(len(c.schemas), func(i int) bool {
+		return c.schemas[i].start > from
+	})
+	if i > 0 {
+		i--
+	} else {
+		// This could happen if we get passed a sample from before 1970.
+		i = 0
+		from = c.schemas[0].start
+	}
+
+	// next, find the schema with the lowest start _after_ through
+	j := sort.Search(len(c.schemas), func(j int) bool {
+		return c.schemas[j].start > through
+	})
+
+	min := func(a, b model.Time) model.Time {
+		if a < b {
+			return a
+		}
+		return b
+	}
+
+	start := from
+	result := []IndexEntry{}
+	for ; i < j; i++ {
+		nextSchemaStarts := model.Latest
+		if i+1 < len(c.schemas) {
+			nextSchemaStarts = c.schemas[i+1].start
+		}
+		end := min(through, nextSchemaStarts-1)
+
+		entries, err := callback(start, end, c.schemas[i].Schema)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, entries...)
+		start = nextSchemaStarts
+	}
+
+	return result, nil
+}
+
+func (c compositeSchema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	return c.forSchemas(from, through, func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+		return schema.GetWriteEntries(from, through, userID, metricName, labels, chunkID)
+	})
+}
+
+func (c compositeSchema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
+	return c.forSchemas(from, through, func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+		return schema.GetReadEntriesForMetric(from, through, userID, metricName)
+	})
+}
+
+func (c compositeSchema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
+	return c.forSchemas(from, through, func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+		return schema.GetReadEntriesForMetricLabel(from, through, userID, metricName, labelName)
+	})
+}
+
+func (c compositeSchema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	return c.forSchemas(from, through, func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+		return schema.GetReadEntriesForMetricLabelValue(from, through, userID, metricName, labelName, labelValue)
+	})
+}
+
+// v1Schema was:
+// - hash key: <userid>:<hour bucket>:<metric name>
+// - range key: <label name>\0<label value>\0<chunk name>
+func v1Schema(cfg SchemaConfig) Schema {
+	return originalSchema{
+		cfg, hourlyBuckets, originalGetWriteEntries, originalGetReadMetricEntries,
+		originalGetReadMetricLabelEntries, originalGetReadMetricLabelValueEntries,
+	}
+}
+
+// v2Schame went to daily buckets in the hash key
+// - hash key: <userid>:d<day bucket>:<metric name>
+func v2Schema(cfg SchemaConfig) Schema {
+	return originalSchema{
+		cfg, dailyBuckets, originalGetWriteEntries, originalGetReadMetricEntries,
+		originalGetReadMetricLabelEntries, originalGetReadMetricLabelValueEntries,
+	}
+}
+
+// v3Schema went to base64 encoded label values & a version ID
+// - range key: <label name>\0<base64(label value)>\0<chunk name>\0<version 1>
+func v3Schema(cfg SchemaConfig) Schema {
+	return originalSchema{
+		cfg, dailyBuckets, base64GetWriteEntries, originalGetReadMetricEntries,
+		originalGetReadMetricLabelEntries, base64GetReadMetricLabelValueEntries,
+	}
+}
+
+type originalSchema struct {
+	cfg                         SchemaConfig
+	buckets                     func(cfg SchemaConfig, from, through model.Time, userID string, metricName model.LabelValue, callback func(tableName, hashKey string) ([]IndexEntry, error)) ([]IndexEntry, error)
+	writeEntries                func(tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error)
+	readMetricEntries           func(tableName, hashKey string) ([]IndexEntry, error)
+	readMetricLabelEntries      func(tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error)
+	readMetricLabelValueEntries func(tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
+}
+
+func (s originalSchema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return s.writeEntries(tableName, hashKey, labels, chunkID)
+	})
+}
+
+func (s originalSchema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return s.readMetricEntries(tableName, hashKey)
+	})
+}
+
+func (s originalSchema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return s.readMetricLabelEntries(tableName, hashKey, labelName)
+	})
+}
+
+func (s originalSchema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return s.readMetricLabelValueEntries(tableName, hashKey, labelName, labelValue)
+	})
+}
+
+func hourlyBuckets(cfg SchemaConfig, from, through model.Time, userID string, metricName model.LabelValue, callback func(tableName, hashKey string) ([]IndexEntry, error)) ([]IndexEntry, error) {
+	var (
+		fromHour    = from.Unix() / secondsInHour
+		throughHour = through.Unix() / secondsInHour
+		result      = []IndexEntry{}
+	)
+
+	for i := fromHour; i <= throughHour; i++ {
+		entries, err := callback(cfg.tableForBucket(i*secondsInHour), fmt.Sprintf("%s:%d:%s", userID, i, metricName))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, entries...)
+	}
+	return result, nil
+}
+
+func dailyBuckets(cfg SchemaConfig, from, through model.Time, userID string, metricName model.LabelValue, callback func(tableName, hashKey string) ([]IndexEntry, error)) ([]IndexEntry, error) {
+	var (
+		fromDay    = from.Unix() / secondsInDay
+		throughDay = through.Unix() / secondsInDay
+		result     = []IndexEntry{}
+	)
+
+	for i := fromDay; i <= throughDay; i++ {
+		entries, err := callback(cfg.tableForBucket(i*secondsInDay), fmt.Sprintf("%s:d%d:%s", userID, i, metricName))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, entries...)
+	}
+	return result, nil
+}
+
+func originalGetWriteEntries(tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	result := []IndexEntry{}
+	for key, value := range labels {
+		if key == model.MetricNameLabel {
+			continue
+		}
+		if strings.ContainsRune(string(value), '\x00') {
+			return nil, fmt.Errorf("label values cannot contain null byte")
+		}
+		result = append(result, IndexEntry{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  buildRangeKey(string(key), string(value), chunkID),
+		})
+	}
+	return result, nil
+}
+
+func originalGetReadMetricEntries(tableName, hashKey string) ([]IndexEntry, error) {
+	return []IndexEntry{
+		{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  nil,
+		},
+	}, nil
+}
+
+func originalGetReadMetricLabelEntries(tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+	return []IndexEntry{
+		{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  buildRangeKey(string(labelName)),
+		},
+	}, nil
+}
+
+func originalGetReadMetricLabelValueEntries(tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	if strings.ContainsRune(string(labelValue), '\x00') {
+		return nil, fmt.Errorf("label values cannot contain null byte")
+	}
+	return []IndexEntry{
+		{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  buildRangeKey(string(labelName), string(labelValue)),
+		},
+	}, nil
+}
+
+func base64GetWriteEntries(tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	result := []IndexEntry{}
+	for key, value := range labels {
+		if key == model.MetricNameLabel {
+			continue
+		}
+		encodedValue := base64.RawStdEncoding.EncodeToString([]byte(value))
+		result = append(result, IndexEntry{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  buildRangeKey(string(key), encodedValue, chunkID, "1"),
+		})
+	}
+	return result, nil
+}
+
+func base64GetReadMetricLabelValueEntries(tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	encodedValue := base64.RawStdEncoding.EncodeToString([]byte(labelValue))
+	return []IndexEntry{
+		{
+			TableName: tableName,
+			HashKey:   hashKey,
+			RangeKey:  buildRangeKey(string(labelName), string(encodedValue)),
+		},
+	}, nil
+}
+
+// v4 schema went to two schemas in one:
+// 1) - hash key: <userid>:<hour bucket>:<metric name>:<label name>
+//    - range key: \0<base64(label value)>\0<chunk name>\0<version 2>
+// 2) - hash key: <userid>:<hour bucket>:<metric name>
+//    - range key: \0\0<chunk name>\0<version 3>
+func v4Schema(cfg SchemaConfig) Schema {
+	return labelNameInHashKeySchema{
+		cfg, dailyBuckets,
+	}
+}
+
+type labelNameInHashKeySchema struct {
+	cfg     SchemaConfig
+	buckets func(cfg SchemaConfig, from, through model.Time, userID string, metricName model.LabelValue, callback func(tableName, hashKey string) ([]IndexEntry, error)) ([]IndexEntry, error)
+}
+
+func (s labelNameInHashKeySchema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		entries := []IndexEntry{
+			{
+				TableName: tableName,
+				HashKey:   hashKey,
+				RangeKey:  buildRangeKey("", "", chunkID, "2"),
+			},
+		}
+
+		for key, value := range labels {
+			if key == model.MetricNameLabel {
+				continue
+			}
+			encodedValue := base64.RawStdEncoding.EncodeToString([]byte(value))
+			entries = append(entries, IndexEntry{
+				TableName: tableName,
+				HashKey:   hashKey + ":" + string(key),
+				RangeKey:  buildRangeKey("", encodedValue, chunkID, "1"),
+			})
+		}
+
+		return entries, nil
+	})
+}
+
+func (s labelNameInHashKeySchema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return []IndexEntry{
+			{
+				TableName: tableName,
+				HashKey:   hashKey,
+				RangeKey:  nil,
+			},
+		}, nil
+	})
+}
+
+func (s labelNameInHashKeySchema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return []IndexEntry{
+			{
+				TableName: tableName,
+				HashKey:   hashKey + ":" + string(labelName),
+				RangeKey:  buildRangeKey(""),
+			},
+		}, nil
+	})
+}
+
+func (s labelNameInHashKeySchema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	encodedValue := base64.RawStdEncoding.EncodeToString([]byte(labelValue))
+	return s.buckets(s.cfg, from, through, userID, metricName, func(tableName, hashKey string) ([]IndexEntry, error) {
+		return []IndexEntry{
+			{
+				TableName: tableName,
+				HashKey:   hashKey + ":" + string(labelName),
+				RangeKey:  buildRangeKey("", encodedValue),
+			},
+		}, nil
+	})
+}
+
+func buildRangeKey(ss ...string) []byte {
+	length := 0
+	for _, s := range ss {
+		length += len(s) + 1
+	}
+	output, i := make([]byte, length, length), 0
+	for _, s := range ss {
+		copy(output[i:i+len(s)], s)
+		i += len(s) + 1
+	}
+	return output
+}
+
+func parseRangeValue(v []byte) (model.LabelName, model.LabelValue, string, error) {
+	var (
+		labelBytes   []byte
+		valueBytes   []byte
+		chunkIDBytes []byte
+		version      []byte
+		i, j         = 0, 0
+	)
+	next := func(output *[]byte) error {
+		for ; j < len(v); j++ {
+			if v[j] == 0 {
+				*output = v[i:j]
+				j++
+				i = j
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid range value: %x", v)
+	}
+	if err := next(&labelBytes); err != nil {
+		return "", "", "", err
+	}
+	if err := next(&valueBytes); err != nil {
+		return "", "", "", err
+	}
+	if err := next(&chunkIDBytes); err != nil {
+		return "", "", "", err
+	}
+	if err := next(&version); err == nil {
+		// We read a version, need to decode value
+		decodedValueLen := base64.RawStdEncoding.DecodedLen(len(valueBytes))
+		decodedValueBytes := make([]byte, decodedValueLen, decodedValueLen)
+		if _, err := base64.RawStdEncoding.Decode(decodedValueBytes, valueBytes); err != nil {
+			return "", "", "", err
+		}
+		valueBytes = decodedValueBytes
+	}
+	return model.LabelName(labelBytes), model.LabelValue(valueBytes), string(chunkIDBytes), nil
+}

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -1,0 +1,487 @@
+package chunk
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/test"
+	"github.com/weaveworks/cortex/util"
+)
+
+type mockSchema int
+
+func (mockSchema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	return nil, nil
+}
+func (mockSchema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
+	return nil, nil
+}
+func (mockSchema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
+	return nil, nil
+}
+func (mockSchema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	return nil, nil
+}
+
+func TestSchemaComposite(t *testing.T) {
+	type result struct {
+		from, through model.Time
+		schema        Schema
+	}
+	collect := func(results *[]result) func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+		return func(from, through model.Time, schema Schema) ([]IndexEntry, error) {
+			*results = append(*results, result{from, through, schema})
+			return nil, nil
+		}
+	}
+	cs := compositeSchema{
+		schemas: []compositeSchemaEntry{
+			{model.TimeFromUnix(0), mockSchema(1)},
+			{model.TimeFromUnix(100), mockSchema(2)},
+			{model.TimeFromUnix(200), mockSchema(3)},
+		},
+	}
+
+	for i, tc := range []struct {
+		cs            compositeSchema
+		from, through int64
+		want          []result
+	}{
+		// Test we have sensible results when there are no schema's defined
+		{compositeSchema{}, 0, 1, []result{}},
+
+		// Test we have sensible results when there is a single schema
+		{
+			compositeSchema{
+				schemas: []compositeSchemaEntry{
+					{model.TimeFromUnix(0), mockSchema(1)},
+				},
+			},
+			0, 10,
+			[]result{
+				{model.TimeFromUnix(0), model.TimeFromUnix(10), mockSchema(1)},
+			},
+		},
+
+		// Test we have sensible results for negative (ie pre 1970) times
+		{
+			compositeSchema{
+				schemas: []compositeSchemaEntry{
+					{model.TimeFromUnix(0), mockSchema(1)},
+				},
+			},
+			-10, -9,
+			[]result{},
+		},
+		{
+			compositeSchema{
+				schemas: []compositeSchemaEntry{
+					{model.TimeFromUnix(0), mockSchema(1)},
+				},
+			},
+			-10, 10,
+			[]result{
+				{model.TimeFromUnix(0), model.TimeFromUnix(10), mockSchema(1)},
+			},
+		},
+
+		// Test we have sensible results when there is two schemas
+		{
+			compositeSchema{
+				schemas: []compositeSchemaEntry{
+					{model.TimeFromUnix(0), mockSchema(1)},
+					{model.TimeFromUnix(100), mockSchema(2)},
+				},
+			},
+			34, 165,
+			[]result{
+				{model.TimeFromUnix(34), model.TimeFromUnix(100) - 1, mockSchema(1)},
+				{model.TimeFromUnix(100), model.TimeFromUnix(165), mockSchema(2)},
+			},
+		},
+
+		// Test all the various combination we can get when there are three schemas
+		{
+			cs, 34, 65,
+			[]result{
+				{model.TimeFromUnix(34), model.TimeFromUnix(65), mockSchema(1)},
+			},
+		},
+
+		{
+			cs, 244, 6785,
+			[]result{
+				{model.TimeFromUnix(244), model.TimeFromUnix(6785), mockSchema(3)},
+			},
+		},
+
+		{
+			cs, 34, 165,
+			[]result{
+				{model.TimeFromUnix(34), model.TimeFromUnix(100) - 1, mockSchema(1)},
+				{model.TimeFromUnix(100), model.TimeFromUnix(165), mockSchema(2)},
+			},
+		},
+
+		{
+			cs, 151, 264,
+			[]result{
+				{model.TimeFromUnix(151), model.TimeFromUnix(200) - 1, mockSchema(2)},
+				{model.TimeFromUnix(200), model.TimeFromUnix(264), mockSchema(3)},
+			},
+		},
+
+		{
+			cs, 32, 264,
+			[]result{
+				{model.TimeFromUnix(32), model.TimeFromUnix(100) - 1, mockSchema(1)},
+				{model.TimeFromUnix(100), model.TimeFromUnix(200) - 1, mockSchema(2)},
+				{model.TimeFromUnix(200), model.TimeFromUnix(264), mockSchema(3)},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("TestSchemaComposite[%d]", i), func(t *testing.T) {
+			have := []result{}
+			tc.cs.forSchemas(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
+			if !reflect.DeepEqual(tc.want, have) {
+				t.Fatalf("wrong schemas - %s", test.Diff(tc.want, have))
+			}
+		})
+	}
+}
+
+type ByHashKey []IndexEntry
+
+func (a ByHashKey) Len() int      { return len(a) }
+func (a ByHashKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByHashKey) Less(i, j int) bool {
+	if a[i].HashKey != a[j].HashKey {
+		return a[i].HashKey < a[j].HashKey
+	}
+	return bytes.Compare(a[i].RangeKey, a[j].RangeKey) < 0
+}
+
+func mergeResults(rss ...[]IndexEntry) []IndexEntry {
+	results := []IndexEntry{}
+	for _, rs := range rss {
+		results = append(results, rs...)
+	}
+	return results
+}
+
+func TestSchemaHashKeys(t *testing.T) {
+	mkResult := func(tableName, fmtStr string, from, through int) []IndexEntry {
+		want := []IndexEntry{}
+		for i := from; i < through; i++ {
+			want = append(want, IndexEntry{
+				TableName: tableName,
+				HashKey:   fmt.Sprintf(fmtStr, i),
+			})
+		}
+		return want
+	}
+
+	const (
+		userID         = "userid"
+		table          = "table"
+		periodicPrefix = "periodicPrefix"
+	)
+
+	cfg := SchemaConfig{
+		OriginalTableName: table,
+
+		PeriodicTableConfig: PeriodicTableConfig{
+			UsePeriodicTables:    true,
+			TablePrefix:          periodicPrefix,
+			TablePeriod:          2 * 24 * time.Hour,
+			PeriodicTableStartAt: util.NewDayValue(model.TimeFromUnix(5 * 24 * 60 * 60)),
+		},
+	}
+	compositeSchema := func(dailyBucketsFrom model.Time) Schema {
+		cfgCp := cfg
+		cfgCp.DailyBucketsFrom = util.NewDayValue(dailyBucketsFrom)
+		schema, err := newCompositeSchema(cfgCp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return schema
+	}
+	hourlyBuckets := v1Schema(cfg)
+	dailyBuckets := v3Schema(cfg)
+	labelBuckets := v4Schema(cfg)
+	metric := model.Metric{
+		model.MetricNameLabel: "foo",
+		"bar": "baz",
+	}
+	chunkID := "chunkID"
+
+	for i, tc := range []struct {
+		Schema
+		from, through int64
+		metricName    string
+		want          []IndexEntry
+	}{
+		// Basic test case for the various bucketing schemes
+		{
+			hourlyBuckets,
+			0, (30 * 60) - 1, "foo", // chunk is smaller than bucket
+			mkResult(table, "userid:%d:foo", 0, 1),
+		},
+		{
+			hourlyBuckets,
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mkResult(table, "userid:%d:foo", 0, 3*24),
+		},
+		{
+			hourlyBuckets,
+			0, 30 * 60, "foo", // chunk is smaller than bucket
+			mkResult(table, "userid:%d:foo", 0, 1),
+		},
+		{
+			dailyBuckets,
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mkResult(table, "userid:d%d:foo", 0, 3),
+		},
+		{
+			labelBuckets,
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(table, "userid:d%d:foo", 0, 3),
+				mkResult(table, "userid:d%d:foo:bar", 0, 3),
+			),
+		},
+
+		// Buckets are by hour until we reach the `dailyBucketsFrom`, after which they are by day.
+		{
+			compositeSchema(model.TimeFromUnix(0).Add(1 * 24 * time.Hour)),
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(table, "userid:%d:foo", 0, 1*24),
+				mkResult(table, "userid:d%d:foo", 1, 3),
+			),
+		},
+
+		// Only the day part of `dailyBucketsFrom` matters, not the time part.
+		{
+			compositeSchema(model.TimeFromUnix(0).Add(2*24*time.Hour) - 1),
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(table, "userid:%d:foo", 0, 1*24),
+				mkResult(table, "userid:d%d:foo", 1, 3),
+			),
+		},
+
+		// Moving dailyBucketsFrom to the previous day compared to the above makes 24 1-hour buckets disappear.
+		{
+			compositeSchema(model.TimeFromUnix(0).Add(1*24*time.Hour) - 1),
+			0, (3 * 24 * 60 * 60) - 1, "foo",
+			mkResult(table, "userid:d%d:foo", 0, 3),
+		},
+
+		// If `dailyBucketsFrom` is after the interval, everything will be bucketed by hour.
+		{
+			compositeSchema(model.TimeFromUnix(0).Add(99 * 24 * time.Hour)),
+			0, (2 * 24 * 60 * 60) - 1, "foo",
+			mkResult(table, "userid:%d:foo", 0, 2*24),
+		},
+
+		// Should only return daily buckets when dailyBucketsFrom is before the interval.
+		{
+			compositeSchema(model.TimeFromUnix(0)),
+			1 * 24 * 60 * 60, (3 * 24 * 60 * 60) - 1, "foo",
+			mkResult(table, "userid:d%d:foo", 1, 3),
+		},
+
+		// Basic weekly- ables.
+		{
+			compositeSchema(model.TimeFromUnix(0)),
+			5 * 24 * 60 * 60, (10 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(periodicPrefix+"2", "userid:d%d:foo", 5, 6),
+				mkResult(periodicPrefix+"3", "userid:d%d:foo", 6, 8),
+				mkResult(periodicPrefix+"4", "userid:d%d:foo", 8, 10),
+			),
+		},
+
+		// Daily buckets + weekly tables.
+		{
+			compositeSchema(model.TimeFromUnix(0)),
+			0, (10 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(table, "userid:d%d:foo", 0, 5),
+				mkResult(periodicPrefix+"2", "userid:d%d:foo", 5, 6),
+				mkResult(periodicPrefix+"3", "userid:d%d:foo", 6, 8),
+				mkResult(periodicPrefix+"4", "userid:d%d:foo", 8, 10),
+			),
+		},
+
+		// Houly Buckets, then daily buckets, then weekly tables.
+		{
+			compositeSchema(model.TimeFromUnix(2 * 24 * 60 * 60)),
+			0, (10 * 24 * 60 * 60) - 1, "foo",
+			mergeResults(
+				mkResult(table, "userid:%d:foo", 0, 2*24),
+				mkResult(table, "userid:d%d:foo", 2, 5),
+				mkResult(periodicPrefix+"2", "userid:d%d:foo", 5, 6),
+				mkResult(periodicPrefix+"3", "userid:d%d:foo", 6, 8),
+				mkResult(periodicPrefix+"4", "userid:d%d:foo", 8, 10),
+			),
+		},
+	} {
+		t.Run(fmt.Sprintf("TestSchemaHashKeys[%d]", i), func(t *testing.T) {
+			have, err := tc.Schema.GetWriteEntries(
+				model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through),
+				userID, model.LabelValue(tc.metricName),
+				metric, chunkID,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := range have {
+				have[i].RangeKey = nil
+			}
+			sort.Sort(ByHashKey(have))
+			sort.Sort(ByHashKey(tc.want))
+			if !reflect.DeepEqual(tc.want, have) {
+				t.Fatalf("wrong hash buckets - %s", test.Diff(tc.want, have))
+			}
+		})
+	}
+}
+
+func TestSchemaRangeKey(t *testing.T) {
+	const (
+		userID     = "userid"
+		table      = "table"
+		metricName = "foo"
+		chunkID    = "chunkID"
+	)
+
+	var (
+		cfg = SchemaConfig{
+			OriginalTableName: table,
+		}
+		hourlyBuckets = v1Schema(cfg)
+		dailyBuckets  = v2Schema(cfg)
+		base64Keys    = v3Schema(cfg)
+		labelBuckets  = v4Schema(cfg)
+		metric        = model.Metric{
+			model.MetricNameLabel: metricName,
+			"bar": "bary",
+			"baz": "bazy",
+		}
+	)
+
+	mkEntries := func(hashKey string, callback func(labelName model.LabelName, labelValue model.LabelValue) string) []IndexEntry {
+		result := []IndexEntry{}
+		for labelName, labelValue := range metric {
+			if labelName == model.MetricNameLabel {
+				continue
+			}
+			result = append(result, IndexEntry{
+				TableName: table,
+				HashKey:   hashKey,
+				RangeKey:  []byte(callback(labelName, labelValue)),
+			})
+		}
+		return result
+	}
+
+	for i, tc := range []struct {
+		Schema
+		want []IndexEntry
+	}{
+		// Basic test case for the various bucketing schemes
+		{
+			hourlyBuckets,
+			mkEntries("userid:0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
+				return fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)
+			}),
+		},
+		{
+			dailyBuckets,
+			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
+				return fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)
+			}),
+		},
+		{
+			base64Keys,
+			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
+				encodedValue := base64.RawStdEncoding.EncodeToString([]byte(labelValue))
+				return fmt.Sprintf("%s\x00%s\x00%s\x001\x00", labelName, encodedValue, chunkID)
+			}),
+		},
+		{
+			labelBuckets,
+			[]IndexEntry{
+				{
+					TableName: table,
+					HashKey:   "userid:d0:foo",
+					RangeKey:  []byte("\x00\x00chunkID\x002\x00"),
+				},
+				{
+					TableName: table,
+					HashKey:   "userid:d0:foo:bar",
+					RangeKey:  []byte("\x00YmFyeQ\x00chunkID\x001\x00"),
+				},
+				{
+					TableName: table,
+					HashKey:   "userid:d0:foo:baz",
+					RangeKey:  []byte("\x00YmF6eQ\x00chunkID\x001\x00"),
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("TestSchameRangeKey[%d]", i), func(t *testing.T) {
+			have, err := tc.Schema.GetWriteEntries(
+				model.TimeFromUnix(0), model.TimeFromUnix(60*60)-1,
+				userID, model.LabelValue(metricName),
+				metric, chunkID,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sort.Sort(ByHashKey(have))
+			sort.Sort(ByHashKey(tc.want))
+			if !reflect.DeepEqual(tc.want, have) {
+				t.Fatalf("wrong hash buckets - %s", test.Diff(tc.want, have))
+			}
+
+			// Test we can parse the resulting range keys
+			for _, entry := range have {
+				_, _, _, err := parseRangeValue(entry.RangeKey)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseRangeValue(t *testing.T) {
+	// Test we can decode legacy range values
+	for _, c := range []struct {
+		encoded              []byte
+		name, value, chunkID string
+	}{
+		{[]byte{'1', 0, '2', 0, '3', 0}, "1", "2", "3"},
+		{[]byte{0x74, 0x6f, 0x6d, 0x73, 0x00, 0x59, 0x32, 0x39, 0x6b, 0x5a, 0x51,
+			0x00, 0x32, 0x3a, 0x31, 0x34, 0x38, 0x34, 0x36, 0x36, 0x31, 0x32, 0x37,
+			0x39, 0x33, 0x39, 0x34, 0x3a, 0x31, 0x34, 0x38, 0x34, 0x36, 0x36, 0x34,
+			0x38, 0x37, 0x39, 0x33, 0x39, 0x34, 0x00, 0x01, 0x00},
+			"toms", "code", "2:1484661279394:1484664879394"},
+	} {
+		name, value, chunkID, err := parseRangeValue(c.encoded)
+		assert.Nil(t, err, "parseRangeValue error")
+		assert.Equal(t, model.LabelName(c.name), name, "name")
+		assert.Equal(t, model.LabelValue(c.value), value, "value")
+		assert.Equal(t, c.chunkID, chunkID, "chunkID")
+	}
+}

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -107,6 +107,22 @@ func TestSchemaComposite(t *testing.T) {
 			},
 		},
 
+		// Test we get only one result when two schema start at same time
+		{
+			compositeSchema{
+				schemas: []compositeSchemaEntry{
+					{model.TimeFromUnix(0), mockSchema(1)},
+					{model.TimeFromUnix(10), mockSchema(2)},
+					{model.TimeFromUnix(10), mockSchema(3)},
+				},
+			},
+			0, 165,
+			[]result{
+				{model.TimeFromUnix(0), model.TimeFromUnix(10) - 1, mockSchema(1)},
+				{model.TimeFromUnix(10), model.TimeFromUnix(165), mockSchema(3)},
+			},
+		},
+
 		// Test all the various combination we can get when there are three schemas
 		{
 			cs, 34, 65,

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -34,7 +34,11 @@ func main() {
 	defer registration.Ring.Stop()
 
 	server := server.New(serverConfig, registration.Ring)
-	chunkStore := chunk.NewAWSStore(chunkStoreConfig)
+	chunkStore, err := chunk.NewAWSStore(chunkStoreConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	ingester, err := ingester.New(ingesterConfig, chunkStore, registration.Ring)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -48,7 +48,11 @@ func main() {
 	server := server.New(serverConfig, r)
 	defer server.Stop()
 
-	chunkStore := chunk.NewAWSStore(chunkStoreConfig)
+	chunkStore, err := chunk.NewAWSStore(chunkStoreConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	queryable := querier.NewQueryable(dist, chunkStore)
 	engine := promql.NewEngine(queryable, nil)
 	api := v1.NewAPI(engine, querier.DummyStorage{Queryable: queryable})

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -25,7 +25,10 @@ func main() {
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig, &rulerConfig, &chunkStoreConfig)
 	flag.Parse()
 
-	chunkStore := chunk.NewAWSStore(chunkStoreConfig)
+	chunkStore, err := chunk.NewAWSStore(chunkStoreConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	r, err := ring.New(ringConfig)
 	if err != nil {


### PR DESCRIPTION
Part of #254 

- Define a Schema interface for calculating the hash and range keys to use.
- Make implementations of this interface for all the different schema's we've had.
- Make a "CompositeSchema" which delegates to various schema's depending on when they we activated.
- Update chunk store to use this; in particular, invert the order of the merge and intersect in the query path.
- Bunch of testing

TODO:
- [x] Add new scheme with the label name part of the hash key, hopefully improving the load balancing across DynamoDB partitions.
- [x] more testing for range keys
- [x] test v4 schema
- [x] adapt chunk store test to use each schema
- [x] figure out when its safe to read base64 only 
  - deployed to dev on Jan 17th https://github.com/weaveworks/service-conf/commit/d5535139413137b71740d1e925b09052690eaf18
  - deployed to prod on Jan 18th https://github.com/weaveworks/service-conf/pull/510 