### PR TITLE
Separate routes for alert configs and rules

### DIFF
--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -86,7 +86,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 type MultitenantAlertmanager struct {
 	cfg *MultitenantAlertmanagerConfig
 
-	configsAPI configs.API
+	configsAPI configs.AlertConfigsAPI
 
 	// All the organization configurations that we have. Only used for instrumentation.
 	cfgs map[string]configs.CortexConfig
@@ -117,7 +117,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 
 	mrouter.ConnectionMaker.InitiateConnections(cfg.MeshPeers.slice(), true)
 
-	configsAPI := configs.API{
+	configsAPI := configs.AlertConfigsAPI{
 		URL:     cfg.ConfigsAPIURL.URL,
 		Timeout: cfg.ClientTimeout,
 	}

--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -86,7 +86,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 type MultitenantAlertmanager struct {
 	cfg *MultitenantAlertmanagerConfig
 
-	configsAPI configs.AlertConfigsAPI
+	configsAPI configs.AlertManagerConfigsAPI
 
 	// All the organization configurations that we have. Only used for instrumentation.
 	cfgs map[string]configs.CortexConfig
@@ -117,7 +117,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 
 	mrouter.ConnectionMaker.InitiateConnections(cfg.MeshPeers.slice(), true)
 
-	configsAPI := configs.AlertConfigsAPI{
+	configsAPI := configs.AlertManagerConfigsAPI{
 		URL:     cfg.ConfigsAPIURL.URL,
 		Timeout: cfg.ClientTimeout,
 	}

--- a/configs/api/api.go
+++ b/configs/api/api.go
@@ -50,14 +50,20 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		handler            http.HandlerFunc
 	}{
 		{"root", "GET", "/", a.admin},
+		// Deprecated public APIs
 		{"get_config", "GET", "/api/configs/org/cortex", a.getConfig},
 		{"set_config", "POST", "/api/configs/org/cortex", a.setConfig},
 		// Dedicated APIs for updating rules config. In future, these *must*
 		// be used.
-		{"get_rules", "GET", "/api/configs/rules", a.getConfig},
-		{"set_rules", "POST", "/api/configs/rules", a.setConfig},
-		// Internal APIs.
+		{"get_rules", "GET", "/api/prom/rules", a.getConfig},
+		{"set_rules", "POST", "/api/prom/rules", a.setConfig},
+		{"get_alert_config", "GET", "/api/prom/alerts", a.getConfig},
+		{"set_alert_config", "POST", "/api/prom/alerts", a.setConfig},
+		// Deprecated internal APIs.
 		{"private_get_configs", "GET", "/private/api/configs/org/cortex", a.getConfigs},
+		// Internal APIs.
+		{"private_get_rules", "GET", "/private/api/prom/rules", a.getConfigs},
+		{"private_get_alerts", "GET", "/private/api/prom/alerts", a.getConfigs},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
 	}

--- a/configs/api/api.go
+++ b/configs/api/api.go
@@ -52,6 +52,10 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		{"root", "GET", "/", a.admin},
 		{"get_config", "GET", "/api/configs/org/cortex", a.getConfig},
 		{"set_config", "POST", "/api/configs/org/cortex", a.setConfig},
+		// Dedicated APIs for updating rules config. In future, these *must*
+		// be used.
+		{"get_rules", "GET", "/api/configs/rules", a.getConfig},
+		{"set_rules", "POST", "/api/configs/rules", a.setConfig},
 		// Internal APIs.
 		{"private_get_configs", "GET", "/private/api/configs/org/cortex", a.getConfigs},
 	} {

--- a/configs/api/api.go
+++ b/configs/api/api.go
@@ -53,15 +53,15 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		// Deprecated public APIs
 		{"get_config", "GET", "/api/configs/org/cortex", a.getConfig},
 		{"set_config", "POST", "/api/configs/org/cortex", a.setConfig},
-		// Dedicated APIs for updating rules config. In future, these *must*
+		// Dedicated APIs for updating rules config. In the future, these *must*
 		// be used.
-		{"get_rules", "GET", "/api/prom/rules", a.getConfig},
-		{"set_rules", "POST", "/api/prom/rules", a.setConfig},
-		{"get_alert_config", "GET", "/api/prom/alerts", a.getConfig},
-		{"set_alert_config", "POST", "/api/prom/alerts", a.setConfig},
+		{"get_rules", "GET", "/api/prom/configs/rules", a.getConfig},
+		{"set_rules", "POST", "/api/prom/configs/rules", a.setConfig},
+		{"get_alertmanager_config", "GET", "/api/prom/configs/alertmanager", a.getConfig},
+		{"set_alertmanager_config", "POST", "/api/prom/configs/alertmanager", a.setConfig},
 		// Internal APIs.
-		{"private_get_rules", "GET", "/private/api/prom/rules", a.getConfigs},
-		{"private_get_alerts", "GET", "/private/api/prom/alerts", a.getConfigs},
+		{"private_get_rules", "GET", "/private/api/prom/configs/rules", a.getConfigs},
+		{"private_get_alertmanager_config", "GET", "/private/api/prom/configs/alertmanager", a.getConfigs},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
 	}

--- a/configs/api/api.go
+++ b/configs/api/api.go
@@ -59,8 +59,6 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		{"set_rules", "POST", "/api/prom/rules", a.setConfig},
 		{"get_alert_config", "GET", "/api/prom/alerts", a.getConfig},
 		{"set_alert_config", "POST", "/api/prom/alerts", a.setConfig},
-		// Deprecated internal APIs.
-		{"private_get_configs", "GET", "/private/api/configs/org/cortex", a.getConfigs},
 		// Internal APIs.
 		{"private_get_rules", "GET", "/private/api/prom/rules", a.getConfigs},
 		{"private_get_alerts", "GET", "/private/api/prom/alerts", a.getConfigs},

--- a/configs/api/api_test.go
+++ b/configs/api/api_test.go
@@ -14,18 +14,18 @@ import (
 )
 
 const (
-	rulesEndpoint        = "/api/prom/rules"
-	rulesPrivateEndpoint = "/private/api/prom/rules"
+	rulesEndpoint        = "/api/prom/configs/rules"
+	rulesPrivateEndpoint = "/private/api/prom/configs/rules"
 
-	alertConfigEndpoint        = "/api/prom/alerts"
-	alertConfigPrivateEndpoint = "/private/api/prom/alerts"
+	alertManagerConfigEndpoint        = "/api/prom/configs/alertmanager"
+	alertManagerConfigPrivateEndpoint = "/private/api/prom/configs/alertmanager"
 )
 
 var (
-	rulesClient       = configurable{rulesEndpoint, rulesPrivateEndpoint}
-	alertConfigClient = configurable{alertConfigEndpoint, alertConfigPrivateEndpoint}
+	rulesClient              = configurable{rulesEndpoint, rulesPrivateEndpoint}
+	alertManagerConfigClient = configurable{alertManagerConfigEndpoint, alertManagerConfigPrivateEndpoint}
 
-	allClients = []configurable{rulesClient, alertConfigClient}
+	allClients = []configurable{rulesClient, alertManagerConfigClient}
 )
 
 // The root page returns 200 OK.

--- a/configs/api/api_test.go
+++ b/configs/api/api_test.go
@@ -14,8 +14,18 @@ import (
 )
 
 const (
-	endpoint        = "/api/configs/org/cortex"
-	privateEndpoint = "/private/api/configs/org/cortex"
+	rulesEndpoint        = "/api/prom/rules"
+	rulesPrivateEndpoint = "/private/api/prom/rules"
+
+	alertConfigEndpoint        = "/api/prom/alerts"
+	alertConfigPrivateEndpoint = "/private/api/prom/alerts"
+)
+
+var (
+	rulesClient       = configurable{rulesEndpoint, rulesPrivateEndpoint}
+	alertConfigClient = configurable{alertConfigEndpoint, alertConfigPrivateEndpoint}
+
+	allClients = []configurable{rulesClient, alertConfigClient}
 )
 
 // The root page returns 200 OK.
@@ -27,16 +37,21 @@ func Test_Root_OK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// postConfig posts a config.
-func postConfig(t *testing.T, userID string, config configs.Config) configs.ConfigView {
-	w := requestAsUser(t, userID, "POST", endpoint, jsonObject(config).Reader(t))
-	require.Equal(t, http.StatusNoContent, w.Code)
-	return getConfig(t, userID)
+type configurable struct {
+	Endpoint        string
+	PrivateEndpoint string
 }
 
-// getConfig gets a config.
-func getConfig(t *testing.T, userID string) configs.ConfigView {
-	w := requestAsUser(t, userID, "GET", endpoint, nil)
+// post a config
+func (c configurable) post(t *testing.T, userID string, config configs.Config) configs.ConfigView {
+	w := requestAsUser(t, userID, "POST", c.Endpoint, jsonObject(config).Reader(t))
+	require.Equal(t, http.StatusNoContent, w.Code)
+	return c.get(t, userID)
+}
+
+// get a config
+func (c configurable) get(t *testing.T, userID string) configs.ConfigView {
+	w := requestAsUser(t, userID, "GET", c.Endpoint, nil)
 	return parseConfigView(t, w.Body.Bytes())
 }
 
@@ -45,18 +60,22 @@ func Test_GetConfig_Anonymous(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	w := request(t, "GET", endpoint, nil)
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	for _, c := range allClients {
+		w := request(t, "GET", c.Endpoint, nil)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	}
 }
 
-// configs returns 404 if there's no such subsystem.
+// configs returns 404 if no config has been created yet.
 func Test_GetConfig_NotFound(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
 	userID := makeUserID()
-	w := requestAsUser(t, userID, "GET", endpoint, nil)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	for _, c := range allClients {
+		w := requestAsUser(t, userID, "GET", c.Endpoint, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	}
 }
 
 // configs returns 401 to requests without authentication.
@@ -64,8 +83,10 @@ func Test_PostConfig_Anonymous(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	w := request(t, "POST", endpoint, nil)
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	for _, c := range allClients {
+		w := request(t, "POST", c.Endpoint, nil)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	}
 }
 
 // Posting to a configuration sets it so that you can get it again.
@@ -76,13 +97,15 @@ func Test_PostConfig_CreatesConfig(t *testing.T) {
 	userID := makeUserID()
 	config := makeConfig()
 	content := jsonObject(config)
-	{
-		w := requestAsUser(t, userID, "POST", endpoint, content.Reader(t))
-		assert.Equal(t, http.StatusNoContent, w.Code)
-	}
-	{
-		w := requestAsUser(t, userID, "GET", endpoint, nil)
-		assert.Equal(t, config, parseConfigView(t, w.Body.Bytes()).Config)
+	for _, c := range allClients {
+		{
+			w := requestAsUser(t, userID, "POST", c.Endpoint, content.Reader(t))
+			assert.Equal(t, http.StatusNoContent, w.Code)
+		}
+		{
+			w := requestAsUser(t, userID, "GET", c.Endpoint, nil)
+			assert.Equal(t, config, parseConfigView(t, w.Body.Bytes()).Config)
+		}
 	}
 }
 
@@ -92,11 +115,13 @@ func Test_PostConfig_UpdatesConfig(t *testing.T) {
 	defer cleanup(t)
 
 	userID := makeUserID()
-	view1 := postConfig(t, userID, makeConfig())
-	config2 := makeConfig()
-	view2 := postConfig(t, userID, config2)
-	assert.True(t, view2.ID > view1.ID, "%v > %v", view2.ID, view1.ID)
-	assert.Equal(t, config2, view2.Config)
+	for _, c := range allClients {
+		view1 := c.post(t, userID, makeConfig())
+		config2 := makeConfig()
+		view2 := c.post(t, userID, config2)
+		assert.True(t, view2.ID > view1.ID, "%v > %v", view2.ID, view1.ID)
+		assert.Equal(t, config2, view2.Config)
+	}
 }
 
 // Different users can have different configurations.
@@ -106,14 +131,15 @@ func Test_PostConfig_MultipleUsers(t *testing.T) {
 
 	userID1 := makeUserID()
 	userID2 := makeUserID()
-	config1 := postConfig(t, userID1, makeConfig())
-	config2 := postConfig(t, userID2, makeConfig())
-
-	foundConfig1 := getConfig(t, userID1)
-	assert.Equal(t, config1, foundConfig1)
-	foundConfig2 := getConfig(t, userID2)
-	assert.Equal(t, config2, foundConfig2)
-	assert.True(t, config2.ID > config1.ID, "%v > %v", config2.ID, config1.ID)
+	for _, c := range allClients {
+		config1 := c.post(t, userID1, makeConfig())
+		config2 := c.post(t, userID2, makeConfig())
+		foundConfig1 := c.get(t, userID1)
+		assert.Equal(t, config1, foundConfig1)
+		foundConfig2 := c.get(t, userID2)
+		assert.Equal(t, config2, foundConfig2)
+		assert.True(t, config2.ID > config1.ID, "%v > %v", config2.ID, config1.ID)
+	}
 }
 
 // GetAllConfigs returns an empty list of configs if there aren't any.
@@ -121,12 +147,14 @@ func Test_GetAllConfigs_Empty(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	w := request(t, "GET", privateEndpoint, nil)
-	assert.Equal(t, http.StatusOK, w.Code)
-	var found api.ConfigsView
-	err := json.Unmarshal(w.Body.Bytes(), &found)
-	assert.NoError(t, err, "Could not unmarshal JSON")
-	assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{}}, found)
+	for _, c := range allClients {
+		w := request(t, "GET", c.PrivateEndpoint, nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var found api.ConfigsView
+		err := json.Unmarshal(w.Body.Bytes(), &found)
+		assert.NoError(t, err, "Could not unmarshal JSON")
+		assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{}}, found)
+	}
 }
 
 // GetAllConfigs returns all created configs.
@@ -136,15 +164,18 @@ func Test_GetAllConfigs(t *testing.T) {
 
 	userID := makeUserID()
 	config := makeConfig()
-	view := postConfig(t, userID, config)
-	w := request(t, "GET", privateEndpoint, nil)
-	assert.Equal(t, http.StatusOK, w.Code)
-	var found api.ConfigsView
-	err := json.Unmarshal(w.Body.Bytes(), &found)
-	assert.NoError(t, err, "Could not unmarshal JSON")
-	assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
-		userID: view,
-	}}, found)
+
+	for _, c := range allClients {
+		view := c.post(t, userID, config)
+		w := request(t, "GET", c.PrivateEndpoint, nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var found api.ConfigsView
+		err := json.Unmarshal(w.Body.Bytes(), &found)
+		assert.NoError(t, err, "Could not unmarshal JSON")
+		assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
+			userID: view,
+		}}, found)
+	}
 }
 
 // GetAllConfigs returns the *newest* versions of all created configs.
@@ -153,35 +184,40 @@ func Test_GetAllConfigs_Newest(t *testing.T) {
 	defer cleanup(t)
 
 	userID := makeUserID()
-	postConfig(t, userID, makeConfig())
-	postConfig(t, userID, makeConfig())
-	lastCreated := postConfig(t, userID, makeConfig())
 
-	w := request(t, "GET", privateEndpoint, nil)
-	assert.Equal(t, http.StatusOK, w.Code)
-	var found api.ConfigsView
-	err := json.Unmarshal(w.Body.Bytes(), &found)
-	assert.NoError(t, err, "Could not unmarshal JSON")
-	assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
-		userID: lastCreated,
-	}}, found)
+	for _, c := range allClients {
+		c.post(t, userID, makeConfig())
+		c.post(t, userID, makeConfig())
+		lastCreated := c.post(t, userID, makeConfig())
+
+		w := request(t, "GET", c.PrivateEndpoint, nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var found api.ConfigsView
+		err := json.Unmarshal(w.Body.Bytes(), &found)
+		assert.NoError(t, err, "Could not unmarshal JSON")
+		assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
+			userID: lastCreated,
+		}}, found)
+	}
 }
 
 func Test_GetConfigs_IncludesNewerConfigsAndExcludesOlder(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	postConfig(t, makeUserID(), makeConfig())
-	config2 := postConfig(t, makeUserID(), makeConfig())
-	userID3 := makeUserID()
-	config3 := postConfig(t, userID3, makeConfig())
+	for _, c := range allClients {
+		c.post(t, makeUserID(), makeConfig())
+		config2 := c.post(t, makeUserID(), makeConfig())
+		userID3 := makeUserID()
+		config3 := c.post(t, userID3, makeConfig())
 
-	w := request(t, "GET", fmt.Sprintf("%s?since=%d", privateEndpoint, config2.ID), nil)
-	assert.Equal(t, http.StatusOK, w.Code)
-	var found api.ConfigsView
-	err := json.Unmarshal(w.Body.Bytes(), &found)
-	assert.NoError(t, err, "Could not unmarshal JSON")
-	assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
-		userID3: config3,
-	}}, found)
+		w := request(t, "GET", fmt.Sprintf("%s?since=%d", c.PrivateEndpoint, config2.ID), nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+		var found api.ConfigsView
+		err := json.Unmarshal(w.Body.Bytes(), &found)
+		assert.NoError(t, err, "Could not unmarshal JSON")
+		assert.Equal(t, api.ConfigsView{Configs: map[string]configs.ConfigView{
+			userID3: config3,
+		}}, found)
+	}
 }

--- a/configs/client/configs.go
+++ b/configs/client/configs.go
@@ -120,20 +120,20 @@ func getConfigs(endpoint string, timeout time.Duration, since ConfigID) (*Cortex
 	return configsFromJSON(res.Body)
 }
 
-// AlertConfigsAPI allows retrieving alert configs.
-type AlertConfigsAPI struct {
+// AlertManagerConfigsAPI allows retrieving alert configs.
+type AlertManagerConfigsAPI struct {
 	URL     *url.URL
 	Timeout time.Duration
 }
 
 // GetConfigs returns all Cortex configurations from a configs API server
 // that have been updated after the given ConfigID was last updated.
-func (c *AlertConfigsAPI) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
+func (c *AlertManagerConfigsAPI) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
 	suffix := ""
 	if since != 0 {
 		suffix = fmt.Sprintf("?since=%d", since)
 	}
-	endpoint := fmt.Sprintf("%s/private/api/prom/alerts%s", c.URL.String(), suffix)
+	endpoint := fmt.Sprintf("%s/private/api/prom/configs/alertmanager%s", c.URL.String(), suffix)
 	return getConfigs(endpoint, c.Timeout, since)
 }
 
@@ -150,6 +150,6 @@ func (c *RulesAPI) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
 	if since != 0 {
 		suffix = fmt.Sprintf("?since=%d", since)
 	}
-	endpoint := fmt.Sprintf("%s/private/api/prom/rules%s", c.URL.String(), suffix)
+	endpoint := fmt.Sprintf("%s/private/api/prom/configs/rules%s", c.URL.String(), suffix)
 	return getConfigs(endpoint, c.Timeout, since)
 }

--- a/configs/client/configs.go
+++ b/configs/client/configs.go
@@ -103,25 +103,12 @@ func (c CortexConfig) GetAlertmanagerConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-// API allows retrieving Cortex configs.
-type API struct {
-	URL     *url.URL
-	Timeout time.Duration
-}
-
-// GetConfigs returns all Cortex configurations from a configs API server
-// that have been updated after the given ConfigID was last updated.
-func (c *API) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
-	suffix := ""
-	if since != 0 {
-		suffix = fmt.Sprintf("?since=%d", since)
-	}
-	url := fmt.Sprintf("%s/private/api/configs/org/cortex%s", c.URL.String(), suffix)
-	req, err := http.NewRequest("GET", url, nil)
+func getConfigs(endpoint string, timeout time.Duration, since ConfigID) (*CortexConfigsResponse, error) {
+	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: c.Timeout}
+	client := &http.Client{Timeout: timeout}
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -131,4 +118,38 @@ func (c *API) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
 		return nil, fmt.Errorf("Invalid response from configs server: %v", res.StatusCode)
 	}
 	return configsFromJSON(res.Body)
+}
+
+// AlertConfigsAPI allows retrieving alert configs.
+type AlertConfigsAPI struct {
+	URL     *url.URL
+	Timeout time.Duration
+}
+
+// GetConfigs returns all Cortex configurations from a configs API server
+// that have been updated after the given ConfigID was last updated.
+func (c *AlertConfigsAPI) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
+	suffix := ""
+	if since != 0 {
+		suffix = fmt.Sprintf("?since=%d", since)
+	}
+	endpoint := fmt.Sprintf("%s/private/api/prom/alerts%s", c.URL.String(), suffix)
+	return getConfigs(endpoint, c.Timeout, since)
+}
+
+// RulesAPI allows retrieving recording and alerting rules.
+type RulesAPI struct {
+	URL     *url.URL
+	Timeout time.Duration
+}
+
+// GetConfigs returns all Cortex configurations from a configs API server
+// that have been updated after the given ConfigID was last updated.
+func (c *RulesAPI) GetConfigs(since ConfigID) (*CortexConfigsResponse, error) {
+	suffix := ""
+	if since != 0 {
+		suffix = fmt.Sprintf("?since=%d", since)
+	}
+	endpoint := fmt.Sprintf("%s/private/api/prom/rules%s", c.URL.String(), suffix)
+	return getConfigs(endpoint, c.Timeout, since)
 }

--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -252,7 +252,7 @@ type Server struct {
 
 // NewServer makes a new rule processing server.
 func NewServer(cfg Config, ruler *Ruler) (*Server, error) {
-	c := configs.API{
+	c := configs.RulesAPI{
 		URL:     cfg.ConfigsAPIURL.URL,
 		Timeout: cfg.ClientTimeout,
 	}

--- a/ruler/scheduler.go
+++ b/ruler/scheduler.go
@@ -62,7 +62,7 @@ func (w workItem) Defer(interval time.Duration) workItem {
 }
 
 type scheduler struct {
-	configsAPI         configs.API // XXX: Maybe make this an interface ConfigSource or similar.
+	configsAPI         configs.RulesAPI
 	evaluationInterval time.Duration
 	q                  *SchedulingQueue
 
@@ -79,7 +79,7 @@ type scheduler struct {
 }
 
 // newScheduler makes a new scheduler.
-func newScheduler(configsAPI configs.API, evaluationInterval, pollInterval time.Duration) scheduler {
+func newScheduler(configsAPI configs.RulesAPI, evaluationInterval, pollInterval time.Duration) scheduler {
 	return scheduler{
 		configsAPI:         configsAPI,
 		evaluationInterval: evaluationInterval,


### PR DESCRIPTION
No behavioural changes to the API (as much as I'd like to). Instead, fairly mechanically create new endpoints—public and private—and update the internal clients of the private endpoints to use the new one.

Thus:

* `/api/configs/org/cortex` becomes `/api/prom/rules` and `/api/prom/alerts` (although the old endpoint is still around to help with backwards compatibility)
* `/private/api/configs/org/cortex` becomes `/private/api/prom/rules` and `/private/api/prom/alerts`

I want to change the private APIs to be gRPC, but I also want to change the semantics of the rules config API, which I think is best reserved for a separate change.

@davkal You should probably be aware that this PR deprecates the old `/api/configs/org/cortex` route.