### PR TITLE
Add Prometheus remote read support

### DIFF
--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	subrouter := server.HTTP.PathPrefix("/api/prom").Subrouter()
 	subrouter.PathPrefix("/api/v1").Handler(middleware.AuthenticateUser.Wrap(promRouter))
-	subrouter.Path("/remote_read").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(queryable.Q.RemoteReadHandler)))
+	subrouter.Path("/read").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(queryable.Q.RemoteReadHandler)))
 	subrouter.Path("/validate_expr").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(dist.ValidateExprHandler)))
 	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(dist.UserStatsHandler)))
 

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -88,6 +88,7 @@ func main() {
 
 	subrouter := server.HTTP.PathPrefix("/api/prom").Subrouter()
 	subrouter.PathPrefix("/api/v1").Handler(middleware.AuthenticateUser.Wrap(promRouter))
+	subrouter.Path("/remote_read").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(queryable.Q.RemoteReadHandler)))
 	subrouter.Path("/validate_expr").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(dist.ValidateExprHandler)))
 	subrouter.Path("/user_stats").Handler(middleware.AuthenticateUser.Wrap(http.HandlerFunc(dist.UserStatsHandler)))
 

--- a/cortex.proto
+++ b/cortex.proto
@@ -24,6 +24,14 @@ message WriteRequest {
 
 message WriteResponse {}
 
+message ReadRequest {
+  repeated QueryRequest queries = 1;
+}
+
+message ReadResponse {
+  repeated TimeSeries timeseries = 1;
+}
+
 message QueryRequest {
   int64 start_timestamp_ms = 1;
   int64 end_timestamp_ms = 2;

--- a/distributor/http_server.go
+++ b/distributor/http_server.go
@@ -17,7 +17,7 @@ import (
 // PushHandler is a http.Handler which accepts WriteRequests.
 func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 	var req cortex.WriteRequest
-	if err := util.ParseProtoRequest(r.Context(), w, r, &req, true); err != nil {
+	if err := util.ParseProtoRequest(r.Context(), r, &req, true); err != nil {
 		log.Errorf(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/weaveworks/cortex"
 	"github.com/weaveworks/cortex/chunk"
-	"github.com/weaveworks/cortex/distributor"
 	"github.com/weaveworks/cortex/util"
 )
 
@@ -205,7 +204,7 @@ func (qm MergeQuerier) Close() error {
 func (qm MergeQuerier) RemoteReadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var req cortex.ReadRequest
-	if err := distributor.ParseProtoRequest(ctx, w, r, &req, true); err != nil {
+	if err := util.ParseProtoRequest(ctx, w, r, &req, true); err != nil {
 		log.Errorf(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/util/http.go
+++ b/util/http.go
@@ -1,8 +1,15 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/weaveworks/common/instrument"
+	"golang.org/x/net/context"
 )
 
 // WriteJSONResponse writes some JSON as a HTTP response.
@@ -17,4 +24,28 @@ func WriteJSONResponse(w http.ResponseWriter, v interface{}) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+}
+
+// ParseProtoRequest parses a proto from the body of a http request.
+func ParseProtoRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, req proto.Message, compressed bool) error {
+	var reader io.Reader = r.Body
+	if compressed {
+		reader = snappy.NewReader(r.Body)
+	}
+
+	buf := bytes.Buffer{}
+	if err := instrument.TimeRequestHistogram(ctx, "Distributor.PushHandler[decompress]", nil, func(_ context.Context) error {
+		_, err := buf.ReadFrom(reader)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	if err := instrument.TimeRequestHistogram(ctx, "Distributor.PushHandler[unmarshall]", nil, func(_ context.Context) error {
+		return proto.Unmarshal(buf.Bytes(), req)
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/util/http.go
+++ b/util/http.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -26,26 +27,47 @@ func WriteJSONResponse(w http.ResponseWriter, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
-// ParseProtoRequest parses a proto from the body of a http request.
-func ParseProtoRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, req proto.Message, compressed bool) error {
+// ParseProtoRequest parses a proto from the body of an HTTP request.
+func ParseProtoRequest(ctx context.Context, r *http.Request, req proto.Message, compressed bool) error {
 	var reader io.Reader = r.Body
 	if compressed {
 		reader = snappy.NewReader(r.Body)
 	}
 
 	buf := bytes.Buffer{}
-	if err := instrument.TimeRequestHistogram(ctx, "Distributor.PushHandler[decompress]", nil, func(_ context.Context) error {
+	if err := instrument.TimeRequestHistogram(ctx, "util.ParseProtoRequest[decompress]", nil, func(_ context.Context) error {
 		_, err := buf.ReadFrom(reader)
 		return err
 	}); err != nil {
 		return err
 	}
 
-	if err := instrument.TimeRequestHistogram(ctx, "Distributor.PushHandler[unmarshall]", nil, func(_ context.Context) error {
+	if err := instrument.TimeRequestHistogram(ctx, "util.ParseProtoRequest[unmarshal]", nil, func(_ context.Context) error {
 		return proto.Unmarshal(buf.Bytes(), req)
 	}); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// SerializeProtoResponse serializes a protobuf response into an HTTP response.
+func SerializeProtoResponse(w http.ResponseWriter, resp proto.Message) error {
+	data, err := proto.Marshal(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return fmt.Errorf("error marshaling proto response: %v", err)
+	}
+
+	buf := bytes.Buffer{}
+	if _, err := snappy.NewWriter(&buf).Write(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return fmt.Errorf("error compressing proto response: %v", err)
+	}
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return fmt.Errorf("error sending proto response: %v", err)
+	}
 	return nil
 }


### PR DESCRIPTION
This allows querying Cortex via Prometheus's new generic remote read
protocol.

See https://github.com/prometheus/prometheus/pull/2499

Fixes https://github.com/weaveworks/cortex/issues/226