### PR TITLE
Fix mutation bug in ExtractMetricNameFromMatchers()

### DIFF
--- a/util/matchers.go
+++ b/util/matchers.go
@@ -31,6 +31,7 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 
 // ExtractMetricNameFromMatchers extracts the metric name from a set of matchers
 func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, error) {
+	outMatchers := make([]*metric.LabelMatcher, len(matchers)-1)
 	for i, matcher := range matchers {
 		if matcher.Name != model.MetricNameLabel {
 			continue
@@ -39,8 +40,9 @@ func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.Label
 			return "", nil, fmt.Errorf("must have equality matcher for MetricNameLabel")
 		}
 		metricName := matcher.Value
-		matchers = matchers[:i+copy(matchers[i:], matchers[i+1:])]
-		return metricName, matchers, nil
+		copy(outMatchers, matchers[:i])
+		copy(outMatchers[i:], matchers[i+1:])
+		return metricName, outMatchers, nil
 	}
 	return "", nil, fmt.Errorf("no matcher for MetricNameLabel")
 }

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+func TestExtractMetricNameFromMatchers(t *testing.T) {
+	metricMatcher, err := metric.NewLabelMatcher(metric.Equal, model.MetricNameLabel, "testmetric")
+	if err != nil {
+		t.Fatal(err)
+	}
+	labelMatcher1, err := metric.NewLabelMatcher(metric.Equal, "label", "value1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	labelMatcher2, err := metric.NewLabelMatcher(metric.Equal, "label", "value2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := [][]*metric.LabelMatcher{
+		{metricMatcher, labelMatcher1, labelMatcher2},
+		{labelMatcher1, metricMatcher, labelMatcher2},
+		{labelMatcher1, labelMatcher2, metricMatcher},
+	}
+
+	for i, matchers := range tests {
+		matchersCopy := make([]*metric.LabelMatcher, len(matchers))
+		copy(matchersCopy, matchers)
+
+		name, outMatchers, err := ExtractMetricNameFromMatchers(matchers)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(matchers, matchersCopy) {
+			t.Fatalf("%d. Matchers got mutated; want %v, got %v", i, matchersCopy, matchers)
+		}
+
+		if name != "testmetric" {
+			t.Fatalf("%d. Wrong metric name; want 'testmetric', got %q", i, name)
+		}
+
+		expOutMatchers := []*metric.LabelMatcher{labelMatcher1, labelMatcher2}
+		if !reflect.DeepEqual(expOutMatchers, outMatchers) {
+			t.Fatalf("%d. Unexpected outMatchers; want %v, got %v", i, expOutMatchers, outMatchers)
+		}
+	}
+}

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/metric"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractMetricNameFromMatchers(t *testing.T) {
@@ -46,8 +47,6 @@ func TestExtractMetricNameFromMatchers(t *testing.T) {
 		}
 
 		expOutMatchers := []*metric.LabelMatcher{labelMatcher1, labelMatcher2}
-		if !reflect.DeepEqual(expOutMatchers, outMatchers) {
-			t.Fatalf("%d. Unexpected outMatchers; want %v, got %v", i, expOutMatchers, outMatchers)
-		}
+		assert.Equal(t, expOutMatchers, outMatchers, "unexpected outMatchers for test case %d", i)
 	}
 }


### PR DESCRIPTION
The passed-in matchers slice got mutated by the copies, leading to the
metric name being removed from the original matchers *iff* the metric
name was not the last element in the slice already. By pure luck, PromQL
only creates LabelMatcher lists where the metric name is the last
element. But in my remote query testing, I ended up constructing
matchers with the metric name somewhere in the middle. The result was
that the metric name was removed from the matchers and all kinds of
metrics (not just the ones for the right metric name) were being
returned for a query.