### PR TITLE
Review feeback for the HashBucketHistogram

### DIFF
--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -52,9 +52,7 @@ var (
 			Namespace: "cortex",
 			Name:      "chunk_store_row_write_total",
 			Help:      "Distribution of writes to individual DynamoDB rows",
-			// Assumes at most 1k writes per hash-bucket per scrape; given even load
-			// this would be 1k * 1024 / 15s = 68k writes / s.
-			Buckets: prometheus.LinearBuckets(1, 10, 100),
+			Buckets:   prometheus.DefBuckets,
 		},
 		HashBuckets: 1024,
 	})

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -50,7 +50,7 @@ var (
 	rowWrites = util.NewHashBucketHistogram(util.HashBucketHistogramOpts{
 		HistogramOpts: prometheus.HistogramOpts{
 			Namespace: "cortex",
-			Name:      "chunk_store_row_write_total",
+			Name:      "chunk_store_row_writes_distribution",
 			Help:      "Distribution of writes to individual DynamoDB rows",
 			Buckets:   prometheus.DefBuckets,
 		},

--- a/util/hash_bucket_histogram.go
+++ b/util/hash_bucket_histogram.go
@@ -26,7 +26,7 @@ type HashBucketHistogramOpts struct {
 // N buckets of counters and hash the key to a bucket.  Then every second
 // we update a histogram with the bucket values (and zero the buckets).
 //
-// Note, we want this metric to be relatively independant of the number of
+// Note, we want this metric to be relatively independent of the number of
 // hash buckets and QPS of the service - we're trying to measure how well
 // load balanced the write load is.  So we normalise the values in the hash
 // buckets such that if all buckets are '1', then we have even load.  We

--- a/util/hash_bucket_histogram.go
+++ b/util/hash_bucket_histogram.go
@@ -3,7 +3,9 @@ package util
 import (
 	"hash/fnv"
 	"reflect"
+	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,42 +23,87 @@ type HashBucketHistogramOpts struct {
 // and 99% are getting Y QPS of lower.  At first glance, this would involve
 // tracking write rate per row, and periodically sticking those numbers in
 // a histogram.  To make this fit in memory: instead of per-row, we keep
-// N buckets of counters and hash the key to a bucket.  Then every scrape
+// N buckets of counters and hash the key to a bucket.  Then every second
 // we update a histogram with the bucket values (and zero the buckets).
+//
+// Note, we want this metric to be relatively independant of the number of
+// hash buckets and QPS of the service - we're trying to measure how well
+// load balanced the write load is.  So we normalise the values in the hash
+// buckets such that if all buckets are '1', then we have even load.  We
+// do this by multiplying the number of ops per bucket by the number of
+// buckets, and dividing by the number of ops.
 type HashBucketHistogram interface {
 	prometheus.Metric
 	prometheus.Collector
 
 	Observe(string, uint32)
+	Stop()
 }
 
 type hashBucketHistogram struct {
 	prometheus.Histogram
+	mtx     sync.RWMutex
+	buckets *hashBuckets
+	quit    chan struct{}
+	opts    HashBucketHistogramOpts
+}
+
+type hashBuckets struct {
+	ops     uint32
 	buckets []uint32
 }
 
 // NewHashBucketHistogram makes a new HashBucketHistogram
 func NewHashBucketHistogram(opts HashBucketHistogramOpts) HashBucketHistogram {
-	return &hashBucketHistogram{
+	result := &hashBucketHistogram{
 		Histogram: prometheus.NewHistogram(opts.HistogramOpts),
-		buckets:   make([]uint32, opts.HashBuckets, opts.HashBuckets),
+		quit:      make(chan struct{}),
+		opts:      opts,
 	}
+	result.swapBuckets()
+	return result
 }
 
-// Collect implements prometheus.Metric
-func (h *hashBucketHistogram) Collect(c chan<- prometheus.Metric) {
-	for i := range h.buckets {
-		h.Histogram.Observe(float64(atomic.SwapUint32(&h.buckets[i], 0)))
+// Stop the background goroutine
+func (h *hashBucketHistogram) Stop() {
+	h.quit <- struct{}{}
+}
+
+func (h *hashBucketHistogram) swapBuckets() *hashBuckets {
+	h.mtx.Lock()
+	buckets := h.buckets
+	h.buckets = &hashBuckets{
+		buckets: make([]uint32, h.opts.HashBuckets, h.opts.HashBuckets),
 	}
-	h.Histogram.Collect(c)
+	h.mtx.Unlock()
+	return buckets
+}
+
+func (h *hashBucketHistogram) loop() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			buckets := h.swapBuckets()
+			for _, v := range buckets.buckets {
+				h.Histogram.Observe(float64(v) * float64(h.opts.HashBuckets) / float64(buckets.ops))
+			}
+		case <-h.quit:
+			return
+		}
+	}
 }
 
 // Observe implements HashBucketHistogram
 func (h *hashBucketHistogram) Observe(key string, value uint32) {
+	h.mtx.RLock()
 	hash := fnv.New32()
 	hash.Write(bytesView(key))
-	i := hash.Sum32() % uint32(len(h.buckets))
-	atomic.AddUint32(&h.buckets[i], value)
+	i := hash.Sum32() % uint32(h.opts.HashBuckets)
+	atomic.AddUint32(&h.buckets.ops, 1)
+	atomic.AddUint32(&h.buckets.buckets[i], value)
+	h.mtx.RUnlock()
 }
 
 func bytesView(v string) []byte {

--- a/util/hash_bucket_histogram.go
+++ b/util/hash_bucket_histogram.go
@@ -61,6 +61,7 @@ func NewHashBucketHistogram(opts HashBucketHistogramOpts) HashBucketHistogram {
 		opts:      opts,
 	}
 	result.swapBuckets()
+	go result.loop()
 	return result
 }
 


### PR DESCRIPTION
See #261 for original PR.

- Dump the bucket values into the histogram once per second
- Normalise the bucket values such that 1 is balanced