### PR TITLE
V6 Schema: actually set RangeValueStart to the start of the time range

### DIFF
--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -627,34 +627,34 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 }
 
 func (v6Entries) GetReadMetricEntries(from, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(from)
+	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
 			HashValue:       hashKey,
-			RangeValueStart: buildRangeKey(encodedThroughBytes),
+			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
 
 func (v6Entries) GetReadMetricLabelEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(from)
+	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
 			HashValue:       hashKey + ":" + string(labelName),
-			RangeValueStart: buildRangeKey(encodedThroughBytes),
+			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
 
 func (v6Entries) GetReadMetricLabelValueEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(from)
+	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
 			HashValue:       hashKey + ":" + string(labelName),
-			RangeValueStart: buildRangeKey(encodedThroughBytes),
+			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
 }

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -626,35 +626,35 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 	return entries, nil
 }
 
-func (v6Entries) GetReadMetricEntries(_, through uint32, tableName, hashKey string) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(through)
+func (v6Entries) GetReadMetricEntries(from, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
+	encodedThroughBytes := encodeTime(from)
 	return []IndexEntry{
 		{
-			TableName:  tableName,
-			HashValue:  hashKey,
-			RangeValue: buildRangeKey(encodedThroughBytes),
+			TableName:       tableName,
+			HashValue:       hashKey,
+			RangeValueStart: buildRangeKey(encodedThroughBytes),
 		},
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelEntries(_, through uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(through)
+func (v6Entries) GetReadMetricLabelEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+	encodedThroughBytes := encodeTime(from)
 	return []IndexEntry{
 		{
-			TableName:  tableName,
-			HashValue:  hashKey + ":" + string(labelName),
-			RangeValue: buildRangeKey(encodedThroughBytes),
+			TableName:       tableName,
+			HashValue:       hashKey + ":" + string(labelName),
+			RangeValueStart: buildRangeKey(encodedThroughBytes),
 		},
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelValueEntries(_, through uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
-	encodedThroughBytes := encodeTime(through)
+func (v6Entries) GetReadMetricLabelValueEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+	encodedThroughBytes := encodeTime(from)
 	return []IndexEntry{
 		{
-			TableName:  tableName,
-			HashValue:  hashKey + ":" + string(labelName),
-			RangeValue: buildRangeKey(encodedThroughBytes),
+			TableName:       tableName,
+			HashValue:       hashKey + ":" + string(labelName),
+			RangeValueStart: buildRangeKey(encodedThroughBytes),
 		},
 	}, nil
 }


### PR DESCRIPTION
So we don't fetch too much from DynamoDB.

Didn't affect data we wrote or query correctness - only made DynamoDB queries slower.