### PR TITLE
Retry failed terminal flushes at end of queue

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -530,7 +530,7 @@ func (i *Ingester) flushLoop(j int) {
 	for {
 		o := i.flushQueues[j].Dequeue()
 		if o == nil {
-			break
+			return
 		}
 		op := o.(*flushOp)
 


### PR DESCRIPTION
See #316 

Had a stab at fixing this. Ended up coming up with two different solutions (commit 1 & commit 2 of this PR). One was to have a new slice-as-queue for storing failures, the other is to put the items back into the priority queue with an exponential "backoff". Not sure which I dislike least.