### PR TITLE
Address some correctness issues with the v5 schema

### DIFF
--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/local/chunk"
 	"github.com/prometheus/prometheus/storage/metric"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
 	"github.com/weaveworks/common/test"
@@ -156,4 +158,85 @@ func mustNewLabelMatcher(matchType metric.MatchType, name model.LabelName, value
 		panic(err)
 	}
 	return matcher
+}
+
+func TestChunkStoreRandom(t *testing.T) {
+	ctx := user.Inject(context.Background(), "0")
+	schemas := []struct {
+		name  string
+		fn    func(cfg SchemaConfig) Schema
+		store *Store
+	}{
+		{name: "v1 schema", fn: v1Schema},
+		{name: "v2 schema", fn: v2Schema},
+		{name: "v3 schema", fn: v3Schema},
+		{name: "v4 schema", fn: v4Schema},
+		{name: "v5 schema", fn: v5Schema},
+	}
+
+	for i := range schemas {
+		dynamoDB := NewMockStorage()
+		setupDynamodb(t, dynamoDB)
+		store, err := NewStore(StoreConfig{
+			mockDynamoDB:  dynamoDB,
+			mockS3:        NewMockS3(),
+			schemaFactory: schemas[i].fn,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		schemas[i].store = store
+	}
+
+	// put 100 chunks from 0 to 99
+	const chunkLen = 13 * 3600 // in seconds
+	for i := 0; i < 100; i++ {
+		ts := model.TimeFromUnix(int64(i * chunkLen))
+		chunks, _ := chunk.New().Add(model.SamplePair{Timestamp: ts, Value: 0})
+		chunk := NewChunk(
+			model.Fingerprint(1),
+			model.Metric{
+				model.MetricNameLabel: "foo",
+				"bar": "baz",
+			},
+			chunks[0],
+			ts,
+			ts.Add(chunkLen),
+		)
+		for _, s := range schemas {
+			if err := s.store.Put(ctx, []Chunk{chunk}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// pick two random numbers and do a query
+	for i := 0; i < 100; i++ {
+		start := rand.Int63n(100 * chunkLen)
+		end := start + rand.Int63n((100*chunkLen)-start)
+		assert.True(t, start < end)
+
+		startTime := model.TimeFromUnix(start)
+		endTime := model.TimeFromUnix(end)
+
+		for _, s := range schemas {
+			chunks, err := s.store.Get(ctx, startTime, endTime,
+				mustNewLabelMatcher(metric.Equal, model.MetricNameLabel, "foo"),
+				mustNewLabelMatcher(metric.Equal, "bar", "baz"),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// We need to check that each chunk is in the time range
+			for _, chunk := range chunks {
+				assert.False(t, chunk.From.After(endTime))
+				assert.False(t, chunk.Through.Before(startTime))
+			}
+
+			// And check we go all the chunks we want
+			numChunks := (end / chunkLen) - (start / chunkLen)
+			assert.Equal(t, int(numChunks), len(chunks), s.name)
+		}
+	}
 }

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -234,7 +234,7 @@ func TestChunkStoreRandom(t *testing.T) {
 				assert.False(t, chunk.Through.Before(startTime))
 			}
 
-			// And check we go all the chunks we want
+			// And check we got all the chunks we want
 			numChunks := (end / chunkLen) - (start / chunkLen)
 			assert.Equal(t, int(numChunks), len(chunks), s.name)
 		}

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -536,36 +536,29 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 	return entries, nil
 }
 
-func (v5Entries) GetReadMetricEntries(from, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
-	encodedFromBytes := encodeTime(from)
+func (v5Entries) GetReadMetricEntries(_, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
-			TableName:       tableName,
-			HashValue:       hashKey,
-			RangeValueStart: buildRangeKey(encodedFromBytes),
+			TableName: tableName,
+			HashValue: hashKey,
 		},
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
-	encodedFromBytes := encodeTime(from)
+func (v5Entries) GetReadMetricLabelEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
-			TableName:       tableName,
-			HashValue:       hashKey + ":" + string(labelName),
-			RangeValueStart: buildRangeKey(encodedFromBytes),
+			TableName: tableName,
+			HashValue: hashKey + ":" + string(labelName),
 		},
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelValueEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
-	encodedFromBytes := encodeTime(from)
-	encodedValueBytes := encodeBase64Value(labelValue)
+func (v5Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName, _ model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
-			TableName:       tableName,
-			HashValue:       hashKey + ":" + string(labelName),
-			RangeValueStart: buildRangeKey(encodedFromBytes, encodedValueBytes),
+			TableName: tableName,
+			HashValue: hashKey + ":" + string(labelName),
 		},
 	}, nil
 }

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -106,8 +106,8 @@ func (cfg SchemaConfig) hourlyBuckets(from, through model.Time, userID string, m
 	)
 
 	for i := fromHour; i <= throughHour; i++ {
-		relativeFrom := util.Max64(i*millisecondsInHour, int64(from))
-		relativeThrough := util.Min64((i+1)*millisecondsInHour, int64(through))
+		relativeFrom := util.Max64(0, int64(from)-(i*millisecondsInHour))
+		relativeThrough := util.Min64(millisecondsInHour, int64(through)-(i*millisecondsInDay))
 		entries, err := callback(uint32(relativeFrom), uint32(relativeThrough), cfg.tableForBucket(i*secondsInHour), fmt.Sprintf("%s:%d:%s", userID, i, metricName))
 		if err != nil {
 			return nil, err
@@ -125,8 +125,8 @@ func (cfg SchemaConfig) dailyBuckets(from, through model.Time, userID string, me
 	)
 
 	for i := fromDay; i <= throughDay; i++ {
-		relativeFrom := util.Max64(i*millisecondsInDay, int64(from))
-		relativeThrough := util.Min64((i+1)*millisecondsInDay, int64(through))
+		relativeFrom := util.Max64(0, int64(from)-(i*millisecondsInDay))
+		relativeThrough := util.Min64(millisecondsInDay, int64(through)-(i*millisecondsInDay))
 		entries, err := callback(uint32(relativeFrom), uint32(relativeThrough), cfg.tableForBucket(i*secondsInDay), fmt.Sprintf("%s:d%d:%s", userID, i, metricName))
 		if err != nil {
 			return nil, err

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/test"
 	"github.com/weaveworks/cortex/util"
 )
@@ -557,5 +558,39 @@ func TestSchemaTimeEncoding(t *testing.T) {
 		} else {
 			assert.Equal(t, 1, bytes.Compare(encodeTime(a), encodeTime(b)), "eq")
 		}
+	}
+}
+
+func TestSchemaDailyBuckets(t *testing.T) {
+	const (
+		userID     = "0"
+		metricName = model.LabelValue("name")
+		tableName  = "table"
+	)
+	var (
+		config = SchemaConfig{
+			OriginalTableName: tableName,
+		}
+	)
+
+	for _, c := range []struct {
+		from, through model.Time
+	}{
+		{
+			from:    model.TimeFromUnix(0),
+			through: model.TimeFromUnix(2 * 24 * 3600),
+		},
+	} {
+		var i int64
+		_, err := config.dailyBuckets(c.from, c.through, userID, metricName, func(from, through uint32, tableName, hashKey string) ([]IndexEntry, error) {
+			fmt.Println(i, int64(c.from), int64(c.through), from, through)
+			require.True(t, (i*millisecondsInDay)+int64(from) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(from), int64(c.from))
+			require.True(t, (i*millisecondsInDay)+int64(from) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(from), int64(c.through))
+			require.True(t, (i*millisecondsInDay)+int64(through) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(through), int64(c.from))
+			require.True(t, (i*millisecondsInDay)+int64(through) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(through), int64(c.through))
+			i++
+			return nil, nil
+		})
+		assert.NoError(t, err)
 	}
 }

--- a/chunk/storage_client_mock_test.go
+++ b/chunk/storage_client_mock_test.go
@@ -163,7 +163,7 @@ func (m *MockStorage) QueryPages(ctx context.Context, entry IndexEntry, callback
 
 		// the smallest index i in [0, n) at which f(i) is true
 		i := sort.Search(len(items), func(i int) bool {
-			return bytes.Compare(items[i], entry.RangeValueStart) > 0
+			return bytes.Compare(items[i], entry.RangeValueStart) >= 0
 		})
 
 		log.Printf("  found range [%d)", i)


### PR DESCRIPTION
Should potentially help with #304 (missing data reported by @rade and @juliusv, but not @Bplotka as he is on v4 schema).

Unfortunately, the way I calculated the relative timestamp of chunks within buckets was wrong, causing overflow of a uint32.  The data written by the v5 schema is incorrect.  This PR adds tests to expose it, and fixes.

The situation is salvageable though - I have made the v5 schema ignore the timestamps for reads.   This will have a performance regression, but I will make a new v6 schema that takes them into account (to help with #199).