### PR TITLE
v6 Schema; move label value out of range key, and re-enable chunk timestamp optimisation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UPTODATE := .uptodate
 	touch $@
 
 # Get a list of directories containing Dockerfiles
-DOCKERFILES := $(shell find . -type f -name Dockerfile ! -path "./tools/*" ! -path "./vendor/*")
+DOCKERFILES := $(shell find . -name tools -prune -o -name vendor -prune -o -type f -name 'Dockerfile' -print)
 UPTODATE_FILES := $(patsubst %/Dockerfile,%/$(UPTODATE),$(DOCKERFILES))
 DOCKER_IMAGE_DIRS := $(patsubst %/Dockerfile,%,$(DOCKERFILES))
 IMAGE_NAMES := $(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)%,$(shell basename $(dir))))
@@ -26,14 +26,14 @@ images:
 	@echo > /dev/null
 
 # Generating proto code is automated.
-PROTO_DEFS := $(shell find . -type f -name "*.proto" ! -path "./tools/*" ! -path "./vendor/*")
+PROTO_DEFS := $(shell find . -name tools -prune -o -name vendor -prune -o -type f -name '*.proto' -print)
 PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 
 # Building binaries is now automated.  The convention is to build a binary
 # for every directory with main.go in it, in the ./cmd directory.
-MAIN_GO := $(shell find ./cmd -type f -name main.go ! -path "./tools/*" ! -path "./vendor/*")
+MAIN_GO := $(shell find . -name tools -prune -o -name vendor -prune -o -type f -name 'main.go' -print)
 EXES := $(foreach exe, $(patsubst ./cmd/%/main.go, %, $(MAIN_GO)), ./cmd/$(exe)/$(exe))
-GO_FILES := $(shell find . -name '*.go' ! -path "./cmd/*" ! -path "./tools/*" ! -path "./vendor/*")
+GO_FILES := $(shell find . -name tools -prune -o -name vendor -prune -o -name cmd -prune -o -type f -name '*.go' -print)
 define dep_exe
 $(1): $(dir $(1))/main.go $(GO_FILES) $(PROTO_GOS)
 $(dir $(1))$(UPTODATE): $(1)
@@ -66,10 +66,24 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 
 $(EXES) $(PROTO_GOS) lint test shell: build/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
-	$(SUDO) docker run $(RM) -ti \
+	$(SUDO) time docker run $(RM) -ti \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/go/src/github.com/weaveworks/cortex \
 		$(IMAGE_PREFIX)build $@
+
+configs-integration-test: build/$(UPTODATE)
+	@mkdir -p $(shell pwd)/.pkg
+	DB_CONTAINER="$$(docker run -d -e 'POSTGRES_DB=configs_test' postgres:9.6)"; \
+	$(SUDO) docker run $(RM) -ti \
+		-v $(shell pwd)/.pkg:/go/pkg \
+		-v $(shell pwd):/go/src/github.com/weaveworks/cortex \
+		-v $(shell pwd)/cmd/configs/migrations:/migrations \
+		--workdir /go/src/github.com/weaveworks/cortex \
+		--link "$$DB_CONTAINER":configs-db.cortex.local \
+		$(IMAGE_PREFIX)build $@; \
+	status=$$?; \
+	test -n "$(CIRCLECI)" || docker rm -f "$$DB_CONTAINER"; \
+	exit $$status
 
 else
 
@@ -89,20 +103,10 @@ test: build/$(UPTODATE)
 shell: build/$(UPTODATE)
 	bash
 
-endif
+configs-integration-test:
+	/bin/bash -c "go test -tags netgo,integration -timeout 30s ./configs/..."
 
-configs-integration-test: cmd/configs/$(UPTODATE)
-	DB_CONTAINER="$$(docker run -d -e 'POSTGRES_DB=configs_test' postgres:9.6)"; \
-	docker run $(RM) \
-		-v $(shell pwd):/go/src/github.com/weaveworks/cortex \
-		-v $(shell pwd)/cmd/configs/migrations:/migrations \
-		--workdir /go/src/github.com/weaveworks/cortex \
-		--link "$$DB_CONTAINER":configs-db.cortex.local \
-		golang:1.8.0 \
-		/bin/bash -c "go test -tags integration -timeout 30s ./configs/..."; \
-	status=$$?; \
-	test -n "$(CIRCLECI)" || docker rm -f "$$DB_CONTAINER"; \
-	exit $$status
+endif
 
 clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -67,6 +67,7 @@ func TestChunkStore(t *testing.T) {
 		{"v3 schema", v3Schema},
 		{"v4 schema", v4Schema},
 		{"v5 schema", v5Schema},
+		{"v6 schema", v6Schema},
 	}
 
 	nameMatcher := mustNewLabelMatcher(metric.Equal, model.MetricNameLabel, "foo")
@@ -172,6 +173,7 @@ func TestChunkStoreRandom(t *testing.T) {
 		{name: "v3 schema", fn: v3Schema},
 		{name: "v4 schema", fn: v4Schema},
 		{name: "v5 schema", fn: v5Schema},
+		{name: "v6 schema", fn: v6Schema},
 	}
 
 	for i := range schemas {

--- a/chunk/dynamodb_client_test.go
+++ b/chunk/dynamodb_client_test.go
@@ -102,7 +102,7 @@ func TestDynamoDBClient(t *testing.T) {
 	}
 	batch := client.NewWriteBatch()
 	for i := 0; i < 30; i++ {
-		batch.Add("table", fmt.Sprintf("hash%d", i), []byte(fmt.Sprintf("range%d", i)))
+		batch.Add("table", fmt.Sprintf("hash%d", i), []byte(fmt.Sprintf("range%d", i)), nil)
 	}
 	dynamoDB.createTable("table")
 

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -648,7 +648,6 @@ func (v6Entries) GetReadMetricLabelValueEntries(_, through uint32, tableName, ha
 			TableName:  tableName,
 			HashValue:  hashKey + ":" + string(labelName),
 			RangeValue: buildRangeKey(encodedThroughBytes),
-			Value:      []byte(labelValue),
 		},
 	}, nil
 }

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -53,7 +53,7 @@ type IndexEntry struct {
 	// For writes, RangeValue will always be set.
 	RangeValue []byte
 
-	// New for v6 schema, Value is not written as part of the range key.
+	// New for v6 schema, label value is not written as part of the range key.
 	Value []byte
 
 	// For reads, one of RangeValuePrefix or RangeValueStart might be set:
@@ -739,7 +739,7 @@ func parseRangeValue(rangeValue []byte, value []byte) (Chunk, model.LabelValue, 
 		return chunk, labelValue, err
 
 	// v6 schema added version 5 range keys, which have the label value written in
-	// to the value, not the range key.
+	// to the value, not the range key. So they are [chunk end time, <empty>, chunk ID, version].
 	case bytes.Equal(components[3], rangeKeyV5):
 		chunk := Chunk{ID: string(components[2])}
 		labelValue := model.LabelValue(value)

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -392,24 +392,26 @@ func TestSchemaRangeKey(t *testing.T) {
 		base64Keys    = v3Schema(cfg)
 		labelBuckets  = v4Schema(cfg)
 		tsRangeKeys   = v5Schema(cfg)
-		//v6RangeKeys   = v6Schema(cfg)
-		metric = model.Metric{
+		v6RangeKeys   = v6Schema(cfg)
+		metric        = model.Metric{
 			model.MetricNameLabel: metricName,
 			"bar": "bary",
 			"baz": "bazy",
 		}
 	)
 
-	mkEntries := func(hashKey string, callback func(labelName model.LabelName, labelValue model.LabelValue) string) []IndexEntry {
+	mkEntries := func(hashKey string, callback func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte)) []IndexEntry {
 		result := []IndexEntry{}
 		for labelName, labelValue := range metric {
 			if labelName == model.MetricNameLabel {
 				continue
 			}
+			rangeValue, value := callback(labelName, labelValue)
 			result = append(result, IndexEntry{
 				TableName:  table,
 				HashValue:  hashKey,
-				RangeValue: []byte(callback(labelName, labelValue)),
+				RangeValue: rangeValue,
+				Value:      value,
 			})
 		}
 		return result
@@ -422,21 +424,21 @@ func TestSchemaRangeKey(t *testing.T) {
 		// Basic test case for the various bucketing schemes
 		{
 			hourlyBuckets,
-			mkEntries("userid:0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
-				return fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)
+			mkEntries("userid:0:foo", func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte) {
+				return []byte(fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)), nil
 			}),
 		},
 		{
 			dailyBuckets,
-			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
-				return fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)
+			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte) {
+				return []byte(fmt.Sprintf("%s\x00%s\x00%s\x00", labelName, labelValue, chunkID)), nil
 			}),
 		},
 		{
 			base64Keys,
-			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) string {
+			mkEntries("userid:d0:foo", func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte) {
 				encodedValue := base64.RawStdEncoding.EncodeToString([]byte(labelValue))
-				return fmt.Sprintf("%s\x00%s\x00%s\x001\x00", labelName, encodedValue, chunkID)
+				return []byte(fmt.Sprintf("%s\x00%s\x00%s\x001\x00", labelName, encodedValue, chunkID)), nil
 			}),
 		},
 		{
@@ -479,8 +481,28 @@ func TestSchemaRangeKey(t *testing.T) {
 				},
 			},
 		},
-
-		// TODO v6 test case
+		{
+			v6RangeKeys,
+			[]IndexEntry{
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x003\x00"),
+				},
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo:bar",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
+					Value:      []byte("bary"),
+				},
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo:baz",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
+					Value:      []byte("bazy"),
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("TestSchameRangeKey[%d]", i), func(t *testing.T) {
 			have, err := tc.Schema.GetWriteEntries(

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -392,7 +392,8 @@ func TestSchemaRangeKey(t *testing.T) {
 		base64Keys    = v3Schema(cfg)
 		labelBuckets  = v4Schema(cfg)
 		tsRangeKeys   = v5Schema(cfg)
-		metric        = model.Metric{
+		//v6RangeKeys   = v6Schema(cfg)
+		metric = model.Metric{
 			model.MetricNameLabel: metricName,
 			"bar": "bary",
 			"baz": "bazy",
@@ -478,6 +479,8 @@ func TestSchemaRangeKey(t *testing.T) {
 				},
 			},
 		},
+
+		// TODO v6 test case
 	} {
 		t.Run(fmt.Sprintf("TestSchameRangeKey[%d]", i), func(t *testing.T) {
 			have, err := tc.Schema.GetWriteEntries(
@@ -496,7 +499,7 @@ func TestSchemaRangeKey(t *testing.T) {
 
 			// Test we can parse the resulting range keys
 			for _, entry := range have {
-				_, _, err := parseRangeValue(entry.RangeValue)
+				_, _, err := parseRangeValue(entry.RangeValue, entry.Value)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -534,10 +537,10 @@ func TestParseRangeValue(t *testing.T) {
 		{[]byte("a1b2c3d4\x00Y29kZQ\x002:1484661279394:1484664879394\x004\x00"),
 			"code", "2:1484661279394:1484664879394"},
 	} {
-		value, chunkID, err := parseRangeValue(c.encoded)
+		chunk, labelValue, err := parseRangeValue(c.encoded, nil)
 		assert.Nil(t, err, "parseRangeValue error")
-		assert.Equal(t, model.LabelValue(c.value), value, "value")
-		assert.Equal(t, c.chunkID, chunkID, "chunkID")
+		assert.Equal(t, model.LabelValue(c.value), labelValue, "value")
+		assert.Equal(t, c.chunkID, chunk.ID, "chunkID")
 	}
 }
 

--- a/chunk/storage_client.go
+++ b/chunk/storage_client.go
@@ -22,15 +22,12 @@ type StorageClient interface {
 
 // WriteBatch represents a batch of writes
 type WriteBatch interface {
-	Add(tableName, hashValue string, rangeValue []byte)
+	Add(tableName, hashValue string, rangeValue []byte, value []byte)
 }
 
 // ReadBatch represents the results of a QueryPages
 type ReadBatch interface {
 	Len() int
 	RangeValue(index int) []byte
-
-	// Value is deprecated - it exists to support an old schema where the chunk
-	// metadata was written to the chunk index.
 	Value(index int) []byte
 }

--- a/util/error.go
+++ b/util/error.go
@@ -9,4 +9,6 @@ const (
 	ErrInvalidLabel              = errors.Error("sample invalid label")
 	ErrUserSeriesLimitExceeded   = errors.Error("per-user series limit exceeded")
 	ErrMetricSeriesLimitExceeded = errors.Error("per-metric series limit exceeded")
+	ErrLabelNameTooLong          = errors.Error("label name too long")
+	ErrLabelValueTooLong         = errors.Error("label value too long")
 )

--- a/util/validate.go
+++ b/util/validate.go
@@ -7,8 +7,10 @@ import (
 )
 
 var (
-	validLabelRE      = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-	validMetricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+	validLabelRE        = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	validMetricNameRE   = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+	maxLabelNameLength  = 1024
+	maxLabelValueLength = 4096
 )
 
 // ValidateSample returns an err if the sample is invalid
@@ -22,9 +24,15 @@ func ValidateSample(s *model.Sample) error {
 		return ErrInvalidMetricName
 	}
 
-	for k := range s.Metric {
+	for k, v := range s.Metric {
 		if !validLabelRE.MatchString(string(k)) {
 			return ErrInvalidLabel
+		}
+		if len(k) > maxLabelNameLength {
+			return ErrLabelNameTooLong
+		}
+		if len(v) > maxLabelValueLength {
+			return ErrLabelValueTooLong
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #316 (ValidationError because range value was too long) and reenabled the v5 query optimisation with the fixed timestamps.