### PR TITLE
Move metrics registration out of Collector types

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 
 	"github.com/weaveworks/cortex/distributor"
@@ -49,6 +50,7 @@ func main() {
 		log.Fatalf("Error initializing distributor: %v", err)
 	}
 	defer dist.Stop()
+	prometheus.MustRegister(dist)
 
 	server := server.New(serverConfig, r)
 	server.HTTP.Handle("/api/prom/push", http.HandlerFunc(dist.PushHandler))

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 
 	"github.com/weaveworks/cortex"
@@ -38,6 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	prometheus.MustRegister(ingester)
 	cortex.RegisterIngesterServer(server.GRPC, ingester)
 	server.HTTP.Path("/ready").Handler(http.HandlerFunc(ingester.ReadinessHandler))
 

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/promql"
@@ -42,6 +43,7 @@ func main() {
 		log.Fatalf("Error initializing distributor: %v", err)
 	}
 	defer dist.Stop()
+	prometheus.MustRegister(dist)
 
 	server := server.New(serverConfig, r)
 	defer server.Stop()

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 
 	"github.com/weaveworks/cortex/chunk"
@@ -37,6 +38,7 @@ func main() {
 		log.Fatalf("Error initializing distributor: %v", err)
 	}
 	defer dist.Stop()
+	prometheus.MustRegister(dist)
 
 	rulerServer, err := ruler.NewServer(rulerConfig, ruler.NewRuler(rulerConfig, dist, chunkStore))
 	if err != nil {

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -153,7 +153,6 @@ func New(cfg Config, ring ReadRing) (*Distributor, error) {
 			Help:      "The total number of failed queries sent to ingesters.",
 		}, []string{"ingester"}),
 	}
-	prometheus.MustRegister(d)
 	go d.Run()
 	return d, nil
 }

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -193,7 +193,6 @@ func New(cfg Config, chunkStore cortex_chunk.Store, ring *ring.Ring) (*Ingester,
 			Help: "The total number of samples returned from queries.",
 		}),
 	}
-	prometheus.MustRegister(i)
 
 	i.done.Add(cfg.ConcurrentFlushes)
 	for j := 0; j < cfg.ConcurrentFlushes; j++ {


### PR DESCRIPTION
Since a metric cannot be registered twice, it's otherwise not possible
to instantiate one of these types multiple times (e.g. for tests).