### PR TITLE
Fix ruler userID injection regression

### DIFF
--- a/ruler/ruler.go
+++ b/ruler/ruler.go
@@ -199,6 +199,10 @@ func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Notifier, error) {
 	n = notifier.New(&notifier.Options{
 		QueueCapacity: r.queueCapacity,
 		Do: func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+			// Note: The passed-in context comes from the Prometheus rule group code
+			// and does *not* contain the userID. So it needs to be added to the context
+			// here before using the context to inject the userID into the HTTP request.
+			ctx = user.Inject(ctx, userID)
 			if err := user.InjectIntoHTTPRequest(ctx, req); err != nil {
 				return nil, err
 			}

--- a/ruler/ruler_test.go
+++ b/ruler/ruler_test.go
@@ -1,0 +1,54 @@
+package ruler
+
+import (
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/common/user"
+)
+
+func newTestRuler(t *testing.T, alertmanagerURL string) *Ruler {
+	var cfg Config
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlags(fs)
+	fs.Parse(nil)
+	cfg.AlertmanagerURL = alertmanagerURL
+
+	// TODO: Populate distributor and chunk store arguments to enable
+	// other kinds of tests.
+	ruler, err := NewRuler(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ruler
+}
+
+func TestNotifierSendsUserIDHeader(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1) // We want one request to our test HTTP server.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, _, err := user.ExtractFromHTTPRequest(r)
+		assert.NoError(t, err)
+		assert.Equal(t, userID, "1")
+		wg.Done()
+	}))
+	defer ts.Close()
+
+	r := newTestRuler(t, ts.URL)
+	n, err := r.getOrCreateNotifier("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Stop()
+
+	n.Send(&model.Alert{
+		Labels: model.LabelSet{"alertname": "testalert"},
+	})
+
+	wg.Wait()
+}


### PR DESCRIPTION
https://github.com/weaveworks/cortex/pull/312 broke user ID handling for
the ruler alert notifications.