### PR TITLE
Add context to table manager interface

### DIFF
--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -353,7 +353,7 @@ func newDynamoTableClient(cfg DynamoDBConfig) (DynamoTableClient, error) {
 	}, nil
 }
 
-func (d dynamoTableClient) ListTables() ([]string, error) {
+func (d dynamoTableClient) ListTables(ctx context.Context) ([]string, error) {
 	table := []string{}
 	if err := d.DynamoDB.ListTablesPages(&dynamodb.ListTablesInput{}, func(resp *dynamodb.ListTablesOutput, _ bool) bool {
 		for _, s := range resp.TableNames {
@@ -366,7 +366,7 @@ func (d dynamoTableClient) ListTables() ([]string, error) {
 	return table, nil
 }
 
-func (d dynamoTableClient) CreateTable(name string, readCapacity, writeCapacity int64) error {
+func (d dynamoTableClient) CreateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
 	input := &dynamodb.CreateTableInput{
 		TableName: aws.String(name),
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
@@ -398,7 +398,7 @@ func (d dynamoTableClient) CreateTable(name string, readCapacity, writeCapacity 
 	return err
 }
 
-func (d dynamoTableClient) DescribeTable(name string) (readCapacity, writeCapacity int64, status string, err error) {
+func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error) {
 	out, err := d.DynamoDB.DescribeTable(&dynamodb.DescribeTableInput{
 		TableName: aws.String(name),
 	})
@@ -409,7 +409,7 @@ func (d dynamoTableClient) DescribeTable(name string) (readCapacity, writeCapaci
 	return *out.Table.ProvisionedThroughput.ReadCapacityUnits, *out.Table.ProvisionedThroughput.WriteCapacityUnits, *out.Table.TableStatus, nil
 }
 
-func (d dynamoTableClient) UpdateTable(name string, readCapacity, writeCapacity int64) error {
+func (d dynamoTableClient) UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
 	_, err := d.DynamoDB.UpdateTable(&dynamodb.UpdateTableInput{
 		TableName: aws.String(name),
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -51,7 +51,7 @@ func (m *MockStorage) ListTables(_ context.Context) ([]string, error) {
 }
 
 // CreateTable implements StorageClient.
-func (m *MockStorage) CreateTable(ctx context.Context, name string, read, write int64) error {
+func (m *MockStorage) CreateTable(_ context.Context, name string, read, write int64) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -69,7 +69,7 @@ func (m *MockStorage) CreateTable(ctx context.Context, name string, read, write 
 }
 
 // DescribeTable implements StorageClient.
-func (m *MockStorage) DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error) {
+func (m *MockStorage) DescribeTable(_ context.Context, name string) (readCapacity, writeCapacity int64, status string, err error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -82,7 +82,7 @@ func (m *MockStorage) DescribeTable(ctx context.Context, name string) (readCapac
 }
 
 // UpdateTable implements StorageClient.
-func (m *MockStorage) UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
+func (m *MockStorage) UpdateTable(_ context.Context, name string, readCapacity, writeCapacity int64) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -103,7 +103,7 @@ func (m *MockStorage) NewWriteBatch() WriteBatch {
 }
 
 // BatchWrite implements StorageClient.
-func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
+func (m *MockStorage) BatchWrite(_ context.Context, batch WriteBatch) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -138,7 +138,7 @@ func (m *MockStorage) BatchWrite(ctx context.Context, batch WriteBatch) error {
 }
 
 // QueryPages implements StorageClient.
-func (m *MockStorage) QueryPages(ctx context.Context, entry IndexEntry, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
+func (m *MockStorage) QueryPages(_ context.Context, entry IndexEntry, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -37,7 +37,7 @@ func NewMockStorage() *MockStorage {
 }
 
 // ListTables implements StorageClient.
-func (m *MockStorage) ListTables(ctx context.Context) ([]string, error) {
+func (m *MockStorage) ListTables(_ context.Context) ([]string, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -37,7 +37,7 @@ func NewMockStorage() *MockStorage {
 }
 
 // ListTables implements StorageClient.
-func (m *MockStorage) ListTables() ([]string, error) {
+func (m *MockStorage) ListTables(ctx context.Context) ([]string, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -51,7 +51,7 @@ func (m *MockStorage) ListTables() ([]string, error) {
 }
 
 // CreateTable implements StorageClient.
-func (m *MockStorage) CreateTable(name string, read, write int64) error {
+func (m *MockStorage) CreateTable(ctx context.Context, name string, read, write int64) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -69,7 +69,7 @@ func (m *MockStorage) CreateTable(name string, read, write int64) error {
 }
 
 // DescribeTable implements StorageClient.
-func (m *MockStorage) DescribeTable(name string) (readCapacity, writeCapacity int64, status string, err error) {
+func (m *MockStorage) DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -82,7 +82,7 @@ func (m *MockStorage) DescribeTable(name string) (readCapacity, writeCapacity in
 }
 
 // UpdateTable implements StorageClient.
-func (m *MockStorage) UpdateTable(name string, readCapacity, writeCapacity int64) error {
+func (m *MockStorage) UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 

--- a/chunk/table_manager.go
+++ b/chunk/table_manager.go
@@ -282,12 +282,8 @@ func (m *DynamoTableManager) calculateExpectedTables() []tableDescription {
 
 // partitionTables works out tables that need to be created vs tables that need to be updated
 func (m *DynamoTableManager) partitionTables(ctx context.Context, descriptions []tableDescription) ([]tableDescription, []tableDescription, error) {
-	var existingTables []string
-	if err := instrument.TimeRequestHistogram(ctx, "DynamoDB.ListTablesPages", dynamoRequestDuration, func(_ context.Context) error {
-		var err error
-		existingTables, err = m.dynamoDB.ListTables(ctx)
-		return err
-	}); err != nil {
+	existingTables, err := m.dynamoDB.ListTables(ctx)
+	if err != nil {
 		return nil, nil, err
 	}
 	sort.Strings(existingTables)
@@ -319,9 +315,8 @@ func (m *DynamoTableManager) partitionTables(ctx context.Context, descriptions [
 func (m *DynamoTableManager) createTables(ctx context.Context, descriptions []tableDescription) error {
 	for _, desc := range descriptions {
 		log.Infof("Creating table %s", desc.name)
-		if err := instrument.TimeRequestHistogram(ctx, "DynamoDB.CreateTable", dynamoRequestDuration, func(_ context.Context) error {
-			return m.dynamoDB.CreateTable(ctx, desc.name, desc.provisionedRead, desc.provisionedWrite)
-		}); err != nil {
+		err := m.dynamoDB.CreateTable(ctx, desc.name, desc.provisionedRead, desc.provisionedWrite)
+		if err != nil {
 			return err
 		}
 	}
@@ -331,13 +326,8 @@ func (m *DynamoTableManager) createTables(ctx context.Context, descriptions []ta
 func (m *DynamoTableManager) updateTables(ctx context.Context, descriptions []tableDescription) error {
 	for _, desc := range descriptions {
 		log.Infof("Checking provisioned throughput on table %s", desc.name)
-		var readCapacity, writeCapacity int64
-		var status string
-		if err := instrument.TimeRequestHistogram(ctx, "DynamoDB.DescribeTable", dynamoRequestDuration, func(_ context.Context) error {
-			var err error
-			readCapacity, writeCapacity, status, err = m.dynamoDB.DescribeTable(ctx, desc.name)
-			return err
-		}); err != nil {
+		readCapacity, writeCapacity, status, err := m.dynamoDB.DescribeTable(ctx, desc.name)
+		if err != nil {
 			return err
 		}
 
@@ -355,9 +345,8 @@ func (m *DynamoTableManager) updateTables(ctx context.Context, descriptions []ta
 		}
 
 		log.Infof("  Updating provisioned throughput on table %s to read = %d, write = %d", desc.name, desc.provisionedRead, desc.provisionedWrite)
-		if err := instrument.TimeRequestHistogram(ctx, "DynamoDB.DescribeTable", dynamoRequestDuration, func(_ context.Context) error {
-			return m.dynamoDB.UpdateTable(ctx, desc.name, desc.provisionedRead, desc.provisionedWrite)
-		}); err != nil {
+		err = m.dynamoDB.UpdateTable(ctx, desc.name, desc.provisionedRead, desc.provisionedWrite)
+		if err != nil {
 			return err
 		}
 	}

--- a/chunk/table_manager_test.go
+++ b/chunk/table_manager_test.go
@@ -50,11 +50,12 @@ func TestDynamoTableManager(t *testing.T) {
 
 	test := func(name string, tm time.Time, expected []tableDescription) {
 		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
 			mtime.NowForce(tm)
-			if err := tableManager.syncTables(context.Background()); err != nil {
+			if err := tableManager.syncTables(ctx); err != nil {
 				t.Fatal(err)
 			}
-			expectTables(t, dynamoDB, expected)
+			expectTables(ctx, t, dynamoDB, expected)
 		})
 	}
 
@@ -143,8 +144,8 @@ func TestDynamoTableManager(t *testing.T) {
 	)
 }
 
-func expectTables(t *testing.T, dynamo DynamoTableClient, expected []tableDescription) {
-	tables, err := dynamo.ListTables()
+func expectTables(ctx context.Context, t *testing.T, dynamo DynamoTableClient, expected []tableDescription) {
+	tables, err := dynamo.ListTables(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +162,7 @@ func expectTables(t *testing.T, dynamo DynamoTableClient, expected []tableDescri
 			t.Fatalf("Expected '%s', found '%s'", desc.name, tables[i])
 		}
 
-		read, write, _, err := dynamo.DescribeTable(desc.name)
+		read, write, _, err := dynamo.DescribeTable(ctx, desc.name)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Move instrumentation to the dynamo table manager client.

This came up in #357.
