### PR TITLE
Multiple alertmanagers in a mesh

### DIFF
--- a/alertmanager/mesh.go
+++ b/alertmanager/mesh.go
@@ -19,8 +19,6 @@
 package alertmanager
 
 import (
-	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"sort"
@@ -29,8 +27,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/common/log"
+
 	"github.com/weaveworks/mesh"
 )
+
+type promLog struct{}
+
+// Printf implements the mesh.Logger interface.
+func (p promLog) Printf(format string, args ...interface{}) {
+	log.Infof(format, args...)
+}
 
 func initMesh(addr, hwaddr, nickname, pw string) *mesh.Router {
 	host, portStr, err := net.SplitHostPort(addr)
@@ -63,7 +70,7 @@ func initMesh(addr, hwaddr, nickname, pw string) *mesh.Router {
 		ConnLimit:          64,
 		PeerDiscovery:      true,
 		TrustedSubnets:     []*net.IPNet{},
-	}, name, nickname, mesh.NullOverlay{}, log.New(ioutil.Discard, "", 0))
+	}, name, nickname, mesh.NullOverlay{}, promLog{})
 
 }
 

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -273,7 +273,10 @@ func (am *MultitenantAlertmanager) Run() {
 			// like a nice property to jml
 			sort.Strings(peers)
 			log.Infof("Updating alertmanager peers from %v to %v", am.meshRouter.getPeers(), peers)
-			am.meshRouter.ConnectionMaker.InitiateConnections(peers, true)
+			errs := am.meshRouter.ConnectionMaker.InitiateConnections(peers, true)
+			for _, err := range errs {
+				log.Error(err)
+			}
 			totalPeers.Set(float64(len(peers)))
 		case now := <-ticker.C:
 			err := am.updateConfigs(now)

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -197,7 +197,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 	flag.StringVar(&cfg.MeshNickname, "alertmanager.mesh.nickname", mustHostname(), "Mesh peer nickname")
 	flag.StringVar(&cfg.MeshPassword, "alertmanager.mesh.password", "", "Password to join the Mesh peer network (empty password disables encryption)")
 
-	flag.StringVar(&cfg.MeshPeerService, "alertmanager.mesh.peer.service", "alertmanager", "SRV service used to discover peers.")
+	flag.StringVar(&cfg.MeshPeerService, "alertmanager.mesh.peer.service", "mesh", "SRV service used to discover peers.")
 	flag.StringVar(&cfg.MeshPeerHost, "alertmanager.mesh.peer.host", "", "Hostname for mesh peers.")
 	flag.DurationVar(&cfg.MeshPeerPollInterval, "alertmanager.mesh.peer.poll-interval", 1*time.Minute, "Period with which to poll DNS for mesh peers.")
 }

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -266,6 +266,7 @@ func (am *MultitenantAlertmanager) Run() {
 			// XXX: Not 100% sure this is necessary. Stable ordering seems
 			// like a nice property to jml
 			sort.Strings(peers)
+			log.Infof("Updating alertmanager peers from %v to %v", am.meshRouter.getPeers(), peers)
 			am.meshRouter.ConnectionMaker.InitiateConnections(peers, true)
 		case now := <-ticker.C:
 			err := am.updateConfigs(now)

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -168,7 +169,10 @@ type MultitenantAlertmanagerConfig struct {
 	MeshHWAddr     string
 	MeshNickname   string
 	MeshPassword   string
-	MeshPeers      stringset
+
+	MeshPeerHost         string
+	MeshPeerService      string
+	MeshPeerPollInterval time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -186,7 +190,10 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 	flag.StringVar(&cfg.MeshHWAddr, "alertmanager.mesh.hardware-address", mustHardwareAddr(), "MAC address, i.e. Mesh peer ID")
 	flag.StringVar(&cfg.MeshNickname, "alertmanager.mesh.nickname", mustHostname(), "Mesh peer nickname")
 	flag.StringVar(&cfg.MeshPassword, "alertmanager.mesh.password", "", "Password to join the Mesh peer network (empty password disables encryption)")
-	flag.Var(&cfg.MeshPeers, "alertmanager.mesh.peer", "Initial Mesh peers (may be repeated)")
+
+	flag.StringVar(&cfg.MeshPeerService, "alertmanager.mesh.peer.service", "alertmanager", "SRV service used to discover peers.")
+	flag.StringVar(&cfg.MeshPeerHost, "alertmanager.mesh.peer.host", "", "Hostname for mesh peers.")
+	flag.DurationVar(&cfg.MeshPeerPollInterval, "alertmanager.mesh.peer.poll-interval", 1*time.Minute, "Period with which to poll DNS for mesh peers.")
 }
 
 // A MultitenantAlertmanager manages Alertmanager instances for multiple
@@ -205,7 +212,8 @@ type MultitenantAlertmanager struct {
 	latestConfig configs.ID
 	latestMutex  sync.RWMutex
 
-	meshRouter *gossipFactory
+	meshRouter   *gossipFactory
+	srvDiscovery *SRVDiscovery
 
 	stop chan struct{}
 	done chan struct{}
@@ -221,9 +229,6 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 	mrouter := initMesh(cfg.MeshListenAddr, cfg.MeshHWAddr, cfg.MeshNickname, cfg.MeshPassword)
 
 	mrouter.Start()
-	defer mrouter.Stop()
-
-	mrouter.ConnectionMaker.InitiateConnections(cfg.MeshPeers.slice(), true)
 
 	configsAPI := configs_client.AlertManagerConfigsAPI{
 		URL:     cfg.ConfigsAPIURL.URL,
@@ -231,15 +236,17 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 	}
 
 	gf := newGossipFactory(mrouter)
-	return &MultitenantAlertmanager{
+	am := &MultitenantAlertmanager{
 		cfg:           cfg,
 		configsAPI:    configsAPI,
 		cfgs:          map[string]configs.Config{},
 		alertmanagers: map[string]*Alertmanager{},
 		meshRouter:    &gf,
+		srvDiscovery:  NewSRVDiscovery(cfg.MeshPeerService, cfg.MeshPeerHost, cfg.MeshPeerPollInterval),
 		stop:          make(chan struct{}),
 		done:          make(chan struct{}),
-	}, nil
+	}
+	return am, nil
 }
 
 // Run the MultitenantAlertmanager.
@@ -251,6 +258,15 @@ func (am *MultitenantAlertmanager) Run() {
 	ticker := time.NewTicker(am.cfg.PollInterval)
 	for {
 		select {
+		case addrs := <-am.srvDiscovery.Addresses:
+			var peers []string
+			for _, srv := range addrs {
+				peers = append(peers, fmt.Sprintf("%s:%d", srv.Target, srv.Port))
+			}
+			// XXX: Not 100% sure this is necessary. Stable ordering seems
+			// like a nice property to jml
+			sort.Strings(peers)
+			am.meshRouter.ConnectionMaker.InitiateConnections(peers, true)
 		case now := <-ticker.C:
 			err := am.updateConfigs(now)
 			if err != nil {
@@ -265,11 +281,13 @@ func (am *MultitenantAlertmanager) Run() {
 
 // Stop stops the MultitenantAlertmanager.
 func (am *MultitenantAlertmanager) Stop() {
+	am.srvDiscovery.Stop()
 	close(am.stop)
 	<-am.done
 	for _, am := range am.alertmanagers {
 		am.Stop()
 	}
+	am.meshRouter.Stop()
 	log.Debugf("MultitenantAlertmanager stopped")
 }
 

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -176,9 +176,9 @@ type MultitenantAlertmanagerConfig struct {
 	MeshNickname   string
 	MeshPassword   string
 
-	MeshPeerHost         string
-	MeshPeerService      string
-	MeshPeerPollInterval time.Duration
+	MeshPeerHost            string
+	MeshPeerService         string
+	MeshPeerRefreshInterval time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -199,7 +199,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 
 	flag.StringVar(&cfg.MeshPeerService, "alertmanager.mesh.peer.service", "mesh", "SRV service used to discover peers.")
 	flag.StringVar(&cfg.MeshPeerHost, "alertmanager.mesh.peer.host", "", "Hostname for mesh peers.")
-	flag.DurationVar(&cfg.MeshPeerPollInterval, "alertmanager.mesh.peer.poll-interval", 1*time.Minute, "Period with which to poll DNS for mesh peers.")
+	flag.DurationVar(&cfg.MeshPeerRefreshInterval, "alertmanager.mesh.peer.refresh-interval", 1*time.Minute, "Period with which to poll DNS for mesh peers.")
 }
 
 // A MultitenantAlertmanager manages Alertmanager instances for multiple
@@ -248,7 +248,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 		cfgs:          map[string]configs.Config{},
 		alertmanagers: map[string]*Alertmanager{},
 		meshRouter:    &gf,
-		srvDiscovery:  NewSRVDiscovery(cfg.MeshPeerService, cfg.MeshPeerHost, cfg.MeshPeerPollInterval),
+		srvDiscovery:  NewSRVDiscovery(cfg.MeshPeerService, cfg.MeshPeerHost, cfg.MeshPeerRefreshInterval),
 		stop:          make(chan struct{}),
 		done:          make(chan struct{}),
 	}

--- a/alertmanager/peers.go
+++ b/alertmanager/peers.go
@@ -1,0 +1,61 @@
+package alertmanager
+
+import (
+	"net"
+	"time"
+
+	"github.com/prometheus/common/log"
+)
+
+// TODO: change memcache_client to use this.
+
+// SRVDiscovery discovers SRV services.
+type SRVDiscovery struct {
+	Service      string
+	Proto        string
+	Hostname     string
+	PollInterval time.Duration
+	Addresses    chan []*net.SRV
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewSRVDiscovery makes a new SRVDiscovery.
+func NewSRVDiscovery(service, hostname string, pollInterval time.Duration) *SRVDiscovery {
+	disco := &SRVDiscovery{
+		Service:      service,
+		Proto:        "tcp",
+		Hostname:     hostname,
+		PollInterval: pollInterval,
+		Addresses:    make(chan []*net.SRV),
+		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
+	}
+	go disco.loop()
+	return disco
+}
+
+// Stop the SRVDiscovery
+func (s *SRVDiscovery) Stop() {
+	close(s.stop)
+	<-s.done
+}
+
+func (s *SRVDiscovery) loop() {
+	defer close(s.done)
+	ticker := time.NewTicker(s.PollInterval)
+	for {
+		select {
+		case <-ticker.C:
+			_, addrs, err := net.LookupSRV(s.Service, s.Proto, s.Hostname)
+			if err != nil {
+				log.Warnf("Error discovering services for %s %s %s: %v", s.Service, s.Proto, s.Hostname, err)
+			}
+			s.Addresses <- addrs
+		case <-s.stop:
+			ticker.Stop()
+			return
+		}
+	}
+}

--- a/configs/client/configs.go
+++ b/configs/client/configs.go
@@ -29,7 +29,6 @@ func configsFromJSON(body io.Reader) (*ConfigsResponse, error) {
 		log.Errorf("configs: couldn't decode JSON body: %v", err)
 		return nil, err
 	}
-	log.Debugf("configs: got response: %v", configs)
 	return &configs, nil
 }
 

--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -68,7 +68,11 @@ type Config struct {
 	NumWorkers         int
 
 	// URL of the Alertmanager to send notifications to.
-	AlertmanagerURL string
+	AlertmanagerURL util.URLValue
+	// How long to wait between refreshing the list of alertmanagers based on
+	// DNS service discovery.
+	AlertmanagerRefreshInterval time.Duration
+
 	// Capacity of the queue for notifications to be sent to the Alertmanager.
 	NotificationQueueCapacity int
 	// HTTP timeout duration when sending notifications to the Alertmanager.
@@ -83,7 +87,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")
 	f.DurationVar(&cfg.ClientTimeout, "ruler.client-timeout", 5*time.Second, "Timeout for requests to Weave Cloud configs service.")
 	f.IntVar(&cfg.NumWorkers, "ruler.num-workers", 1, "Number of rule evaluator worker routines in this process")
-	f.StringVar(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "", "URL of the Alertmanager to send notifications to.")
+	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL of the Alertmanager to send notifications to.")
+	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing alertmanager hosts.")
 	f.IntVar(&cfg.NotificationQueueCapacity, "ruler.notification-queue-capacity", 10000, "Capacity of the queue for notifications to be sent to the Alertmanager.")
 	f.DurationVar(&cfg.NotificationTimeout, "ruler.notification-timeout", 10*time.Second, "HTTP timeout duration when sending notifications to the Alertmanager.")
 }
@@ -120,28 +125,23 @@ func NewRuler(cfg Config, d *distributor.Distributor, c *chunk.Store) (*Ruler, e
 // Builds a Prometheus config.Config from a ruler.Config with just the required
 // options to configure notifications to Alertmanager.
 func buildNotifierConfig(rulerConfig *Config) (*config.Config, error) {
-	if rulerConfig.AlertmanagerURL == "" {
+	if rulerConfig.AlertmanagerURL.URL == nil {
 		return &config.Config{}, nil
 	}
 
-	u, err := url.Parse(rulerConfig.AlertmanagerURL)
-	if err != nil {
-		return nil, err
+	u := rulerConfig.AlertmanagerURL
+	dnsSDConfig := config.DNSSDConfig{
+		Names:           []string{u.Host},
+		RefreshInterval: model.Duration(rulerConfig.AlertmanagerRefreshInterval),
+		Type:            "SRV",
+		Port:            0, // Ignored, because of SRV.
 	}
 	amConfig := &config.AlertmanagerConfig{
 		Scheme:     u.Scheme,
 		PathPrefix: u.Path,
 		Timeout:    rulerConfig.NotificationTimeout,
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-			StaticConfigs: []*config.TargetGroup{
-				{
-					Targets: []model.LabelSet{
-						{
-							model.AddressLabel: model.LabelValue(u.Host),
-						},
-					},
-				},
-			},
+			DNSSDConfigs: []*config.DNSSDConfig{&dnsSDConfig},
 		},
 	}
 

--- a/ruler/ruler_test.go
+++ b/ruler/ruler_test.go
@@ -17,7 +17,8 @@ func newTestRuler(t *testing.T, alertmanagerURL string) *Ruler {
 	fs := flag.NewFlagSet("test", flag.PanicOnError)
 	cfg.RegisterFlags(fs)
 	fs.Parse(nil)
-	cfg.AlertmanagerURL = alertmanagerURL
+	cfg.AlertmanagerURL.Set(alertmanagerURL)
+	cfg.AlertmanagerDiscovery = false
 
 	// TODO: Populate distributor and chunk store arguments to enable
 	// other kinds of tests.


### PR DESCRIPTION
- Set alertmanager peers based on k8s SRV lookup
- `meshWait` doesn't need updating because it's already dynamically operating on the sorted list of mesh peers, which is what we're using for service discovery
- Update ruler to use DNS service discovery to send alerts to all alertmanagers

Tested with a script that's available in https://github.com/weaveworks/test-alertmanager 

See #50 

TODO:
- [x] Fix build
- [x] Confirm Prom DNS SD lookup discovers alertmanager HTTP port.