### PR TITLE
Say which table errored during query

### DIFF
--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -255,12 +255,12 @@ func (a awsStorageClient) QueryPages(ctx context.Context, entry IndexEntry, call
 				continue
 			}
 
-			return page.Error
+			return fmt.Errorf("QueryPages error: table=%v, err=%v", *input.TableName, page.Error)
 		}
 
 		queryOutput := page.Data.(*dynamodb.QueryOutput)
 		if getNextPage := callback(dynamoDBReadBatch(queryOutput.Items), !page.HasNextPage()); !getNextPage {
-			return page.Error
+			return fmt.Errorf("QueryPages error: table=%v, err=%v", *input.TableName, page.Error)
 		}
 
 		backoff = minBackoff


### PR DESCRIPTION
Can be useful when debugging issues such as "no such table".