### PR TITLE
Shard ingest flush queue by username and metric name 

### DIFF
--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -190,7 +190,7 @@ func (c *AWSStore) updateIndex(ctx context.Context, userID string, chunks []Chun
 func (c *AWSStore) calculateDynamoWrites(userID string, chunks []Chunk) (map[string][]*dynamodb.WriteRequest, error) {
 	writeReqs := map[string][]*dynamodb.WriteRequest{}
 	for _, chunk := range chunks {
-		metricName, err := extractMetricNameFromMetric(chunk.Metric)
+		metricName, err := util.ExtractMetricNameFromMetric(chunk.Metric)
 		if err != nil {
 			return nil, err
 		}
@@ -472,15 +472,6 @@ func (c *AWSStore) fetchChunkData(ctx context.Context, userID string, chunkSet [
 		return nil, errors[0]
 	}
 	return chunks, nil
-}
-
-func extractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
-	for name, value := range m {
-		if name == model.MetricNameLabel {
-			return value, nil
-		}
-	}
-	return "", fmt.Errorf("no MetricNameLabel for chunk")
 }
 
 func extractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, error) {

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -3,6 +3,7 @@ package ingester
 import (
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"net/http"
 	"sync"
 	"time"
@@ -439,7 +440,9 @@ func (i *Ingester) sweepUsers(immediate bool) {
 	for id, state := range i.userStates.cp() {
 		for pair := range state.fpToSeries.iter() {
 			state.fpLocker.Lock(pair.fp)
-			i.sweepSeries(id, pair.fp, pair.series, immediate)
+			if err := i.sweepSeries(id, pair.fp, pair.series, immediate); err != nil {
+				log.Errorf("Error sweeping series: %v", err)
+			}
 			state.fpLocker.Unlock(pair.fp)
 		}
 	}
@@ -449,18 +452,33 @@ func (i *Ingester) sweepUsers(immediate bool) {
 //
 // NB we don't close the head chunk here, as the series could wait in the queue
 // for some time, and we want to encourage chunks to be as full as possible.
-func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memorySeries, immediate bool) {
-	if len(series.chunkDescs) <= 0 {
-		return
-	}
-
-	firstTime := series.firstTime()
+func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memorySeries, immediate bool) error {
 	flush := i.shouldFlushSeries(series, immediate)
-
-	if flush {
-		flushQueueIndex := int(uint64(fp) % uint64(i.cfg.ConcurrentFlushes))
-		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate})
+	if !flush {
+		return nil
 	}
+
+	return i.enqueueSeriesForFlushing(userID, fp, series, immediate)
+}
+
+func (i *Ingester) enqueueSeriesForFlushing(userID string, fp model.Fingerprint, series *memorySeries, immediate bool) error {
+	metricName, err := util.ExtractMetricNameFromMetric(series.metric)
+	if err != nil {
+		return err
+	}
+
+	h := fnv.New32()
+	if _, err := h.Write([]byte(userID)); err != nil {
+		return err
+	}
+	if _, err := h.Write([]byte(metricName)); err != nil {
+		return err
+	}
+
+	flushQueueIndex := int(h.Sum32() % uint32(i.cfg.ConcurrentFlushes))
+	firstTime := series.firstTime()
+	i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate})
+	return nil
 }
 
 func (i *Ingester) shouldFlushSeries(series *memorySeries, immediate bool) bool {

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/metric"
 )
 
@@ -14,4 +17,14 @@ func SplitFiltersAndMatchers(allMatchers []*metric.LabelMatcher) (filters, match
 		}
 	}
 	return
+}
+
+// ExtractMetricNameFromMetric extract the metric name from a model.Metric
+func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
+	for name, value := range m {
+		if name == model.MetricNameLabel {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("no MetricNameLabel for chunk")
 }


### PR DESCRIPTION
...to match the underlying sharding of the index.  Part of #254.

The idea being, if we do hotspot a partition in the index, then lets not hotspot it with all 50 flush threads.  At least this will give the other series a chance to flush, and hopefully get us closer to saturating the provisioned capacity. 