### PR TITLE
Implement per-user series limits

### DIFF
--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/metric"
 	"golang.org/x/net/context"
@@ -144,5 +146,89 @@ func TestIngesterAppend(t *testing.T) {
 		if !reflect.DeepEqual(res, testData[userID]) {
 			t.Fatalf("unexpected chunk store result\n\nwant:\n\n%v\n\ngot:\n\n%v\n\n", testData[userID], res)
 		}
+	}
+}
+
+func TestIngesterSeriesLimitExceeded(t *testing.T) {
+	cfg := Config{
+		FlushCheckPeriod: 99999 * time.Hour,
+		MaxChunkIdle:     99999 * time.Hour,
+		MaxSeriesPerUser: 1,
+	}
+	store := &testStore{
+		chunks: map[string][]chunk.Chunk{},
+	}
+	ing, err := New(cfg, store, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userID := "1"
+	sample1 := &model.Sample{
+		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
+		Timestamp: 0,
+		Value:     1,
+	}
+	sample2 := &model.Sample{
+		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "bar"},
+		Timestamp: 1,
+		Value:     2,
+	}
+	sample3 := &model.Sample{
+		Metric:    model.Metric{model.MetricNameLabel: "testmetric", "foo": "biz"},
+		Timestamp: 1,
+		Value:     3,
+	}
+
+	// Append only one series first, expect no error.
+	ctx := user.WithID(context.Background(), userID)
+	_, err = ing.Push(ctx, util.ToWriteRequest([]*model.Sample{sample1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Append to two series, expect series-exceeded error.
+	_, err = ing.Push(ctx, util.ToWriteRequest([]*model.Sample{sample2, sample3}))
+	if grpc.ErrorDesc(err) != util.ErrUserSeriesLimitExceeded.Error() {
+		t.Fatalf("expected series-exceeded error, got %v", err)
+	}
+
+	// Read samples back via ingester queries.
+	matcher, err := metric.NewLabelMatcher(metric.Equal, model.MetricNameLabel, "testmetric")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := util.ToQueryRequest(model.Earliest, model.Latest, []*metric.LabelMatcher{matcher})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := ing.Query(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := util.FromQueryResponse(resp)
+	sort.Sort(res)
+
+	expected := model.Matrix{
+		{
+			Metric: sample1.Metric,
+			Values: []model.SamplePair{
+				{
+					Timestamp: sample1.Timestamp,
+					Value:     sample1.Value,
+				},
+				{
+					Timestamp: sample2.Timestamp,
+					Value:     sample2.Value,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Fatalf("unexpected query result\n\nwant:\n\n%v\n\ngot:\n\n%v\n\n", expected, res)
 	}
 }

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -153,7 +153,9 @@ func TestIngesterSeriesLimitExceeded(t *testing.T) {
 	cfg := Config{
 		FlushCheckPeriod: 99999 * time.Hour,
 		MaxChunkIdle:     99999 * time.Hour,
-		MaxSeriesPerUser: 1,
+		UserStatesConfig: UserStatesConfig{
+			MaxSeriesPerUser: 1,
+		},
 	}
 	store := &testStore{
 		chunks: map[string][]chunk.Chunk{},

--- a/util/error.go
+++ b/util/error.go
@@ -1,0 +1,14 @@
+package util
+
+// Error see https://dave.cheney.net/2016/04/07/constant-errors.
+type Error string
+
+func (e Error) Error() string { return string(e) }
+
+// Errors returned by Cortex components.
+const (
+	ErrMissingMetricName       = Error("sample missing metric name")
+	ErrInvalidMetricName       = Error("sample invalid metric name")
+	ErrInvalidLabel            = Error("sample invalid label")
+	ErrUserSeriesLimitExceeded = Error("per-user series limit exceeded")
+)

--- a/util/validate.go
+++ b/util/validate.go
@@ -6,18 +6,6 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// Error see https://dave.cheney.net/2016/04/07/constant-errors
-type Error string
-
-func (e Error) Error() string { return string(e) }
-
-// Errors returned by ValidateSample
-const (
-	ErrMissingMetricName = Error("sample missing metric name")
-	ErrInvalidMetricName = Error("sample invalid metric name")
-	ErrInvalidLabel      = Error("sample invalid label")
-)
-
 var (
 	validLabelRE      = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 	validMetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)


### PR DESCRIPTION
When a series limit is reached, samples for existing series should still
be stored, so this is treated as a partial failure.

I tried various approaches to error propagation and handling, including
more complicated ones, but went for this medium-simple approach in the
end that uses gRPC errors to communicate a series-exceeded error from
the ingester back to the distributor, still manages to only partially
fail for the affected series, and communicates the specific error back
to the user. Due to only returning the last error encountered when
writing to multiple ingesters, this may at times cover up the
series-exceeded error if there is another error afterwards.