### PR TITLE
Short cut distributor sample pushes.

### DIFF
--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -282,7 +282,7 @@ outer:
 }
 
 func (c *AWSStore) lookupChunks(ctx context.Context, userID string, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
-	metricName, matchers, err := extractMetricNameFromMatchers(matchers)
+	metricName, matchers, err := util.ExtractMetricNameFromMatchers(matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -472,19 +472,4 @@ func (c *AWSStore) fetchChunkData(ctx context.Context, userID string, chunkSet [
 		return nil, errors[0]
 	}
 	return chunks, nil
-}
-
-func extractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, error) {
-	for i, matcher := range matchers {
-		if matcher.Name != model.MetricNameLabel {
-			continue
-		}
-		if matcher.Type != metric.Equal {
-			return "", nil, fmt.Errorf("must have equality matcher for MetricNameLabel")
-		}
-		metricName := matcher.Value
-		matchers = matchers[:i+copy(matchers[i:], matchers[i+1:])]
-		return metricName, matchers, nil
-	}
-	return "", nil, fmt.Errorf("no matcher for MetricNameLabel")
 }

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -284,6 +284,10 @@ func (d *Distributor) Push(ctx context.Context, req *remote.WriteRequest) (*cort
 	samples := util.FromWriteRequest(req)
 	d.receivedSamples.Add(float64(len(samples)))
 
+	if len(samples) == 0 {
+		return &cortex.WriteResponse{}, nil
+	}
+
 	limiter := d.getOrCreateIngestLimiter(userID)
 	if !limiter.AllowN(time.Now(), len(samples)) {
 		return nil, errIngestionRateLimitExceeded

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -252,9 +252,18 @@ func tokenFor(userID string, name model.LabelValue) uint32 {
 }
 
 type sampleTracker struct {
-	sample     *model.Sample
-	minSuccess int
-	succeeded  int32
+	sample      *model.Sample
+	minSuccess  int
+	maxFailures int
+	succeeded   int32
+	failed      int32
+}
+
+type pushTracker struct {
+	samplesPending int32
+	samplesFailed  int32
+	done           chan struct{}
+	err            chan error
 }
 
 // Push implements cortex.IngesterServer
@@ -285,11 +294,15 @@ func (d *Distributor) Push(ctx context.Context, req *remote.WriteRequest) (*cort
 	sampleTrackers := make([]sampleTracker, len(samples), len(samples))
 	samplesByIngester := map[*ring.IngesterDesc][]*sampleTracker{}
 	for i := range samples {
+		// We need a response from a quorum of ingesters, which is n/2 + 1.
+		minSuccess := (len(ingesters[i]) / 2) + 1
+
 		sampleTrackers[i] = sampleTracker{
-			sample: samples[i],
-			// We need a response from a quorum of ingesters, which is n/2 + 1.
-			minSuccess: (len(ingesters[i]) / 2) + 1,
-			succeeded:  0,
+			sample:      samples[i],
+			minSuccess:  minSuccess,
+			maxFailures: len(ingesters[i]) - minSuccess,
+			succeeded:   0,
+			failed:      0,
 		}
 
 		// Skip those that have not heartbeated in a while. NB these are still
@@ -315,26 +328,23 @@ func (d *Distributor) Push(ctx context.Context, req *remote.WriteRequest) (*cort
 		}
 	}
 
-	errs := make(chan error)
-	for hostname, samples := range samplesByIngester {
+	pushTracker := pushTracker{
+		samplesPending: int32(len(samples)),
+		samplesFailed:  0,
+		done:           make(chan struct{}),
+		err:            make(chan error),
+	}
+	for ingester, samples := range samplesByIngester {
 		go func(ingester *ring.IngesterDesc, samples []*sampleTracker) {
-			errs <- d.sendSamples(ctx, ingester, samples)
-		}(hostname, samples)
+			d.sendSamples(ctx, ingester, samples, &pushTracker)
+		}(ingester, samples)
 	}
-	var lastErr error
-	for i := 0; i < len(samplesByIngester); i++ {
-		if err := <-errs; err != nil {
-			lastErr = err
-			continue
-		}
+	select {
+	case err := <-pushTracker.err:
+		return nil, err
+	case <-pushTracker.done:
+		return &cortex.WriteResponse{}, nil
 	}
-	for i := range sampleTrackers {
-		if sampleTrackers[i].succeeded < int32(sampleTrackers[i].minSuccess) {
-			return nil, fmt.Errorf("need %d successful writes, only got %d, last error was: %v",
-				sampleTrackers[i].minSuccess, sampleTrackers[i].succeeded, lastErr)
-		}
-	}
-	return &cortex.WriteResponse{}, nil
 }
 
 func (d *Distributor) getOrCreateIngestLimiter(userID string) *rate.Limiter {
@@ -350,7 +360,38 @@ func (d *Distributor) getOrCreateIngestLimiter(userID string) *rate.Limiter {
 	return limiter
 }
 
-func (d *Distributor) sendSamples(ctx context.Context, ingester *ring.IngesterDesc, sampleTrackers []*sampleTracker) error {
+func (d *Distributor) sendSamples(ctx context.Context, ingester *ring.IngesterDesc, sampleTrackers []*sampleTracker, pushTracker *pushTracker) {
+	err := d.sendSamplesErr(ctx, ingester, sampleTrackers)
+
+	// If we suceed, decrement each sample's pending count by one.  If we reach
+	// the requred number of successful puts on this sample, then decrement the
+	// number of pending samples by one.  If we successfully push all samples to
+	// min success ingesters, wake up the waiting rpc so it can return early.
+	// Similarly, track the number of errors, and if it exceeds maxFailures
+	// shortcut the waiting rpc.
+	//
+	// The use of atomic increments here guarantees only a single sendSamples
+	// goroutine will write to either channel.
+	for i := range sampleTrackers {
+		if err != nil {
+			if atomic.AddInt32(&sampleTrackers[i].failed, 1) > int32(sampleTrackers[i].maxFailures) {
+				continue
+			}
+			if atomic.AddInt32(&pushTracker.samplesFailed, 1) == 1 {
+				pushTracker.err <- err
+			}
+		} else {
+			if atomic.AddInt32(&sampleTrackers[i].succeeded, 1) != int32(sampleTrackers[i].minSuccess) {
+				continue
+			}
+			if atomic.AddInt32(&pushTracker.samplesPending, -1) == 0 {
+				pushTracker.done <- struct{}{}
+			}
+		}
+	}
+}
+
+func (d *Distributor) sendSamplesErr(ctx context.Context, ingester *ring.IngesterDesc, sampleTrackers []*sampleTracker) error {
 	client, err := d.getClientFor(ingester)
 	if err != nil {
 		return err
@@ -366,25 +407,8 @@ func (d *Distributor) sendSamples(ctx context.Context, ingester *ring.IngesterDe
 	d.ingesterAppends.WithLabelValues(ingester.Addr).Inc()
 	if err != nil {
 		d.ingesterAppendFailures.WithLabelValues(ingester.Addr).Inc()
-		return err
 	}
-
-	for i := range sampleTrackers {
-		atomic.AddInt32(&sampleTrackers[i].succeeded, 1)
-	}
-	return nil
-}
-
-func metricNameFromLabelMatchers(matchers ...*metric.LabelMatcher) (model.LabelValue, error) {
-	for _, m := range matchers {
-		if m.Name == model.MetricNameLabel {
-			if m.Type != metric.Equal {
-				return "", fmt.Errorf("non-equality matchers are not supported on the metric name")
-			}
-			return m.Value, nil
-		}
-	}
-	return "", fmt.Errorf("no metric name matcher found")
+	return err
 }
 
 // Query implements Querier.
@@ -393,7 +417,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 	err := instrument.TimeRequestHistogram(ctx, "Distributor.Query", d.queryDuration, func(ctx context.Context) error {
 		fpToSampleStream := map[model.Fingerprint]*model.SampleStream{}
 
-		metricName, err := metricNameFromLabelMatchers(matchers...)
+		metricName, _, err := util.ExtractMetricNameFromMatchers(matchers)
 		if err != nil {
 			return err
 		}

--- a/distributor/distributor_test.go
+++ b/distributor/distributor_test.go
@@ -1,51 +1,169 @@
 package distributor
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
+	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex"
 	"github.com/weaveworks/cortex/ring"
 )
 
+// mockRing doesn't do any consistent hashing, just returns same ingesters for every query.
 type mockRing struct {
 	prometheus.Counter
+	ingesters []*ring.IngesterDesc
 }
 
 func (r mockRing) Get(key uint32, n int, op ring.Operation) ([]*ring.IngesterDesc, error) {
-	return nil, nil
+	return r.ingesters[:n], nil
 }
 
 func (r mockRing) BatchGet(keys []uint32, n int, op ring.Operation) ([][]*ring.IngesterDesc, error) {
-	return nil, nil
+	result := [][]*ring.IngesterDesc{}
+	for i := 0; i < len(keys); i++ {
+		result = append(result, r.ingesters[:n])
+	}
+	return result, nil
 }
 
 func (r mockRing) GetAll() []*ring.IngesterDesc {
-	return nil
+	return r.ingesters
 }
 
 type mockIngester struct {
+	happy bool
+}
+
+func (i mockIngester) Push(ctx context.Context, in *remote.WriteRequest, opts ...grpc.CallOption) (*cortex.WriteResponse, error) {
+	if !i.happy {
+		return nil, fmt.Errorf("Fail")
+	}
+	return &cortex.WriteResponse{}, nil
+}
+
+func (i mockIngester) Query(ctx context.Context, in *cortex.QueryRequest, opts ...grpc.CallOption) (*cortex.QueryResponse, error) {
+	return nil, nil
+}
+
+func (i mockIngester) LabelValues(ctx context.Context, in *cortex.LabelValuesRequest, opts ...grpc.CallOption) (*cortex.LabelValuesResponse, error) {
+	return nil, nil
+}
+
+func (i mockIngester) UserStats(ctx context.Context, in *cortex.UserStatsRequest, opts ...grpc.CallOption) (*cortex.UserStatsResponse, error) {
+	return nil, nil
+}
+
+func (i mockIngester) MetricsForLabelMatchers(ctx context.Context, in *cortex.MetricsForLabelMatchersRequest, opts ...grpc.CallOption) (*cortex.MetricsForLabelMatchersResponse, error) {
+	return nil, nil
 }
 
 func TestDistributor(t *testing.T) {
-	ring := mockRing{
-		Counter: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "foo",
-		}),
-	}
+	ctx := user.WithID(context.Background(), "user")
+	for i, tc := range []struct {
+		ingesters        []mockIngester
+		samples          int
+		expectedResponse *cortex.WriteResponse
+		expectedError    error
+	}{
+		// A push of no samples shouldn't block or return error, even if ingesters are sad
+		{
+			ingesters:        []mockIngester{{}, {}, {}},
+			expectedResponse: &cortex.WriteResponse{},
+		},
 
-	_, err := New(Config{
-		ReplicationFactor:   3,
-		MinReadSuccesses:    2,
-		HeartbeatTimeout:    1 * time.Minute,
-		RemoteTimeout:       1 * time.Minute,
-		ClientCleanupPeriod: 1 * time.Minute,
-		IngestionRateLimit:  10000,
-		IngestionBurstSize:  10000,
-	}, ring)
-	if err != nil {
-		t.Fatal(err)
-	}
+		// A push to 3 happy ingesters should succeed
+		{
+			samples:          10,
+			ingesters:        []mockIngester{{true}, {true}, {true}},
+			expectedResponse: &cortex.WriteResponse{},
+		},
 
+		// A push to 2 happy ingesters should succeed
+		{
+			samples:          10,
+			ingesters:        []mockIngester{{}, {true}, {true}},
+			expectedResponse: &cortex.WriteResponse{},
+		},
+
+		// A push to 1 happy ingesters should fail
+		{
+			samples:       10,
+			ingesters:     []mockIngester{{}, {}, {true}},
+			expectedError: fmt.Errorf("Fail"),
+		},
+
+		// A push to 0 happy ingesters should fail
+		{
+			samples:       10,
+			ingesters:     []mockIngester{{}, {}, {}},
+			expectedError: fmt.Errorf("Fail"),
+		},
+	} {
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			ingesterDescs := []*ring.IngesterDesc{}
+			ingesters := map[string]mockIngester{}
+			for i, ingester := range tc.ingesters {
+				addr := fmt.Sprintf("%d", i)
+				ingesterDescs = append(ingesterDescs, &ring.IngesterDesc{
+					Addr:      addr,
+					Timestamp: time.Now().Unix(),
+				})
+				ingesters[addr] = ingester
+			}
+
+			ring := mockRing{
+				Counter: prometheus.NewCounter(prometheus.CounterOpts{
+					Name: "foo",
+				}),
+				ingesters: ingesterDescs,
+			}
+
+			d, err := New(Config{
+				ReplicationFactor:   3,
+				MinReadSuccesses:    2,
+				HeartbeatTimeout:    1 * time.Minute,
+				RemoteTimeout:       1 * time.Minute,
+				ClientCleanupPeriod: 1 * time.Minute,
+				IngestionRateLimit:  10000,
+				IngestionBurstSize:  10000,
+
+				ingesterClientFactory: func(addr string) cortex.IngesterClient {
+					return ingesters[addr]
+				},
+			}, ring)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer d.Stop()
+
+			request := &remote.WriteRequest{}
+			for i := 0; i < tc.samples; i++ {
+				ts := &remote.TimeSeries{
+					Labels: []*remote.LabelPair{
+						{"__name__", "foo"},
+						{"bar", "baz"},
+						{"sample", fmt.Sprintf("%d", i)},
+					},
+				}
+				ts.Samples = []*remote.Sample{
+					{
+						Value:       float64(i),
+						TimestampMs: int64(i),
+					},
+				}
+				request.Timeseries = append(request.Timeseries, ts)
+			}
+			response, err := d.Push(ctx, request)
+			assert.Equal(t, tc.expectedResponse, response, "Wrong response")
+			assert.Equal(t, tc.expectedError, err, "Wrong error")
+		})
+	}
 }

--- a/distributor/distributor_test.go
+++ b/distributor/distributor_test.go
@@ -1,0 +1,51 @@
+package distributor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/cortex/ring"
+)
+
+type mockRing struct {
+	prometheus.Counter
+}
+
+func (r mockRing) Get(key uint32, n int, op ring.Operation) ([]*ring.IngesterDesc, error) {
+	return nil, nil
+}
+
+func (r mockRing) BatchGet(keys []uint32, n int, op ring.Operation) ([][]*ring.IngesterDesc, error) {
+	return nil, nil
+}
+
+func (r mockRing) GetAll() []*ring.IngesterDesc {
+	return nil
+}
+
+type mockIngester struct {
+}
+
+func TestDistributor(t *testing.T) {
+	ring := mockRing{
+		Counter: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "foo",
+		}),
+	}
+
+	_, err := New(Config{
+		ReplicationFactor:   3,
+		MinReadSuccesses:    2,
+		HeartbeatTimeout:    1 * time.Minute,
+		RemoteTimeout:       1 * time.Minute,
+		ClientCleanupPeriod: 1 * time.Minute,
+		IngestionRateLimit:  10000,
+		IngestionBurstSize:  10000,
+	}, ring)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -28,3 +28,19 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 	}
 	return "", fmt.Errorf("no MetricNameLabel for chunk")
 }
+
+// ExtractMetricNameFromMatchers extracts the metric name from a set of matchers
+func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, error) {
+	for i, matcher := range matchers {
+		if matcher.Name != model.MetricNameLabel {
+			continue
+		}
+		if matcher.Type != metric.Equal {
+			return "", nil, fmt.Errorf("must have equality matcher for MetricNameLabel")
+		}
+		metricName := matcher.Value
+		matchers = matchers[:i+copy(matchers[i:], matchers[i+1:])]
+		return metricName, matchers, nil
+	}
+	return "", nil, fmt.Errorf("no matcher for MetricNameLabel")
+}


### PR DESCRIPTION
When enough samples succeed (or fail), return the rpc - don't wait for all of them.

This should massively reduce the 99th percentile latency (currently up in the 200ms), and bring it a lot closer to the average (of 40ms).