### PR TITLE
Support queries with no metric name

### DIFF
--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -210,13 +210,13 @@ func (a awsStorageClient) BatchWrite(ctx context.Context, input WriteBatch) erro
 	return nil
 }
 
-func (a awsStorageClient) QueryPages(ctx context.Context, entry IndexEntry, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
+func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
 	input := &dynamodb.QueryInput{
-		TableName: aws.String(entry.TableName),
+		TableName: aws.String(query.TableName),
 		KeyConditions: map[string]*dynamodb.Condition{
 			hashKey: {
 				AttributeValueList: []*dynamodb.AttributeValue{
-					{S: aws.String(entry.HashValue)},
+					{S: aws.String(query.HashValue)},
 				},
 				ComparisonOperator: aws.String(dynamodb.ComparisonOperatorEq),
 			},
@@ -224,17 +224,17 @@ func (a awsStorageClient) QueryPages(ctx context.Context, entry IndexEntry, call
 		ReturnConsumedCapacity: aws.String(dynamodb.ReturnConsumedCapacityTotal),
 	}
 
-	if entry.RangeValuePrefix != nil {
+	if query.RangeValuePrefix != nil {
 		input.KeyConditions[rangeKey] = &dynamodb.Condition{
 			AttributeValueList: []*dynamodb.AttributeValue{
-				{B: entry.RangeValuePrefix},
+				{B: query.RangeValuePrefix},
 			},
 			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorBeginsWith),
 		}
-	} else if entry.RangeValueStart != nil {
+	} else if query.RangeValueStart != nil {
 		input.KeyConditions[rangeKey] = &dynamodb.Condition{
 			AttributeValueList: []*dynamodb.AttributeValue{
-				{B: entry.RangeValueStart},
+				{B: query.RangeValueStart},
 			},
 			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorGe),
 		}

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -150,7 +150,7 @@ func TestDynamoDBClient(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 30; i++ {
-		entry := IndexEntry{
+		entry := IndexQuery{
 			TableName: "table",
 			HashValue: fmt.Sprintf("hash%d", i),
 		}

--- a/chunk/by_key.go
+++ b/chunk/by_key.go
@@ -7,7 +7,8 @@ func (cs ByKey) Len() int           { return len(cs) }
 func (cs ByKey) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
 func (cs ByKey) Less(i, j int) bool { return cs[i].externalKey() < cs[j].externalKey() }
 
-// unique will remove duplicates from the input
+// unique will remove duplicates from the input.
+// list must be sorted.
 func unique(cs ByKey) ByKey {
 	if len(cs) == 0 {
 		return nil

--- a/chunk/by_key.go
+++ b/chunk/by_key.go
@@ -56,9 +56,9 @@ func merge(a, b ByKey) ByKey {
 	return result
 }
 
-// nWayMerge will merge and dedupe n lists of chunks.
+// nWayUnion will merge and dedupe n lists of chunks.
 // lists must be sorted and not contain dupes.
-func nWayMerge(sets []ByKey) ByKey {
+func nWayUnion(sets []ByKey) ByKey {
 	l := len(sets)
 	switch l {
 	case 0:
@@ -70,10 +70,10 @@ func nWayMerge(sets []ByKey) ByKey {
 	default:
 		var (
 			split = l / 2
-			left  = nWayMerge(sets[:split])
-			right = nWayMerge(sets[split:])
+			left  = nWayUnion(sets[:split])
+			right = nWayUnion(sets[split:])
 		)
-		return nWayMerge([]ByKey{left, right})
+		return nWayUnion([]ByKey{left, right})
 	}
 }
 

--- a/chunk/by_key.go
+++ b/chunk/by_key.go
@@ -55,6 +55,27 @@ func merge(a, b ByKey) ByKey {
 	return result
 }
 
+// nWayMerge will merge and dedupe n lists of chunks.
+// lists must be sorted and not contain dupes.
+func nWayMerge(sets []ByKey) ByKey {
+	l := len(sets)
+	switch l {
+	case 0:
+		return ByKey{}
+	case 1:
+		return sets[0]
+	case 2:
+		return merge(sets[0], sets[1])
+	default:
+		var (
+			split = l / 2
+			left  = nWayMerge(sets[:split])
+			right = nWayMerge(sets[split:])
+		)
+		return nWayIntersect([]ByKey{left, right})
+	}
+}
+
 // nWayIntersect will interesct n sorted lists of chunks.
 func nWayIntersect(sets []ByKey) ByKey {
 	l := len(sets)

--- a/chunk/by_key.go
+++ b/chunk/by_key.go
@@ -73,7 +73,7 @@ func nWayMerge(sets []ByKey) ByKey {
 			left  = nWayMerge(sets[:split])
 			right = nWayMerge(sets[split:])
 		)
-		return nWayIntersect([]ByKey{left, right})
+		return nWayMerge([]ByKey{left, right})
 	}
 }
 

--- a/chunk/by_key.go
+++ b/chunk/by_key.go
@@ -11,7 +11,7 @@ func (cs ByKey) Less(i, j int) bool { return cs[i].externalKey() < cs[j].externa
 // list must be sorted.
 func unique(cs ByKey) ByKey {
 	if len(cs) == 0 {
-		return nil
+		return ByKey{}
 	}
 
 	result := make(ByKey, 1, len(cs))

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -56,12 +56,12 @@ func TestNWayMerge(t *testing.T) {
 		want ByKey
 	}{
 		{nil, ByKey{}},
-		{[]ByKey{ByKey{c("a")}}, ByKey{c("a")}},
-		{[]ByKey{ByKey{c("a")}, ByKey{}}, ByKey{c("a")}},
-		{[]ByKey{ByKey{}, ByKey{c("b")}}, ByKey{c("b")}},
-		{[]ByKey{ByKey{c("a")}, ByKey{c("b")}}, ByKey{c("a"), c("b")}},
+		{[]ByKey{{c("a")}}, ByKey{c("a")}},
+		{[]ByKey{{c("a")}, {}}, ByKey{c("a")}},
+		{[]ByKey{{}, {c("b")}}, ByKey{c("b")}},
+		{[]ByKey{{c("a")}, {c("b")}}, ByKey{c("a"), c("b")}},
 		{
-			[]ByKey{ByKey{c("a"), c("c"), c("e")}, ByKey{c("c"), c("d")}, ByKey{c("b")}},
+			[]ByKey{{c("a"), c("c"), c("e")}, {c("c"), c("d")}, {c("b")}},
 			ByKey{c("a"), c("b"), c("c"), c("d"), c("e")},
 		},
 	} {

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -50,7 +50,7 @@ func TestMerge(t *testing.T) {
 	}
 }
 
-func TestNWayMerge(t *testing.T) {
+func TestNWayUnion(t *testing.T) {
 	for _, tc := range []struct {
 		in   []ByKey
 		want ByKey
@@ -65,7 +65,7 @@ func TestNWayMerge(t *testing.T) {
 			ByKey{c("a"), c("b"), c("c"), c("d"), c("e")},
 		},
 	} {
-		have := nWayMerge(tc.in)
+		have := nWayUnion(tc.in)
 		if !reflect.DeepEqual(have, tc.want) {
 			t.Errorf("%v != %v", have, tc.want)
 		}

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -50,6 +50,28 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestNWayMerge(t *testing.T) {
+	for _, tc := range []struct {
+		in   []ByKey
+		want ByKey
+	}{
+		{nil, ByKey{}},
+		{[]ByKey{ByKey{c("a")}}, ByKey{c("a")}},
+		{[]ByKey{ByKey{c("a")}, ByKey{}}, ByKey{c("a")}},
+		{[]ByKey{ByKey{}, ByKey{c("b")}}, ByKey{c("b")}},
+		{[]ByKey{ByKey{c("a")}, ByKey{c("b")}}, ByKey{c("a"), c("b")}},
+		{
+			[]ByKey{ByKey{c("a"), c("c"), c("e")}, ByKey{c("c"), c("d")}, ByKey{c("b")}},
+			ByKey{c("a"), c("b"), c("c"), c("d"), c("e")},
+		},
+	} {
+		have := nWayMerge(tc.in)
+		if !reflect.DeepEqual(have, tc.want) {
+			t.Errorf("%v != %v", have, tc.want)
+		}
+	}
+}
+
 func TestNWayIntersect(t *testing.T) {
 	for _, tc := range []struct {
 		in   []ByKey

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -3,6 +3,8 @@ package chunk
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func c(id string) Chunk {
@@ -20,8 +22,8 @@ func TestUnique(t *testing.T) {
 		{ByKey{c("a"), c("b"), c("c")}, ByKey{c("a"), c("b"), c("c")}},
 	} {
 		have := unique(tc.in)
-		if !reflect.DeepEqual(have, tc.want) {
-			t.Errorf("%v != %v", have, tc.want)
+		if !reflect.DeepEqual(tc.want, have) {
+			assert.Equal(t, tc.want, have)
 		}
 	}
 }
@@ -44,8 +46,8 @@ func TestMerge(t *testing.T) {
 			ByKey{c("a"), c("b"), c("c"), c("d")}},
 	} {
 		have := merge(tc.args.a, tc.args.b)
-		if !reflect.DeepEqual(have, tc.want) {
-			t.Errorf("%v != %v", have, tc.want)
+		if !reflect.DeepEqual(tc.want, have) {
+			assert.Equal(t, tc.want, have)
 		}
 	}
 }
@@ -66,8 +68,8 @@ func TestNWayUnion(t *testing.T) {
 		},
 	} {
 		have := nWayUnion(tc.in)
-		if !reflect.DeepEqual(have, tc.want) {
-			t.Errorf("%v != %v", have, tc.want)
+		if !reflect.DeepEqual(tc.want, have) {
+			assert.Equal(t, tc.want, have)
 		}
 	}
 }
@@ -84,8 +86,8 @@ func TestNWayIntersect(t *testing.T) {
 		{[]ByKey{{c("a"), c("b"), c("c")}, {c("a"), c("c")}, {c("a")}}, ByKey{c("a")}},
 	} {
 		have := nWayIntersect(tc.in)
-		if !reflect.DeepEqual(have, tc.want) {
-			t.Errorf("%v != %v", have, tc.want)
+		if !reflect.DeepEqual(tc.want, have) {
+			assert.Equal(t, tc.want, have)
 		}
 	}
 }

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -43,7 +43,8 @@ func TestMerge(t *testing.T) {
 		{args{ByKey{c("a")}, ByKey{c("b")}}, ByKey{c("a"), c("b")}},
 		{
 			args{ByKey{c("a"), c("c")}, ByKey{c("a"), c("b"), c("d")}},
-			ByKey{c("a"), c("b"), c("c"), c("d")}},
+			ByKey{c("a"), c("b"), c("c"), c("d")},
+		},
 	} {
 		have := merge(tc.args.a, tc.args.b)
 		if !reflect.DeepEqual(tc.want, have) {
@@ -59,11 +60,16 @@ func TestNWayUnion(t *testing.T) {
 	}{
 		{nil, ByKey{}},
 		{[]ByKey{{c("a")}}, ByKey{c("a")}},
+		{[]ByKey{{c("a")}, {c("a")}}, ByKey{c("a")}},
 		{[]ByKey{{c("a")}, {}}, ByKey{c("a")}},
 		{[]ByKey{{}, {c("b")}}, ByKey{c("b")}},
 		{[]ByKey{{c("a")}, {c("b")}}, ByKey{c("a"), c("b")}},
 		{
 			[]ByKey{{c("a"), c("c"), c("e")}, {c("c"), c("d")}, {c("b")}},
+			ByKey{c("a"), c("b"), c("c"), c("d"), c("e")},
+		},
+		{
+			[]ByKey{{c("c"), c("d")}, {c("b")}, {c("a"), c("c"), c("e")}},
 			ByKey{c("a"), c("b"), c("c"), c("d"), c("e")},
 		},
 	} {

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -9,7 +9,24 @@ func c(id string) Chunk {
 	return Chunk{UserID: id}
 }
 
-func TestIntersect(t *testing.T) {
+func TestUnique(t *testing.T) {
+	for _, tc := range []struct {
+		in   ByKey
+		want ByKey
+	}{
+		{nil, ByKey{}},
+		{ByKey{c("a"), c("a")}, ByKey{c("a")}},
+		{ByKey{c("a"), c("a"), c("b"), c("b"), c("c")}, ByKey{c("a"), c("b"), c("c")}},
+		{ByKey{c("a"), c("b"), c("c")}, ByKey{c("a"), c("b"), c("c")}},
+	} {
+		have := unique(tc.in)
+		if !reflect.DeepEqual(have, tc.want) {
+			t.Errorf("%v != %v", have, tc.want)
+		}
+	}
+}
+
+func TestNWayIntersect(t *testing.T) {
 	for _, tc := range []struct {
 		in   []ByKey
 		want ByKey

--- a/chunk/by_key_test.go
+++ b/chunk/by_key_test.go
@@ -26,6 +26,30 @@ func TestUnique(t *testing.T) {
 	}
 }
 
+func TestMerge(t *testing.T) {
+	type args struct {
+		a ByKey
+		b ByKey
+	}
+	for _, tc := range []struct {
+		args args
+		want ByKey
+	}{
+		{args{ByKey{}, ByKey{}}, ByKey{}},
+		{args{ByKey{c("a")}, ByKey{}}, ByKey{c("a")}},
+		{args{ByKey{}, ByKey{c("b")}}, ByKey{c("b")}},
+		{args{ByKey{c("a")}, ByKey{c("b")}}, ByKey{c("a"), c("b")}},
+		{
+			args{ByKey{c("a"), c("c")}, ByKey{c("a"), c("b"), c("d")}},
+			ByKey{c("a"), c("b"), c("c"), c("d")}},
+	} {
+		have := merge(tc.args.a, tc.args.b)
+		if !reflect.DeepEqual(have, tc.want) {
+			t.Errorf("%v != %v", have, tc.want)
+		}
+	}
+}
+
 func TestNWayIntersect(t *testing.T) {
 	for _, tc := range []struct {
 		in   []ByKey

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -303,7 +303,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 		}
 	}
 
-	return nWayMerge(chunkSets), lastErr
+	return nWayUnion(chunkSets), lastErr
 }
 
 func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher, metricName model.LabelValue) ([]Chunk, error) {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -242,10 +242,7 @@ outer:
 }
 
 func (c *Store) lookupMatchers(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
-	metricName, matchers, _, err := util.ExtractMetricNameFromMatchers(matchers)
-	if err != nil {
-		return nil, err
-	}
+	metricName, matchers, _ := util.ExtractMetricNameFromMatchers(matchers)
 
 	userID, err := user.Extract(ctx)
 	if err != nil {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -300,8 +300,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 		}
 	}
 
-	// Merge chunkSets in order
-	return nWayIntersect(chunkSets), lastErr
+	return nWayMerge(chunkSets), lastErr
 }
 
 func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher, metricName model.LabelValue) ([]Chunk, error) {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -247,10 +247,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 		return nil, err
 	}
 
-	// Get metric name from matchers
 	metricName, matchers, ok := util.ExtractMetricNameFromMatchers(matchers)
-
-	// If there is a metric name, return chunks using metric name
 	if ok {
 		return c.lookupChunksByMetricName(ctx, from, through, matchers, userID, metricName)
 	}

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -270,7 +270,10 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 	skippedMetricNames := 0
 
 	for _, metricNameEntry := range metricNameEntries {
-		metricName := model.LabelValue(metricNameEntry.Value)
+		metricName, err := parseMetricNameRangeValue(metricNameEntry.RangeValue, metricNameEntry.Value)
+		if err != nil {
+			return nil, err
+		}
 
 		// If there is a metric name matcher, however we are fetching all metric name
 		// chunks, skip metric names which don't match the metric name matcher.
@@ -434,7 +437,7 @@ func (c *Store) convertIndexEntriesToChunks(ctx context.Context, entries []Index
 	var chunkSet ByKey
 
 	for _, entry := range entries {
-		chunkKey, labelValue, metadataInIndex, err := parseRangeValue(entry.RangeValue, entry.Value)
+		chunkKey, labelValue, metadataInIndex, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -257,6 +257,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 
 	// If there is no metric name, we want return chunks for all metric names
 	metricNameQueries, err := c.schema.GetReadQueries(from, through, userID)
+	fmt.Printf("here, %x", metricNameQueries)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -191,7 +191,7 @@ func (c *Store) Get(ctx context.Context, from, through model.Time, allMatchers .
 	filters, matchers := util.SplitFiltersAndMatchers(allMatchers)
 
 	// Fetch chunk descriptors (just ID really) from storage
-	chunks, err := c.lookupMatchers(ctx, from, through, matchers)
+	chunks, err := c.lookupChunksByMatchers(ctx, from, through, matchers)
 	if err != nil {
 		return nil, promql.ErrStorage(err)
 	}
@@ -241,26 +241,74 @@ outer:
 	return filteredChunks, nil
 }
 
-func (c *Store) lookupMatchers(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
-	metricName, matchers, _ := util.ExtractMetricNameFromMatchers(matchers)
-
+func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
 	userID, err := user.Extract(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Get metric name from matchers
+	metricName, matchers, ok := util.ExtractMetricNameFromMatchers(matchers)
+
+	// If there is a metric name, return chunks using metric name
+	if ok {
+		return c.lookupChunksByMetricName(ctx, from, through, matchers, userID, metricName)
+	}
+
+	// If there is no metric name, we want return chunks for all metric names
+	metricNameQueries, err := c.schema.GetReadQueries(from, through, userID)
+	metricNameEntries, err := c.lookupEntriesByQueries(ctx, metricNameQueries)
+
+	incomingChunkSets := make(chan ByKey)
+	incomingErrors := make(chan error)
+	for _, metricNameEntry := range metricNameEntries {
+		go func(metricName model.LabelValue) {
+			chunks, err := c.lookupChunksByMetricName(ctx, from, through, matchers, userID, metricName)
+			if err != nil {
+				incomingErrors <- err
+			} else {
+				incomingChunkSets <- chunks
+			}
+		}(model.LabelValue(metricNameEntry.Value))
+	}
+
+	var chunkSets []ByKey
+	var lastErr error
+	for i := 0; i < len(metricNameEntries); i++ {
+		select {
+		case incoming := <-incomingChunkSets:
+			chunkSets = append(chunkSets, incoming)
+		case err := <-incomingErrors:
+			lastErr = err
+		}
+	}
+
+	// Merge chunkSets in order
+	return nWayIntersect(chunkSets), lastErr
+}
+
+func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher, userID string, metricName model.LabelValue) ([]Chunk, error) {
+	// Just get chunks for metric if there are no matchers
 	if len(matchers) == 0 {
 		queries, err := c.schema.GetReadQueriesForMetric(from, through, userID, metricName)
 		if err != nil {
 			return nil, err
 		}
-		return c.lookupEntries(ctx, queries, nil)
+
+		entries, err := c.lookupEntriesByQueries(ctx, queries)
+		if err != nil {
+			return nil, err
+		}
+
+		return c.convertIndexEntriesToChunks(ctx, entries, nil)
 	}
 
+	// Otherwise get chunks which include other matchers
 	incomingChunkSets := make(chan ByKey)
 	incomingErrors := make(chan error)
 	for _, matcher := range matchers {
 		go func(matcher *metric.LabelMatcher) {
+			// Lookup IndexQuery's
 			var queries []IndexQuery
 			var err error
 			if matcher.Type != metric.Equal {
@@ -272,15 +320,25 @@ func (c *Store) lookupMatchers(ctx context.Context, from, through model.Time, ma
 				incomingErrors <- err
 				return
 			}
-			incoming, err := c.lookupEntries(ctx, queries, matcher)
+
+			// Lookup IndexEntry's
+			entries, err := c.lookupEntriesByQueries(ctx, queries)
+			if err != nil {
+				incomingErrors <- err
+				return
+			}
+
+			// Convert IndexEntry's into chunks
+			chunks, err := c.convertIndexEntriesToChunks(ctx, entries, matcher)
 			if err != nil {
 				incomingErrors <- err
 			} else {
-				incomingChunkSets <- incoming
+				incomingChunkSets <- chunks
 			}
 		}(matcher)
 	}
 
+	// Recieve chunkSets from all matchers
 	var chunkSets []ByKey
 	var lastErr error
 	for i := 0; i < len(matchers); i++ {
@@ -292,77 +350,85 @@ func (c *Store) lookupMatchers(ctx context.Context, from, through model.Time, ma
 		}
 	}
 
+	// Merge chunkSets in order
 	return nWayIntersect(chunkSets), lastErr
 }
 
-func (c *Store) lookupEntries(ctx context.Context, queries []IndexQuery, matcher *metric.LabelMatcher) (ByKey, error) {
-	incomingChunkSets := make(chan ByKey)
+func (c *Store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
+	// Call lookupEntriesByQuery for each query
+	incomingEntries := make(chan []IndexEntry)
 	incomingErrors := make(chan error)
 	for _, query := range queries {
 		go func(query IndexQuery) {
-			incoming, err := c.lookupEntry(ctx, query, matcher)
+			entries, err := c.lookupEntriesByQuery(ctx, query)
 			if err != nil {
 				incomingErrors <- err
 			} else {
-				incomingChunkSets <- incoming
+				incomingEntries <- entries
 			}
 		}(query)
 	}
 
-	var chunks ByKey
+	// Combine the results into one slice
+	var entries []IndexEntry
 	var lastErr error
 	for i := 0; i < len(queries); i++ {
 		select {
-		case incoming := <-incomingChunkSets:
-			chunks = merge(chunks, incoming)
+		case incoming := <-incomingEntries:
+			entries = append(entries, incoming...)
 		case err := <-incomingErrors:
 			lastErr = err
 		}
 	}
 
-	return chunks, lastErr
+	return entries, lastErr
 }
 
-func (c *Store) lookupEntry(ctx context.Context, query IndexQuery, matcher *metric.LabelMatcher) (ByKey, error) {
-	var chunkSet ByKey
-	var processingError error
+func (c *Store) lookupEntriesByQuery(ctx context.Context, query IndexQuery) ([]IndexEntry, error) {
+	var entries []IndexEntry
+
 	if err := c.storage.QueryPages(ctx, query, func(resp ReadBatch, lastPage bool) (shouldContinue bool) {
-		processingError = processResponse(ctx, resp, &chunkSet, matcher)
-		return processingError == nil && !lastPage
+		for i := 0; i < resp.Len(); i++ {
+			entries = append(entries, IndexEntry{
+				TableName:  query.TableName,
+				HashValue:  query.HashValue,
+				RangeValue: resp.RangeValue(i),
+				Value:      resp.Value(i),
+			})
+		}
+		return !lastPage
 	}); err != nil {
 		log.Errorf("Error querying storage: %v", err)
 		return nil, err
-	} else if processingError != nil {
-		log.Errorf("Error processing storage response: %v", processingError)
-		return nil, processingError
 	}
-	sort.Sort(ByKey(chunkSet))
-	chunkSet = unique(chunkSet)
-	return chunkSet, nil
+
+	return entries, nil
 }
 
-func processResponse(ctx context.Context, resp ReadBatch, chunkSet *ByKey, matcher *metric.LabelMatcher) error {
+func (c *Store) convertIndexEntriesToChunks(ctx context.Context, entries []IndexEntry, matcher *metric.LabelMatcher) (ByKey, error) {
 	userID, err := user.Extract(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for i := 0; i < resp.Len(); i++ {
-		chunkKey, labelValue, metadataInIndex, err := parseRangeValue(resp.RangeValue(i), resp.Value(i))
+	var chunkSet ByKey
+
+	for _, entry := range entries {
+		chunkKey, labelValue, metadataInIndex, err := parseRangeValue(entry.RangeValue, entry.Value)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		chunk, err := parseExternalKey(userID, chunkKey)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// This can be removed in Dev 2017, 13 months after the last chunks
 		// was written with metadata in the index.
-		if metadataInIndex && resp.Value(i) != nil {
-			if err := json.Unmarshal(resp.Value(i), &chunk); err != nil {
-				return err
+		if metadataInIndex && entry.Value != nil {
+			if err := json.Unmarshal(entry.Value, &chunk); err != nil {
+				return nil, err
 			}
 			chunk.metadataInIndex = true
 		}
@@ -371,9 +437,9 @@ func processResponse(ctx context.Context, resp ReadBatch, chunkSet *ByKey, match
 			log.Debug("Dropping chunk for non-matching metric ", chunk.Metric)
 			continue
 		}
-		*chunkSet = append(*chunkSet, chunk)
+		chunkSet = append(chunkSet, chunk)
 	}
-	return nil
+	return chunkSet, nil
 }
 
 func (c *Store) fetchChunkData(ctx context.Context, chunkSet []Chunk) ([]Chunk, error) {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -376,7 +376,6 @@ func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through mode
 }
 
 func (c *Store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
-	// Call lookupEntriesByQuery for each query
 	incomingEntries := make(chan []IndexEntry)
 	incomingErrors := make(chan error)
 	for _, query := range queries {
@@ -460,7 +459,10 @@ func (c *Store) convertIndexEntriesToChunks(ctx context.Context, entries []Index
 		}
 		chunkSet = append(chunkSet, chunk)
 	}
-	return chunkSet, nil
+
+	// Return chunks sorted and deduped because they will be merged with other sets
+	sort.Sort(chunkSet)
+	return unique(chunkSet), nil
 }
 
 func (c *Store) fetchChunkData(ctx context.Context, chunkSet []Chunk) ([]Chunk, error) {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -254,7 +254,13 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 
 	// If there is no metric name, we want return chunks for all metric names
 	metricNameQueries, err := c.schema.GetReadQueries(from, through, userID)
+	if err != nil {
+		return nil, err
+	}
 	metricNameEntries, err := c.lookupEntriesByQueries(ctx, metricNameQueries)
+	if err != nil {
+		return nil, err
+	}
 
 	incomingChunkSets := make(chan ByKey)
 	incomingErrors := make(chan error)

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -363,7 +363,7 @@ func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through mode
 		}(matcher)
 	}
 
-	// Recieve chunkSets from all matchers
+	// Receive chunkSets from all matchers
 	var chunkSets []ByKey
 	var lastErr error
 	for i := 0; i < len(matchers); i++ {

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -275,8 +275,8 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 			return nil, err
 		}
 
-		// If there is a metric name matcher, however we are fetching all metric name
-		// chunks, skip metric names which don't match the metric name matcher.
+		// We are fetching all metric name chunks, however if there is a metricNameMatcher,
+		// we only want metric names that match
 		if ok && !metricNameMatcher.Match(metricName) {
 			skippedMetricNames++
 			continue
@@ -374,7 +374,7 @@ func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through mode
 		}
 	}
 
-	// Merge chunkSets in order
+	// Merge chunkSets in order because we wish to keep label series together consecutively
 	return nWayIntersect(chunkSets), lastErr
 }
 

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -242,14 +242,14 @@ outer:
 }
 
 func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
+	metricName, matchers, ok := util.ExtractMetricNameFromMatchers(matchers)
+	if ok {
+		return c.lookupChunksByMetricName(ctx, from, through, matchers, metricName)
+	}
+
 	userID, err := user.Extract(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	metricName, matchers, ok := util.ExtractMetricNameFromMatchers(matchers)
-	if ok {
-		return c.lookupChunksByMetricName(ctx, from, through, matchers, userID, metricName)
 	}
 
 	// If there is no metric name, we want return chunks for all metric names
@@ -260,7 +260,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 	incomingErrors := make(chan error)
 	for _, metricNameEntry := range metricNameEntries {
 		go func(metricName model.LabelValue) {
-			chunks, err := c.lookupChunksByMetricName(ctx, from, through, matchers, userID, metricName)
+			chunks, err := c.lookupChunksByMetricName(ctx, from, through, matchers, metricName)
 			if err != nil {
 				incomingErrors <- err
 			} else {
@@ -284,7 +284,12 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 	return nWayIntersect(chunkSets), lastErr
 }
 
-func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher, userID string, metricName model.LabelValue) ([]Chunk, error) {
+func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher, metricName model.LabelValue) ([]Chunk, error) {
+	userID, err := user.Extract(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Just get chunks for metric if there are no matchers
 	if len(matchers) == 0 {
 		queries, err := c.schema.GetReadQueriesForMetric(from, through, userID, metricName)

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -242,7 +242,7 @@ outer:
 }
 
 func (c *Store) lookupMatchers(ctx context.Context, from, through model.Time, matchers []*metric.LabelMatcher) ([]Chunk, error) {
-	metricName, matchers, err := util.ExtractMetricNameFromMatchers(matchers)
+	metricName, matchers, _, err := util.ExtractMetricNameFromMatchers(matchers)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -257,7 +257,6 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 
 	// If there is no metric name, we want return chunks for all metric names
 	metricNameQueries, err := c.schema.GetReadQueries(from, through, userID)
-	fmt.Printf("here, %x", metricNameQueries)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk/chunk_store.go
+++ b/chunk/chunk_store.go
@@ -277,7 +277,7 @@ func (c *Store) lookupChunksByMatchers(ctx context.Context, from, through model.
 
 		// If there is a metric name matcher, however we are fetching all metric name
 		// chunks, skip metric names which don't match the metric name matcher.
-		if ok && metricNameMatcher.Match(metricName) {
+		if ok && !metricNameMatcher.Match(metricName) {
 			skippedMetricNames++
 			continue
 		}

--- a/chunk/chunk_store_test.go
+++ b/chunk/chunk_store_test.go
@@ -56,6 +56,7 @@ func TestChunkStore(t *testing.T) {
 		{"v4 schema", v4Schema},
 		{"v5 schema", v5Schema},
 		{"v6 schema", v6Schema},
+		{"v7 schema", v7Schema},
 	}
 
 	nameMatcher := mustNewLabelMatcher(metric.Equal, model.MetricNameLabel, "foo")
@@ -159,6 +160,7 @@ func TestChunkStoreRandom(t *testing.T) {
 		{name: "v4 schema", fn: v4Schema},
 		{name: "v5 schema", fn: v5Schema},
 		{name: "v6 schema", fn: v6Schema},
+		{name: "v7 schema", fn: v7Schema},
 	}
 
 	for i := range schemas {

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -125,7 +125,8 @@ func (m *MockStorage) BatchWrite(_ context.Context, batch WriteBatch) error {
 			items = append(items, mockItem{})
 			copy(items[i+1:], items[i:])
 		} else {
-			return fmt.Errorf("Dupe write")
+			// Ignore duplicate write
+			continue
 		}
 		items[i] = mockItem{
 			rangeValue: req.rangeValue,

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -138,7 +138,7 @@ func (m *MockStorage) BatchWrite(_ context.Context, batch WriteBatch) error {
 }
 
 // QueryPages implements StorageClient.
-func (m *MockStorage) QueryPages(_ context.Context, entry IndexEntry, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
+func (m *MockStorage) QueryPages(_ context.Context, entry IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -138,35 +138,35 @@ func (m *MockStorage) BatchWrite(_ context.Context, batch WriteBatch) error {
 }
 
 // QueryPages implements StorageClient.
-func (m *MockStorage) QueryPages(_ context.Context, entry IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
+func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	table, ok := m.tables[entry.TableName]
+	table, ok := m.tables[query.TableName]
 	if !ok {
 		return fmt.Errorf("table not found")
 	}
 
-	items, ok := table.items[entry.HashValue]
+	items, ok := table.items[query.HashValue]
 	if !ok {
 		return nil
 	}
 
-	if entry.RangeValuePrefix != nil {
-		log.Debugf("Lookup prefix %s/%x (%d)", entry.HashValue, entry.RangeValuePrefix, len(items))
+	if query.RangeValuePrefix != nil {
+		log.Debugf("Lookup prefix %s/%x (%d)", query.HashValue, query.RangeValuePrefix, len(items))
 
 		// the smallest index i in [0, n) at which f(i) is true
 		i := sort.Search(len(items), func(i int) bool {
-			if bytes.Compare(items[i].rangeValue, entry.RangeValuePrefix) > 0 {
+			if bytes.Compare(items[i].rangeValue, query.RangeValuePrefix) > 0 {
 				return true
 			}
-			return bytes.HasPrefix(items[i].rangeValue, entry.RangeValuePrefix)
+			return bytes.HasPrefix(items[i].rangeValue, query.RangeValuePrefix)
 		})
 		j := sort.Search(len(items)-i, func(j int) bool {
-			if bytes.Compare(items[i+j].rangeValue, entry.RangeValuePrefix) < 0 {
+			if bytes.Compare(items[i+j].rangeValue, query.RangeValuePrefix) < 0 {
 				return false
 			}
-			return !bytes.HasPrefix(items[i+j].rangeValue, entry.RangeValuePrefix)
+			return !bytes.HasPrefix(items[i+j].rangeValue, query.RangeValuePrefix)
 		})
 
 		log.Debugf("  found range [%d:%d)", i, i+j)
@@ -175,12 +175,12 @@ func (m *MockStorage) QueryPages(_ context.Context, entry IndexQuery, callback f
 		}
 		items = items[i : i+j]
 
-	} else if entry.RangeValueStart != nil {
-		log.Debugf("Lookup range %s/%x -> ... (%d)", entry.HashValue, entry.RangeValueStart, len(items))
+	} else if query.RangeValueStart != nil {
+		log.Debugf("Lookup range %s/%x -> ... (%d)", query.HashValue, query.RangeValueStart, len(items))
 
 		// the smallest index i in [0, n) at which f(i) is true
 		i := sort.Search(len(items), func(i int) bool {
-			return bytes.Compare(items[i].rangeValue, entry.RangeValueStart) >= 0
+			return bytes.Compare(items[i].rangeValue, query.RangeValueStart) >= 0
 		})
 
 		log.Debugf("  found range [%d)", i)
@@ -190,7 +190,7 @@ func (m *MockStorage) QueryPages(_ context.Context, entry IndexQuery, callback f
 		items = items[i:]
 
 	} else {
-		log.Debugf("Lookup %s/* (%d)", entry.HashValue, len(items))
+		log.Debugf("Lookup %s/* (%d)", query.HashValue, len(items))
 	}
 
 	result := mockReadBatch{}

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -10,12 +10,12 @@ import (
 )
 
 var (
-	rangeKeyV1 = []byte{'1'}
-	rangeKeyV2 = []byte{'2'}
-	rangeKeyV3 = []byte{'3'}
-	rangeKeyV4 = []byte{'4'}
-	rangeKeyV5 = []byte{'5'}
-	rangeKeyV6 = []byte{'6'}
+	chunkTimeRangeKeyV1  = []byte{'1'}
+	chunkTimeRangeKeyV2  = []byte{'2'}
+	chunkTimeRangeKeyV3  = []byte{'3'}
+	chunkTimeRangeKeyV4  = []byte{'4'}
+	chunkTimeRangeKeyV5  = []byte{'5'}
+	metricNameRangeKeyV1 = []byte{'6'}
 )
 
 // Schema interface defines methods to calculate the hash and range keys needed
@@ -281,7 +281,7 @@ func (base64Entries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey strin
 		result = append(result, IndexEntry{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey([]byte(key), encodedBytes, chunkIDBytes, rangeKeyV1),
+			RangeValue: buildRangeKey([]byte(key), encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
 	return result, nil
@@ -310,7 +310,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, bucketH
 		{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(nil, nil, chunkIDBytes, rangeKeyV2),
+			RangeValue: buildRangeKey(nil, nil, chunkIDBytes, chunkTimeRangeKeyV2),
 		},
 	}
 
@@ -322,7 +322,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, bucketH
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
-			RangeValue: buildRangeKey(nil, encodedBytes, chunkIDBytes, rangeKeyV1),
+			RangeValue: buildRangeKey(nil, encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
 
@@ -373,7 +373,7 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
+			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
@@ -385,7 +385,7 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
-			RangeValue: buildRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, rangeKeyV4),
+			RangeValue: buildRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, chunkTimeRangeKeyV4),
 		})
 	}
 
@@ -435,7 +435,7 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
+			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
@@ -446,7 +446,7 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV5),
+			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
 			Value:      []byte(value),
 		})
 	}
@@ -511,7 +511,7 @@ func (v7Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		{
 			TableName:  tableName,
 			HashValue:  bucketHashKey,
-			RangeValue: buildRangeKey(nil, nil, metricNameHashBytes[:], rangeKeyV6),
+			RangeValue: buildRangeKey(metricNameHashBytes[:], nil, nil, metricNameRangeKeyV1),
 			Value:      []byte(metricName),
 		},
 	}
@@ -520,7 +520,7 @@ func (v7Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 	entries = append(entries, IndexEntry{
 		TableName:  tableName,
 		HashValue:  bucketHashKey + ":" + string(metricName),
-		RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
+		RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 	})
 
 	// Add IndexEntries with userID:bigBucket:metricName:labelName HashValue
@@ -531,7 +531,7 @@ func (v7Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
 			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV5),
+			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
 			Value:      []byte(value),
 		})
 	}

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -132,8 +132,7 @@ type schema struct {
 func (s schema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	var result []IndexEntry
 
-	buckets := s.buckets(from, through, userID)
-	for _, bucket := range buckets {
+	for _, bucket := range s.buckets(from, through, userID) {
 		entries, err := s.entries.GetWriteEntries(bucket.from, bucket.through, bucket.tableName, bucket.hashKey, metricName, labels, chunkID)
 		if err != nil {
 			return nil, err

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -5,17 +5,9 @@ import (
 
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/cortex/util"
-)
-
-const (
-	secondsInHour      = int64(time.Hour / time.Second)
-	secondsInDay       = int64(24 * time.Hour / time.Second)
-	millisecondsInHour = int64(time.Hour / time.Millisecond)
-	millisecondsInDay  = int64(24 * time.Hour / time.Millisecond)
 )
 
 var (

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -326,7 +326,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model
 		encodedBytes := encodeBase64Value(value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName) + ":" + string(key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
 			RangeValue: buildRangeKey(nil, encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
@@ -351,7 +351,7 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelQueries(bucket Bucket, metric
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue: fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 		},
 	}, nil
 }
@@ -361,7 +361,7 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelValueQueries(bucket Bucket, m
 	return []IndexQuery{
 		{
 			TableName:        bucket.tableName,
-			HashValue:        bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue:        fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 			RangeValuePrefix: buildRangeKey(nil, encodedBytes),
 		},
 	}, nil
@@ -389,7 +389,7 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		encodedValueBytes := encodeBase64Value(value)
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName) + ":" + string(key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
 			RangeValue: buildRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, chunkTimeRangeKeyV4),
 		})
 	}
@@ -414,7 +414,7 @@ func (v5Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue: fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 		},
 	}, nil
 }
@@ -423,7 +423,7 @@ func (v5Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.
 	return []IndexQuery{
 		{
 			TableName: bucket.tableName,
-			HashValue: bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue: fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 		},
 	}, nil
 }
@@ -450,7 +450,7 @@ func (v6Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		}
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName) + ":" + string(key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
 			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
 			Value:      []byte(value),
 		})
@@ -479,7 +479,7 @@ func (v6Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 	return []IndexQuery{
 		{
 			TableName:       bucket.tableName,
-			HashValue:       bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
@@ -490,7 +490,7 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.
 	return []IndexQuery{
 		{
 			TableName:       bucket.tableName,
-			HashValue:       bucket.hashKey + ":" + string(metricName) + ":" + string(labelName),
+			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
@@ -535,7 +535,7 @@ func (v7Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		}
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
-			HashValue:  bucket.hashKey + ":" + string(metricName) + ":" + string(key),
+			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
 			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
 			Value:      []byte(value),
 		})

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -2,7 +2,6 @@ package chunk
 
 import (
 	"crypto/sha1"
-
 	"fmt"
 	"strings"
 

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -34,6 +34,7 @@ type Schema interface {
 	GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
 
 	// When doing a read, use these methods to return the list of entries you should query
+	GetReadEntries(from, through model.Time, userID string) ([]IndexEntry, error)
 	GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error)
 	GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error)
 	GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
@@ -137,6 +138,12 @@ func (s schema) GetWriteEntries(from, through model.Time, userID string, metricN
 	})
 }
 
+func (s schema) GetReadEntries(from, through model.Time, userID string) ([]IndexEntry, error) {
+	return s.buckets(from, through, userID, "", func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+		return s.entries.GetReadEntries(bucketFrom, bucketThrough, tableName, bucketHashKey)
+	})
+}
+
 func (s schema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
 	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
 		return s.entries.GetReadMetricEntries(bucketFrom, bucketThrough, tableName, bucketHashKey, metricName)
@@ -157,6 +164,7 @@ func (s schema) GetReadEntriesForMetricLabelValue(from, through model.Time, user
 
 type entries interface {
 	GetWriteEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
+	GetReadEntries(from, through uint32, tableName, hashKey string) ([]IndexEntry, error)
 	GetReadMetricEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue) ([]IndexEntry, error)
 	GetReadMetricLabelEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error)
 	GetReadMetricLabelValueEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
@@ -181,6 +189,10 @@ func (originalEntries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey str
 		})
 	}
 	return result, nil
+}
+
+func (originalEntries) GetReadEntries(_, _ uint32, _, _ string) ([]IndexEntry, error) {
+	return nil, fmt.Errorf("originalEntries does not support GetReadEntries")
 }
 
 func (originalEntries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
@@ -238,6 +250,10 @@ func (base64Entries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey strin
 	return result, nil
 }
 
+func (base64Entries) GetReadEntries(_, _ uint32, _, _ string) ([]IndexEntry, error) {
+	return nil, fmt.Errorf("base64Entries does not support GetReadEntries")
+}
+
 func (base64Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
 	encodedBytes := encodeBase64Value(labelValue)
 	return []IndexEntry{
@@ -274,6 +290,10 @@ func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, bucketH
 	}
 
 	return entries, nil
+}
+
+func (labelNameInHashKeyEntries) GetReadEntries(_, _ uint32, _, _ string) ([]IndexEntry, error) {
+	return nil, fmt.Errorf("labelNameInHashKeyEntries does not support GetReadEntries")
 }
 
 func (labelNameInHashKeyEntries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
@@ -335,6 +355,10 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 	return entries, nil
 }
 
+func (v5Entries) GetReadEntries(_, _ uint32, _, _ string) ([]IndexEntry, error) {
+	return nil, fmt.Errorf("v5Entries does not support GetReadEntries")
+}
+
 func (v5Entries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
@@ -391,6 +415,10 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 	}
 
 	return entries, nil
+}
+
+func (v6Entries) GetReadEntries(_, _ uint32, _, _ string) ([]IndexEntry, error) {
+	return nil, fmt.Errorf("v6Entries does not support GetReadEntries")
 }
 
 func (v6Entries) GetReadMetricEntries(from, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,11 @@ var (
 	chunkTimeRangeKeyV4  = []byte{'4'}
 	chunkTimeRangeKeyV5  = []byte{'5'}
 	metricNameRangeKeyV1 = []byte{'6'}
+)
+
+// Errors
+var (
+	ErrNoMetricNameNotSupported = errors.New("metric name required for pre-v7 schemas")
 )
 
 // Schema interface defines methods to calculate the hash and range keys needed
@@ -228,7 +234,7 @@ func (originalEntries) GetWriteEntries(bucket Bucket, metricName model.LabelValu
 }
 
 func (originalEntries) GetReadQueries(_ Bucket) ([]IndexQuery, error) {
-	return nil, fmt.Errorf("originalEntries does not support GetReadQueries")
+	return nil, ErrNoMetricNameNotSupported
 }
 
 func (originalEntries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
@@ -287,7 +293,7 @@ func (base64Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue,
 }
 
 func (base64Entries) GetReadQueries(_ Bucket) ([]IndexQuery, error) {
-	return nil, fmt.Errorf("base64Entries does not support GetReadQueries")
+	return nil, ErrNoMetricNameNotSupported
 }
 
 func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
@@ -329,7 +335,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model
 }
 
 func (labelNameInHashKeyEntries) GetReadQueries(_ Bucket) ([]IndexQuery, error) {
-	return nil, fmt.Errorf("labelNameInHashKeyEntries does not support GetReadQueries")
+	return nil, ErrNoMetricNameNotSupported
 }
 
 func (labelNameInHashKeyEntries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
@@ -392,7 +398,7 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 }
 
 func (v5Entries) GetReadQueries(_ Bucket) ([]IndexQuery, error) {
-	return nil, fmt.Errorf("v5Entries does not support GetReadQueries")
+	return nil, ErrNoMetricNameNotSupported
 }
 
 func (v5Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {
@@ -454,7 +460,7 @@ func (v6Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 }
 
 func (v6Entries) GetReadQueries(bucket Bucket) ([]IndexQuery, error) {
-	return nil, fmt.Errorf("v6Entries does not support GetReadQueries")
+	return nil, ErrNoMetricNameNotSupported
 }
 
 func (v6Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue) ([]IndexQuery, error) {

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -517,7 +517,7 @@ func (entries v7Entries) GetWriteEntries(bucket Bucket, metricName model.LabelVa
 	indexEntries = append(indexEntries, IndexEntry{
 		TableName:  bucket.tableName,
 		HashValue:  bucket.hashKey,
-		RangeValue: encodeRangeKey(metricNameHashBytes[:], nil, nil, metricNameRangeKeyV1),
+		RangeValue: encodeRangeKey(encodeBase64Bytes(metricNameHashBytes[:]), nil, nil, metricNameRangeKeyV1),
 		Value:      []byte(metricName),
 	})
 

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -1,11 +1,14 @@
 package chunk
 
 import (
+	"crypto/sha1"
+
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/weaveworks/cortex/util"
 )
 
 const (
@@ -21,6 +24,7 @@ var (
 	rangeKeyV3 = []byte{'3'}
 	rangeKeyV4 = []byte{'4'}
 	rangeKeyV5 = []byte{'5'}
+	rangeKeyV6 = []byte{'6'}
 )
 
 // Schema interface defines methods to calculate the hash and range keys needed
@@ -113,6 +117,14 @@ func v6Schema(cfg SchemaConfig) Schema {
 	}
 }
 
+// v7 schema is an extension of v6, with support for queries with no metric names
+func v7Schema(cfg SchemaConfig) Schema {
+	return schema{
+		cfg.dailyBuckets,
+		v7Entries{},
+	}
+}
+
 // schema implements Schema given a bucketing function and and set of range key callbacks
 type schema struct {
 	buckets func(from, through model.Time, userID string, metricName model.LabelValue, callback bucketCallback) ([]IndexEntry, error)
@@ -120,39 +132,39 @@ type schema struct {
 }
 
 func (s schema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
-	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, hashKey string) ([]IndexEntry, error) {
-		return s.entries.GetWriteEntries(bucketFrom, bucketThrough, tableName, hashKey, labels, chunkID)
+	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+		return s.entries.GetWriteEntries(bucketFrom, bucketThrough, tableName, bucketHashKey, metricName, labels, chunkID)
 	})
 }
 
 func (s schema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
-	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, hashKey string) ([]IndexEntry, error) {
-		return s.entries.GetReadMetricEntries(bucketFrom, bucketThrough, tableName, hashKey)
+	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+		return s.entries.GetReadMetricEntries(bucketFrom, bucketThrough, tableName, bucketHashKey, metricName)
 	})
 }
 
 func (s schema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
-	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, hashKey string) ([]IndexEntry, error) {
-		return s.entries.GetReadMetricLabelEntries(bucketFrom, bucketThrough, tableName, hashKey, labelName)
+	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+		return s.entries.GetReadMetricLabelEntries(bucketFrom, bucketThrough, tableName, bucketHashKey, metricName, labelName)
 	})
 }
 
 func (s schema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
-	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, hashKey string) ([]IndexEntry, error) {
-		return s.entries.GetReadMetricLabelValueEntries(bucketFrom, bucketThrough, tableName, hashKey, labelName, labelValue)
+	return s.buckets(from, through, userID, metricName, func(bucketFrom, bucketThrough uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+		return s.entries.GetReadMetricLabelValueEntries(bucketFrom, bucketThrough, tableName, bucketHashKey, metricName, labelName, labelValue)
 	})
 }
 
 type entries interface {
-	GetWriteEntries(from, through uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error)
-	GetReadMetricEntries(from, through uint32, tableName, hashKey string) ([]IndexEntry, error)
-	GetReadMetricLabelEntries(from, through uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error)
-	GetReadMetricLabelValueEntries(from, through uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
+	GetWriteEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error)
+	GetReadMetricEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue) ([]IndexEntry, error)
+	GetReadMetricLabelEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error)
+	GetReadMetricLabelValueEntries(from, through uint32, tableName, hashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error)
 }
 
 type originalEntries struct{}
 
-func (originalEntries) GetWriteEntries(_, _ uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (originalEntries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	result := []IndexEntry{}
 	for key, value := range labels {
@@ -164,41 +176,41 @@ func (originalEntries) GetWriteEntries(_, _ uint32, tableName, hashKey string, l
 		}
 		result = append(result, IndexEntry{
 			TableName:  tableName,
-			HashValue:  hashKey,
+			HashValue:  bucketHashKey + ":" + string(metricName),
 			RangeValue: buildRangeKey([]byte(key), []byte(value), chunkIDBytes),
 		})
 	}
 	return result, nil
 }
 
-func (originalEntries) GetReadMetricEntries(_, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
+func (originalEntries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName:        tableName,
-			HashValue:        hashKey,
+			HashValue:        bucketHashKey + ":" + string(metricName),
 			RangeValuePrefix: nil,
 		},
 	}, nil
 }
 
-func (originalEntries) GetReadMetricLabelEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+func (originalEntries) GetReadMetricLabelEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName:        tableName,
-			HashValue:        hashKey,
+			HashValue:        bucketHashKey + ":" + string(metricName),
 			RangeValuePrefix: buildRangeKey([]byte(labelName)),
 		},
 	}, nil
 }
 
-func (originalEntries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+func (originalEntries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
 	if strings.ContainsRune(string(labelValue), '\x00') {
 		return nil, fmt.Errorf("label values cannot contain null byte")
 	}
 	return []IndexEntry{
 		{
 			TableName:        tableName,
-			HashValue:        hashKey,
+			HashValue:        bucketHashKey + ":" + string(metricName),
 			RangeValuePrefix: buildRangeKey([]byte(labelName), []byte(labelValue)),
 		},
 	}, nil
@@ -208,7 +220,7 @@ type base64Entries struct {
 	originalEntries
 }
 
-func (base64Entries) GetWriteEntries(_, _ uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (base64Entries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	result := []IndexEntry{}
 	for key, value := range labels {
@@ -219,19 +231,19 @@ func (base64Entries) GetWriteEntries(_, _ uint32, tableName, hashKey string, lab
 		encodedBytes := encodeBase64Value(value)
 		result = append(result, IndexEntry{
 			TableName:  tableName,
-			HashValue:  hashKey,
+			HashValue:  bucketHashKey + ":" + string(metricName),
 			RangeValue: buildRangeKey([]byte(key), encodedBytes, chunkIDBytes, rangeKeyV1),
 		})
 	}
 	return result, nil
 }
 
-func (base64Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+func (base64Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
 	encodedBytes := encodeBase64Value(labelValue)
 	return []IndexEntry{
 		{
 			TableName:        tableName,
-			HashValue:        hashKey,
+			HashValue:        bucketHashKey + ":" + string(metricName),
 			RangeValuePrefix: buildRangeKey([]byte(labelName), encodedBytes),
 		},
 	}, nil
@@ -239,12 +251,12 @@ func (base64Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hash
 
 type labelNameInHashKeyEntries struct{}
 
-func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	entries := []IndexEntry{
 		{
 			TableName:  tableName,
-			HashValue:  hashKey,
+			HashValue:  bucketHashKey + ":" + string(metricName),
 			RangeValue: buildRangeKey(nil, nil, chunkIDBytes, rangeKeyV2),
 		},
 	}
@@ -256,7 +268,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, hashKey
 		encodedBytes := encodeBase64Value(value)
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
-			HashValue:  hashKey + ":" + string(key),
+			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
 			RangeValue: buildRangeKey(nil, encodedBytes, chunkIDBytes, rangeKeyV1),
 		})
 	}
@@ -264,30 +276,30 @@ func (labelNameInHashKeyEntries) GetWriteEntries(_, _ uint32, tableName, hashKey
 	return entries, nil
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricEntries(_, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName: tableName,
-			HashValue: hashKey,
+			HashValue: bucketHashKey + ":" + string(metricName),
 		},
 	}, nil
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricLabelEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetReadMetricLabelEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName: tableName,
-			HashValue: hashKey + ":" + string(labelName),
+			HashValue: bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 		},
 	}, nil
 }
 
-func (labelNameInHashKeyEntries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+func (labelNameInHashKeyEntries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
 	encodedBytes := encodeBase64Value(labelValue)
 	return []IndexEntry{
 		{
 			TableName:        tableName,
-			HashValue:        hashKey + ":" + string(labelName),
+			HashValue:        bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 			RangeValuePrefix: buildRangeKey(nil, encodedBytes),
 		},
 	}, nil
@@ -296,14 +308,14 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelValueEntries(_, _ uint32, tab
 // v5Entries includes chunk end time in range key - see #298.
 type v5Entries struct{}
 
-func (v5Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v5Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	encodedThroughBytes := encodeTime(through)
 
 	entries := []IndexEntry{
 		{
 			TableName:  tableName,
-			HashValue:  hashKey,
+			HashValue:  bucketHashKey + ":" + string(metricName),
 			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
 		},
 	}
@@ -315,7 +327,7 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 		encodedValueBytes := encodeBase64Value(value)
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
-			HashValue:  hashKey + ":" + string(key),
+			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
 			RangeValue: buildRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, rangeKeyV4),
 		})
 	}
@@ -323,29 +335,29 @@ func (v5Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 	return entries, nil
 }
 
-func (v5Entries) GetReadMetricEntries(_, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
+func (v5Entries) GetReadMetricEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName: tableName,
-			HashValue: hashKey,
+			HashValue: bucketHashKey + ":" + string(metricName),
 		},
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+func (v5Entries) GetReadMetricLabelEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName: tableName,
-			HashValue: hashKey + ":" + string(labelName),
+			HashValue: bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 		},
 	}, nil
 }
 
-func (v5Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey string, labelName model.LabelName, _ model.LabelValue) ([]IndexEntry, error) {
+func (v5Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, _ model.LabelValue) ([]IndexEntry, error) {
 	return []IndexEntry{
 		{
 			TableName: tableName,
-			HashValue: hashKey + ":" + string(labelName),
+			HashValue: bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 		},
 	}, nil
 }
@@ -354,14 +366,14 @@ func (v5Entries) GetReadMetricLabelValueEntries(_, _ uint32, tableName, hashKey 
 // moves label value out of range key (see #199).
 type v6Entries struct{}
 
-func (v6Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+func (v6Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	chunkIDBytes := []byte(chunkID)
 	encodedThroughBytes := encodeTime(through)
 
 	entries := []IndexEntry{
 		{
 			TableName:  tableName,
-			HashValue:  hashKey,
+			HashValue:  bucketHashKey + ":" + string(metricName),
 			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
 		},
 	}
@@ -372,7 +384,7 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 		}
 		entries = append(entries, IndexEntry{
 			TableName:  tableName,
-			HashValue:  hashKey + ":" + string(key),
+			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
 			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV5),
 			Value:      []byte(value),
 		})
@@ -381,35 +393,83 @@ func (v6Entries) GetWriteEntries(_, through uint32, tableName, hashKey string, l
 	return entries, nil
 }
 
-func (v6Entries) GetReadMetricEntries(from, _ uint32, tableName, hashKey string) ([]IndexEntry, error) {
+func (v6Entries) GetReadMetricEntries(from, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue) ([]IndexEntry, error) {
 	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
-			HashValue:       hashKey,
+			HashValue:       bucketHashKey + ":" + string(metricName),
 			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName) ([]IndexEntry, error) {
+func (v6Entries) GetReadMetricLabelEntries(from, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
 	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
-			HashValue:       hashKey + ":" + string(labelName),
+			HashValue:       bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
 
-func (v6Entries) GetReadMetricLabelValueEntries(from, _ uint32, tableName, hashKey string, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+func (v6Entries) GetReadMetricLabelValueEntries(from, _ uint32, tableName, bucketHashKey string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
 	encodedFromBytes := encodeTime(from)
 	return []IndexEntry{
 		{
 			TableName:       tableName,
-			HashValue:       hashKey + ":" + string(labelName),
+			HashValue:       bucketHashKey + ":" + string(metricName) + ":" + string(labelName),
 			RangeValueStart: buildRangeKey(encodedFromBytes),
 		},
 	}, nil
+}
+
+// v7Entries supports queries with no metric name
+type v7Entries struct {
+	v6Entries
+}
+
+func (v7Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
+	metricName, err := util.ExtractMetricNameFromMetric(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	chunkIDBytes := []byte(chunkID)
+	encodedThroughBytes := encodeTime(through)
+	metricNameHashBytes := sha1.Sum([]byte(metricName))
+
+	// Add IndexEntry with userID:bigBucket HashValue
+	entries := []IndexEntry{
+		{
+			TableName:  tableName,
+			HashValue:  bucketHashKey,
+			RangeValue: buildRangeKey(nil, nil, metricNameHashBytes[:], rangeKeyV6),
+			Value:      []byte(metricName),
+		},
+	}
+
+	// Add IndexEntry with userID:bigBucket:metricName HashValue
+	entries = append(entries, IndexEntry{
+		TableName:  tableName,
+		HashValue:  bucketHashKey + ":" + string(metricName),
+		RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV3),
+	})
+
+	// Add IndexEntries with userID:bigBucket:metricName:labelName HashValue
+	for key, value := range labels {
+		if key == model.MetricNameLabel {
+			continue
+		}
+		entries = append(entries, IndexEntry{
+			TableName:  tableName,
+			HashValue:  bucketHashKey + ":" + string(metricName) + ":" + string(key),
+			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, rangeKeyV5),
+			Value:      []byte(value),
+		})
+	}
+
+	return entries, nil
 }

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -473,3 +473,12 @@ func (v7Entries) GetWriteEntries(_, through uint32, tableName, bucketHashKey str
 
 	return entries, nil
 }
+
+func (v7Entries) GetReadEntries(from, _ uint32, tableName, bucketHashKey string) ([]IndexEntry, error) {
+	return []IndexEntry{
+		{
+			TableName: tableName,
+			HashValue: bucketHashKey,
+		},
+	}, nil
+}

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -227,7 +227,7 @@ func (originalEntries) GetWriteEntries(bucket Bucket, metricName model.LabelValu
 		result = append(result, IndexEntry{
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey([]byte(key), []byte(value), chunkIDBytes),
+			RangeValue: encodeRangeKey([]byte(key), []byte(value), chunkIDBytes),
 		})
 	}
 	return result, nil
@@ -252,7 +252,7 @@ func (originalEntries) GetReadMetricLabelQueries(bucket Bucket, metricName model
 		{
 			TableName:        bucket.tableName,
 			HashValue:        bucket.hashKey + ":" + string(metricName),
-			RangeValuePrefix: buildRangeKey([]byte(labelName)),
+			RangeValuePrefix: encodeRangeKey([]byte(labelName)),
 		},
 	}, nil
 }
@@ -265,7 +265,7 @@ func (originalEntries) GetReadMetricLabelValueQueries(bucket Bucket, metricName 
 		{
 			TableName:        bucket.tableName,
 			HashValue:        bucket.hashKey + ":" + string(metricName),
-			RangeValuePrefix: buildRangeKey([]byte(labelName), []byte(labelValue)),
+			RangeValuePrefix: encodeRangeKey([]byte(labelName), []byte(labelValue)),
 		},
 	}, nil
 }
@@ -286,7 +286,7 @@ func (base64Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue,
 		result = append(result, IndexEntry{
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey([]byte(key), encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
+			RangeValue: encodeRangeKey([]byte(key), encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
 	return result, nil
@@ -302,7 +302,7 @@ func (base64Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName mo
 		{
 			TableName:        bucket.tableName,
 			HashValue:        bucket.hashKey + ":" + string(metricName),
-			RangeValuePrefix: buildRangeKey([]byte(labelName), encodedBytes),
+			RangeValuePrefix: encodeRangeKey([]byte(labelName), encodedBytes),
 		},
 	}, nil
 }
@@ -315,7 +315,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model
 		{
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(nil, nil, chunkIDBytes, chunkTimeRangeKeyV2),
+			RangeValue: encodeRangeKey(nil, nil, chunkIDBytes, chunkTimeRangeKeyV2),
 		},
 	}
 
@@ -327,7 +327,7 @@ func (labelNameInHashKeyEntries) GetWriteEntries(bucket Bucket, metricName model
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
-			RangeValue: buildRangeKey(nil, encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
+			RangeValue: encodeRangeKey(nil, encodedBytes, chunkIDBytes, chunkTimeRangeKeyV1),
 		})
 	}
 
@@ -362,7 +362,7 @@ func (labelNameInHashKeyEntries) GetReadMetricLabelValueQueries(bucket Bucket, m
 		{
 			TableName:        bucket.tableName,
 			HashValue:        fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
-			RangeValuePrefix: buildRangeKey(nil, encodedBytes),
+			RangeValuePrefix: encodeRangeKey(nil, encodedBytes),
 		},
 	}, nil
 }
@@ -378,7 +378,7 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		{
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
+			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
@@ -390,7 +390,7 @@ func (v5Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
-			RangeValue: buildRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, chunkTimeRangeKeyV4),
+			RangeValue: encodeRangeKey(encodedThroughBytes, encodedValueBytes, chunkIDBytes, chunkTimeRangeKeyV4),
 		})
 	}
 
@@ -440,7 +440,7 @@ func (v6Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		{
 			TableName:  bucket.tableName,
 			HashValue:  bucket.hashKey + ":" + string(metricName),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
+			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV3),
 		},
 	}
 
@@ -451,7 +451,7 @@ func (v6Entries) GetWriteEntries(bucket Bucket, metricName model.LabelValue, lab
 		entries = append(entries, IndexEntry{
 			TableName:  bucket.tableName,
 			HashValue:  fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, key),
-			RangeValue: buildRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
+			RangeValue: encodeRangeKey(encodedThroughBytes, nil, chunkIDBytes, chunkTimeRangeKeyV5),
 			Value:      []byte(value),
 		})
 	}
@@ -469,7 +469,7 @@ func (v6Entries) GetReadMetricQueries(bucket Bucket, metricName model.LabelValue
 		{
 			TableName:       bucket.tableName,
 			HashValue:       bucket.hashKey + ":" + string(metricName),
-			RangeValueStart: buildRangeKey(encodedFromBytes),
+			RangeValueStart: encodeRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
@@ -480,7 +480,7 @@ func (v6Entries) GetReadMetricLabelQueries(bucket Bucket, metricName model.Label
 		{
 			TableName:       bucket.tableName,
 			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
-			RangeValueStart: buildRangeKey(encodedFromBytes),
+			RangeValueStart: encodeRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
@@ -491,7 +491,7 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.
 		{
 			TableName:       bucket.tableName,
 			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
-			RangeValueStart: buildRangeKey(encodedFromBytes),
+			RangeValueStart: encodeRangeKey(encodedFromBytes),
 		},
 	}, nil
 }
@@ -517,7 +517,7 @@ func (entries v7Entries) GetWriteEntries(bucket Bucket, metricName model.LabelVa
 	indexEntries = append(indexEntries, IndexEntry{
 		TableName:  bucket.tableName,
 		HashValue:  bucket.hashKey,
-		RangeValue: buildRangeKey(metricNameHashBytes[:], nil, nil, metricNameRangeKeyV1),
+		RangeValue: encodeRangeKey(metricNameHashBytes[:], nil, nil, metricNameRangeKeyV1),
 		Value:      []byte(metricName),
 	})
 

--- a/chunk/schema_config.go
+++ b/chunk/schema_config.go
@@ -12,6 +12,13 @@ import (
 	"github.com/weaveworks/cortex/util"
 )
 
+const (
+	secondsInHour      = int64(time.Hour / time.Second)
+	secondsInDay       = int64(24 * time.Hour / time.Second)
+	millisecondsInHour = int64(time.Hour / time.Millisecond)
+	millisecondsInDay  = int64(24 * time.Hour / time.Millisecond)
+)
+
 // SchemaConfig contains the config for our chunk index schemas
 type SchemaConfig struct {
 	PeriodicTableConfig

--- a/chunk/schema_config.go
+++ b/chunk/schema_config.go
@@ -80,9 +80,14 @@ func (cfg SchemaConfig) hourlyBuckets(from, through model.Time, userID string) [
 		result      = []Bucket{}
 	)
 
+	// If through ends on the hour, don't include the upcoming hour
+	if through.Unix()%secondsInHour == 0 {
+		throughHour--
+	}
+
 	for i := fromHour; i <= throughHour; i++ {
 		relativeFrom := util.Max64(0, int64(from)-(i*millisecondsInHour))
-		relativeThrough := util.Min64(millisecondsInHour, int64(through)-(i*millisecondsInDay))
+		relativeThrough := util.Min64(millisecondsInHour, int64(through)-(i*millisecondsInHour))
 		result = append(result, Bucket{
 			from:      uint32(relativeFrom),
 			through:   uint32(relativeThrough),
@@ -99,6 +104,11 @@ func (cfg SchemaConfig) dailyBuckets(from, through model.Time, userID string) []
 		throughDay = through.Unix() / secondsInDay
 		result     = []Bucket{}
 	)
+
+	// If through ends on 00:00 of the day, don't include the upcoming day
+	if through.Unix()%secondsInDay == 0 {
+		throughDay--
+	}
 
 	for i := fromDay; i <= throughDay; i++ {
 		// The idea here is that the hash key contains the bucket start time (rounded to

--- a/chunk/schema_config.go
+++ b/chunk/schema_config.go
@@ -110,7 +110,7 @@ func (cfg SchemaConfig) dailyBuckets(from, through model.Time, userID string) []
 			from:      uint32(relativeFrom),
 			through:   uint32(relativeThrough),
 			tableName: cfg.tableForBucket(i * secondsInDay),
-			hashKey:   fmt.Sprintf("%s:%d", userID, i),
+			hashKey:   fmt.Sprintf("%s:d%d", userID, i),
 		})
 	}
 	return result

--- a/chunk/schema_config.go
+++ b/chunk/schema_config.go
@@ -65,7 +65,7 @@ func (cfg *SchemaConfig) tableForBucket(bucketStart int64) string {
 	return cfg.TablePrefix + strconv.Itoa(int(bucketStart/int64(cfg.TablePeriod/time.Second)))
 }
 
-// Bucket is a range of time with a tableName and a hashKey
+// Bucket describes a range of time with a tableName and hashKey
 type Bucket struct {
 	from      uint32
 	through   uint32

--- a/chunk/schema_config_test.go
+++ b/chunk/schema_config_test.go
@@ -319,36 +319,3 @@ func TestCompositeSchema(t *testing.T) {
 		})
 	}
 }
-
-// func TestSchemaDailyBuckets(t *testing.T) {
-// 	const (
-// 		userID     = "0"
-// 		metricName = model.LabelValue("name")
-// 		tableName  = "table"
-// 	)
-// 	var (
-// 		config = SchemaConfig{
-// 			OriginalTableName: tableName,
-// 		}
-// 	)
-
-// 	for _, c := range []struct {
-// 		from, through model.Time
-// 	}{
-// 		{
-// 			from:    model.TimeFromUnix(0),
-// 			through: model.TimeFromUnix(2 * 24 * 3600),
-// 		},
-// 	} {
-// 		var i int64
-// 		_, err := config.dailyBuckets(c.from, c.through, userID, metricName, func(from, through uint32, tableName, hashKey string) ([]IndexEntry, error) {
-// 			require.True(t, (i*millisecondsInDay)+int64(from) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(from), int64(c.from))
-// 			require.True(t, (i*millisecondsInDay)+int64(from) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(from), int64(c.through))
-// 			require.True(t, (i*millisecondsInDay)+int64(through) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(through), int64(c.from))
-// 			require.True(t, (i*millisecondsInDay)+int64(through) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(through), int64(c.through))
-// 			i++
-// 			return nil, nil
-// 		})
-// 		assert.NoError(t, err)
-// 	}
-// }

--- a/chunk/schema_config_test.go
+++ b/chunk/schema_config_test.go
@@ -40,7 +40,7 @@ func TestHourlyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(0),
 				through: model.TimeFromUnix(1800),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      0,
 				through:   1800 * 1000, // ms
 				tableName: "table",
@@ -53,7 +53,7 @@ func TestHourlyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(0),
 				through: model.TimeFromUnix(3600),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      0,
 				through:   3600 * 1000, // ms
 				tableName: "table",
@@ -66,17 +66,17 @@ func TestHourlyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(900),
 				through: model.TimeFromUnix((2 * 3600) + 1800),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      900 * 1000,  // ms
 				through:   3600 * 1000, // ms
 				tableName: "table",
 				hashKey:   "0:0",
-			}, Bucket{
+			}, {
 				from:      0,
 				through:   3600 * 1000, // ms
 				tableName: "table",
 				hashKey:   "0:1",
-			}, Bucket{
+			}, {
 				from:      0,
 				through:   1800 * 1000, // ms
 				tableName: "table",
@@ -124,7 +124,7 @@ func TestDailyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(0),
 				through: model.TimeFromUnix(6 * 3600),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      0,
 				through:   (6 * 3600) * 1000, // ms
 				tableName: "table",
@@ -137,7 +137,7 @@ func TestDailyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(0),
 				through: model.TimeFromUnix(24 * 3600),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      0,
 				through:   (24 * 3600) * 1000, // ms
 				tableName: "table",
@@ -150,17 +150,17 @@ func TestDailyBuckets(t *testing.T) {
 				from:    model.TimeFromUnix(6 * 3600),
 				through: model.TimeFromUnix((2 * 24 * 3600) + (12 * 3600)),
 			},
-			[]Bucket{Bucket{
+			[]Bucket{{
 				from:      (6 * 3600) * 1000,  // ms
 				through:   (24 * 3600) * 1000, // ms
 				tableName: "table",
 				hashKey:   "0:d0",
-			}, Bucket{
+			}, {
 				from:      0,
 				through:   (24 * 3600) * 1000, // ms
 				tableName: "table",
 				hashKey:   "0:d1",
-			}, Bucket{
+			}, {
 				from:      0,
 				through:   (12 * 3600) * 1000, // ms
 				tableName: "table",

--- a/chunk/schema_config_test.go
+++ b/chunk/schema_config_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/test"
 )
 
@@ -146,7 +144,7 @@ func TestSchemaComposite(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("TestSchemaComposite[%d]", i), func(t *testing.T) {
 			have := []result{}
-			tc.cs.forSchemas(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
+			tc.cs.forSchemasIndexEntry(model.TimeFromUnix(tc.from), model.TimeFromUnix(tc.through), collect(&have))
 			if !reflect.DeepEqual(tc.want, have) {
 				t.Fatalf("wrong schemas - %s", test.Diff(tc.want, have))
 			}
@@ -154,35 +152,35 @@ func TestSchemaComposite(t *testing.T) {
 	}
 }
 
-func TestSchemaDailyBuckets(t *testing.T) {
-	const (
-		userID     = "0"
-		metricName = model.LabelValue("name")
-		tableName  = "table"
-	)
-	var (
-		config = SchemaConfig{
-			OriginalTableName: tableName,
-		}
-	)
+// func TestSchemaDailyBuckets(t *testing.T) {
+// 	const (
+// 		userID     = "0"
+// 		metricName = model.LabelValue("name")
+// 		tableName  = "table"
+// 	)
+// 	var (
+// 		config = SchemaConfig{
+// 			OriginalTableName: tableName,
+// 		}
+// 	)
 
-	for _, c := range []struct {
-		from, through model.Time
-	}{
-		{
-			from:    model.TimeFromUnix(0),
-			through: model.TimeFromUnix(2 * 24 * 3600),
-		},
-	} {
-		var i int64
-		_, err := config.dailyBuckets(c.from, c.through, userID, metricName, func(from, through uint32, tableName, hashKey string) ([]IndexEntry, error) {
-			require.True(t, (i*millisecondsInDay)+int64(from) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(from), int64(c.from))
-			require.True(t, (i*millisecondsInDay)+int64(from) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(from), int64(c.through))
-			require.True(t, (i*millisecondsInDay)+int64(through) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(through), int64(c.from))
-			require.True(t, (i*millisecondsInDay)+int64(through) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(through), int64(c.through))
-			i++
-			return nil, nil
-		})
-		assert.NoError(t, err)
-	}
-}
+// 	for _, c := range []struct {
+// 		from, through model.Time
+// 	}{
+// 		{
+// 			from:    model.TimeFromUnix(0),
+// 			through: model.TimeFromUnix(2 * 24 * 3600),
+// 		},
+// 	} {
+// 		var i int64
+// 		_, err := config.dailyBuckets(c.from, c.through, userID, metricName, func(from, through uint32, tableName, hashKey string) ([]IndexEntry, error) {
+// 			require.True(t, (i*millisecondsInDay)+int64(from) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(from), int64(c.from))
+// 			require.True(t, (i*millisecondsInDay)+int64(from) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(from), int64(c.through))
+// 			require.True(t, (i*millisecondsInDay)+int64(through) >= int64(c.from), "%d <= %d", (i*millisecondsInDay)+int64(through), int64(c.from))
+// 			require.True(t, (i*millisecondsInDay)+int64(through) <= int64(c.through), "%d >= %d", (i*millisecondsInDay)+int64(through), int64(c.through))
+// 			i++
+// 			return nil, nil
+// 		})
+// 		assert.NoError(t, err)
+// 	}
+// }

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -241,7 +241,7 @@ const (
 
 // parseRangeValueType returns the type of rangeValue
 func parseRangeValueType(rangeValue []byte) (int, error) {
-	components := deconstructRangeKey(rangeValue)
+	components := unbuildRangeKey(rangeValue)
 	switch {
 	case len(components) < 3:
 		return 0, fmt.Errorf("invalid range value: %x", rangeValue)

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -241,7 +241,7 @@ const (
 
 // parseRangeValueType returns the type of rangeValue
 func parseRangeValueType(rangeValue []byte) (int, error) {
-	components := unbuildRangeKey(rangeValue)
+	components := decodeRangeKey(rangeValue)
 	switch {
 	case len(components) < 3:
 		return 0, fmt.Errorf("invalid range value: %x", rangeValue)

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -21,13 +21,16 @@ type mockSchema int
 func (mockSchema) GetWriteEntries(from, through model.Time, userID string, metricName model.LabelValue, labels model.Metric, chunkID string) ([]IndexEntry, error) {
 	return nil, nil
 }
-func (mockSchema) GetReadEntriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexEntry, error) {
+func (mockSchema) GetReadQueries(from, through model.Time, userID string) ([]IndexQuery, error) {
 	return nil, nil
 }
-func (mockSchema) GetReadEntriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexEntry, error) {
+func (mockSchema) GetReadQueriesForMetric(from, through model.Time, userID string, metricName model.LabelValue) ([]IndexQuery, error) {
 	return nil, nil
 }
-func (mockSchema) GetReadEntriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexEntry, error) {
+func (mockSchema) GetReadQueriesForMetricLabel(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName) ([]IndexQuery, error) {
+	return nil, nil
+}
+func (mockSchema) GetReadQueriesForMetricLabelValue(from, through model.Time, userID string, metricName model.LabelValue, labelName model.LabelName, labelValue model.LabelValue) ([]IndexQuery, error) {
 	return nil, nil
 }
 

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -411,7 +411,7 @@ func TestSchemaRangeKey(t *testing.T) {
 				{
 					TableName:  table,
 					HashValue:  "userid:d0",
-					RangeValue: []byte(string(fooSha1Hash[:]) + "\x00\x00\x006\x00"),
+					RangeValue: append(encodeBase64Bytes(fooSha1Hash[:]), []byte("\x00\x00\x006\x00")...),
 					Value:      []byte("foo"),
 				},
 				{

--- a/chunk/schema_test.go
+++ b/chunk/schema_test.go
@@ -454,8 +454,6 @@ func TestSchemaRangeKey(t *testing.T) {
 				rangeValueType, err := parseRangeValueType(entry.RangeValue)
 				require.NoError(t, err)
 
-				fmt.Printf("range value type: %x", rangeValueType)
-
 				switch rangeValueType {
 				case MetricNameRangeValue:
 					_, err := parseMetricNameRangeValue(entry.RangeValue, entry.Value)

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -82,7 +82,6 @@ const (
 // metric name.
 func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValue, error) {
 	components := deconstructRangeKey(rangeValue)
-	fmt.Printf("components: %x", components)
 	switch {
 	case len(components) < 4:
 		return "", fmt.Errorf("invalid metric name range value: %x", rangeValue)

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-func buildRangeKey(ss ...[]byte) []byte {
+func encodeRangeKey(ss ...[]byte) []byte {
 	length := 0
 	for _, s := range ss {
 		length += len(s) + 1
@@ -24,7 +24,7 @@ func buildRangeKey(ss ...[]byte) []byte {
 	return output
 }
 
-func unbuildRangeKey(value []byte) [][]byte {
+func decodeRangeKey(value []byte) [][]byte {
 	components := make([][]byte, 0, 5)
 	i, j := 0, 0
 	for j < len(value) {
@@ -75,7 +75,7 @@ func decodeTime(bs []byte) uint32 {
 // range values. Currently checks range value key and returns the value as the
 // metric name.
 func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValue, error) {
-	components := unbuildRangeKey(rangeValue)
+	components := decodeRangeKey(rangeValue)
 	switch {
 	case len(components) < 4:
 		return "", fmt.Errorf("invalid metric name range value: %x", rangeValue)
@@ -92,7 +92,7 @@ func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValu
 // parseChunkTimeRangeValue returns the chunkKey, labelValue and metadataInIndex
 // for chunk time range values.
 func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (string, model.LabelValue, bool, error) {
-	components := unbuildRangeKey(rangeValue)
+	components := decodeRangeKey(rangeValue)
 
 	switch {
 	case len(components) < 3:

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -39,6 +39,13 @@ func decodeRangeKey(value []byte) [][]byte {
 	return components
 }
 
+func encodeBase64Bytes(bytes []byte) []byte {
+	encodedLen := base64.RawStdEncoding.EncodedLen(len(bytes))
+	encoded := make([]byte, encodedLen, encodedLen)
+	base64.RawStdEncoding.Encode(encoded, bytes)
+	return encoded
+}
+
 func encodeBase64Value(value model.LabelValue) []byte {
 	encodedLen := base64.RawStdEncoding.EncodedLen(len(value))
 	encoded := make([]byte, encodedLen, encodedLen)

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+
 	"fmt"
 
 	"github.com/prometheus/common/model"

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -24,7 +24,7 @@ func buildRangeKey(ss ...[]byte) []byte {
 	return output
 }
 
-func deconstructRangeKey(value []byte) [][]byte {
+func unbuildRangeKey(value []byte) [][]byte {
 	components := make([][]byte, 0, 5)
 	i, j := 0, 0
 	for j < len(value) {
@@ -75,7 +75,7 @@ func decodeTime(bs []byte) uint32 {
 // range values. Currently checks range value key and returns the value as the
 // metric name.
 func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValue, error) {
-	components := deconstructRangeKey(rangeValue)
+	components := unbuildRangeKey(rangeValue)
 	switch {
 	case len(components) < 4:
 		return "", fmt.Errorf("invalid metric name range value: %x", rangeValue)
@@ -92,7 +92,7 @@ func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValu
 // parseChunkTimeRangeValue returns the chunkKey, labelValue and metadataInIndex
 // for chunk time range values.
 func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (string, model.LabelValue, bool, error) {
-	components := deconstructRangeKey(rangeValue)
+	components := unbuildRangeKey(rangeValue)
 
 	switch {
 	case len(components) < 3:

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -77,50 +77,15 @@ const (
 	ChunkTimeRangeValue
 )
 
-// parseRangeValueType returns the type of rangeValue
-func parseRangeValueType(rangeValue []byte) (int, error) {
-	components := deconstructRangeKey(rangeValue)
-	switch {
-	case len(components) < 3:
-		return 0, fmt.Errorf("invalid range value: %x", rangeValue)
-
-	// v1 & v2 chunk time range values
-	case len(components) == 3:
-		return MetricNameRangeValue, nil
-
-	// chunk time range values
-	case bytes.Equal(components[3], chunkTimeRangeKeyV1):
-		return ChunkTimeRangeValue, nil
-
-	case bytes.Equal(components[3], chunkTimeRangeKeyV2):
-		return ChunkTimeRangeValue, nil
-
-	case bytes.Equal(components[3], chunkTimeRangeKeyV3):
-		return ChunkTimeRangeValue, nil
-
-	case bytes.Equal(components[3], chunkTimeRangeKeyV4):
-		return ChunkTimeRangeValue, nil
-
-	case bytes.Equal(components[3], chunkTimeRangeKeyV5):
-		return ChunkTimeRangeValue, nil
-
-	// metric name range values
-	case bytes.Equal(components[3], metricNameRangeKeyV1):
-		return MetricNameRangeValue, nil
-
-	default:
-		return 0, fmt.Errorf("unrecognised range value type. version: '%v'", string(components[3]))
-	}
-}
-
 // parseMetricNameRangeValue returns the metric name stored in metric name
 // range values. Currently checks range value key and returns the value as the
 // metric name.
 func parseMetricNameRangeValue(rangeValue []byte, value []byte) (model.LabelValue, error) {
 	components := deconstructRangeKey(rangeValue)
+	fmt.Printf("components: %x", components)
 	switch {
 	case len(components) < 4:
-		return "", fmt.Errorf("invalid range value: %x", rangeValue)
+		return "", fmt.Errorf("invalid metric name range value: %x", rangeValue)
 
 	// v1 has the metric name as the value (with the hash as the first component)
 	case bytes.Equal(components[3], metricNameRangeKeyV1):
@@ -138,7 +103,7 @@ func parseChunkTimeRangeValue(rangeValue []byte, value []byte) (string, model.La
 
 	switch {
 	case len(components) < 3:
-		return "", "", false, fmt.Errorf("invalid range value: %x", rangeValue)
+		return "", "", false, fmt.Errorf("invalid chunk time range value: %x", rangeValue)
 
 	// v1 & v2 schema had three components - label name, label value and chunk ID.
 	// No version number.

--- a/chunk/schema_util.go
+++ b/chunk/schema_util.go
@@ -71,12 +71,6 @@ func decodeTime(bs []byte) uint32 {
 	return binary.BigEndian.Uint32(buf)
 }
 
-// range value types
-const (
-	MetricNameRangeValue = iota
-	ChunkTimeRangeValue
-)
-
 // parseMetricNameRangeValue returns the metric name stored in metric name
 // range values. Currently checks range value key and returns the value as the
 // metric name.

--- a/chunk/schema_util_test.go
+++ b/chunk/schema_util_test.go
@@ -31,7 +31,7 @@ func TestSchemaTimeEncoding(t *testing.T) {
 	}
 }
 
-func TestParseRangeValue(t *testing.T) {
+func TestParseChunkTimeRangeValue(t *testing.T) {
 	// Test we can decode legacy range values
 	for _, c := range []struct {
 		encoded        []byte
@@ -64,5 +64,21 @@ func TestParseRangeValue(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, model.LabelValue(c.value), labelValue)
 		assert.Equal(t, c.chunkID, chunkID)
+	}
+}
+
+func TestParseMetricNameRangeValue(t *testing.T) {
+	for _, c := range []struct {
+		encoded       []byte
+		value         string
+		expMetricName string
+	}{
+		// version 1 (id 6) metric name range keys (used in v7 Schema) have
+		// metric name hash in first 'dimension', however just returns the value
+		{[]byte("a1b2c3d4\x00\x00\x006\x00"), "foo", "foo"},
+	} {
+		metricName, err := parseMetricNameRangeValue(c.encoded, []byte(c.value))
+		require.NoError(t, err)
+		assert.Equal(t, model.LabelValue(c.expMetricName), metricName)
 	}
 }

--- a/chunk/schema_util_test.go
+++ b/chunk/schema_util_test.go
@@ -60,7 +60,7 @@ func TestParseRangeValue(t *testing.T) {
 		{[]byte("a1b2c3d4\x00Y29kZQ\x002:1484661279394:1484664879394\x004\x00"),
 			"code", "2:1484661279394:1484664879394"},
 	} {
-		chunkID, labelValue, _, err := parseRangeValue(c.encoded, nil)
+		chunkID, labelValue, _, err := parseChunkTimeRangeValue(c.encoded, nil)
 		require.NoError(t, err)
 		assert.Equal(t, model.LabelValue(c.value), labelValue)
 		assert.Equal(t, c.chunkID, chunkID)

--- a/chunk/schema_util_test.go
+++ b/chunk/schema_util_test.go
@@ -76,6 +76,7 @@ func TestParseMetricNameRangeValue(t *testing.T) {
 		// version 1 (id 6) metric name range keys (used in v7 Schema) have
 		// metric name hash in first 'dimension', however just returns the value
 		{[]byte("a1b2c3d4\x00\x00\x006\x00"), "foo", "foo"},
+		{encodeRangeKey([]byte("bar"), nil, nil, metricNameRangeKeyV1), "bar", "bar"},
 	} {
 		metricName, err := parseMetricNameRangeValue(c.encoded, []byte(c.value))
 		require.NoError(t, err)

--- a/chunk/storage_client.go
+++ b/chunk/storage_client.go
@@ -16,7 +16,7 @@ type StorageClient interface {
 	BatchWrite(context.Context, WriteBatch) error
 
 	// For the read path.
-	QueryPages(ctx context.Context, entry IndexEntry, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error
+	QueryPages(ctx context.Context, query IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error
 
 	// For storing and retrieving chunks.
 	PutChunk(ctx context.Context, key string, data []byte) error

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -448,10 +448,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 			return err
 		}
 
-		metricName, _, ok, err := util.ExtractMetricNameFromMatchers(matchers)
-		if err != nil {
-			return err
-		}
+		metricName, _, ok := util.ExtractMetricNameFromMatchers(matchers)
 
 		req, err := util.ToQueryRequest(from, to, matchers)
 		if err != nil {

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -477,9 +477,9 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 
 // Query implements Querier.
 func (d *Distributor) queryIngesters(ctx context.Context, ingesters []*ring.IngesterDesc, replicationFactor int, req *cortex.QueryRequest) (model.Matrix, error) {
-	// We need a response from a quorum of ingesters, which is n/2 + 1, where n is the replication factor
-	minSuccess := (replicationFactor / 2) + 1
-	maxErrs := len(ingesters) - minSuccess
+	// We need a response from a quorum of ingesters, where maxErrs is n/2, where n is the replicationFactor
+	maxErrs := replicationFactor / 2
+	minSuccess := len(ingesters) - maxErrs
 	if len(ingesters) < minSuccess {
 		return nil, fmt.Errorf("could only find %d ingesters for query. Need at least %d", len(ingesters), minSuccess)
 	}

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -448,7 +448,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 			return err
 		}
 
-		metricName, _, ok := util.ExtractMetricNameFromMatchers(matchers)
+		metricNameMatcher, _, ok := util.ExtractMetricNameMatcherFromMatchers(matchers)
 
 		req, err := util.ToQueryRequest(from, to, matchers)
 		if err != nil {
@@ -457,8 +457,8 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 
 		// Get ingesters by metricName if one exists, otherwise get all ingesters
 		var ingesters []*ring.IngesterDesc
-		if ok {
-			ingesters, err = d.ring.Get(tokenFor(userID, []byte(metricName)), d.cfg.ReplicationFactor, ring.Read)
+		if ok && metricNameMatcher.Type == metric.Equal {
+			ingesters, err = d.ring.Get(tokenFor(userID, []byte(metricNameMatcher.Value)), d.cfg.ReplicationFactor, ring.Read)
 			if err != nil {
 				return promql.ErrStorage(err)
 			}

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -38,7 +38,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - -ingester.join-after=30s
-        - -ingester.claim-on-rollout=true
+        - -ingester.claim-on-rollout=false
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
         - -dynamodb.original-table-name=cortex

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -41,12 +41,15 @@ spec:
         - -ingester.claim-on-rollout=true
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
-        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
         - -dynamodb.periodic-table.start=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -18,12 +18,15 @@ spec:
         - -server.http-listen-port=80
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://abc:123@s3.default.svc.cluster.local:4569
-        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
         - -dynamodb.periodic-table.start=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -21,12 +21,15 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/api/prom/alertmanager/
         - -consul.hostname=consul.default.svc.cluster.local:8500
         - -s3.url=s3://abc:123@default.svc.cluster.local:4569/s3
-        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
         - -dynamodb.periodic-table.start=2017-01-06
         - -dynamodb.daily-buckets-from=2017-01-10
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -16,7 +16,8 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - -server.http-listen-port=80
-        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
         - -dynamodb.periodic-table.start=2017-01-06
         ports:

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -30,19 +30,19 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 }
 
 // ExtractMetricNameFromMatchers extracts the metric name from a set of matchers
-func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, bool, error) {
+func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, bool) {
 	outMatchers := make([]*metric.LabelMatcher, len(matchers)-1)
 	for i, matcher := range matchers {
 		if matcher.Name != model.MetricNameLabel {
 			continue
 		}
 		if matcher.Type != metric.Equal {
-			return "", nil, false, fmt.Errorf("must have equality matcher for MetricNameLabel")
+			return "", nil, false
 		}
 		metricName := matcher.Value
 		copy(outMatchers, matchers[:i])
 		copy(outMatchers[i:], matchers[i+1:])
-		return metricName, outMatchers, true, nil
+		return metricName, outMatchers, true
 	}
-	return "", nil, false, nil
+	return "", nil, false
 }

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -36,6 +36,8 @@ func ExtractMetricNameMatcherFromMatchers(matchers []*metric.LabelMatcher) (*met
 		if matcher.Name != model.MetricNameLabel {
 			continue
 		}
+
+		// Copy other matchers, excluding the found metric name matcher
 		copy(outMatchers, matchers[:i])
 		copy(outMatchers[i:], matchers[i+1:])
 		return matcher, outMatchers, true

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -10,7 +10,8 @@ import (
 // SplitFiltersAndMatchers splits empty matchers off, which are treated as filters, see #220
 func SplitFiltersAndMatchers(allMatchers []*metric.LabelMatcher) (filters, matchers []*metric.LabelMatcher) {
 	for _, matcher := range allMatchers {
-		if matcher.Match("") {
+		// Test for empty filters. Other metrics such as NotEqual are not filters.
+		if matcher.Match("") && (matcher.Type == metric.Equal || matcher.Type == metric.RegexMatch) {
 			filters = append(filters, matcher)
 		} else {
 			matchers = append(matchers, matcher)
@@ -42,5 +43,6 @@ func ExtractMetricNameMatcherFromMatchers(matchers []*metric.LabelMatcher) (*met
 		copy(outMatchers[i:], matchers[i+1:])
 		return matcher, outMatchers, true
 	}
-	return nil, nil, false
+	// Return all matchers if none are metric name matchers
+	return nil, matchers, false
 }

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -30,19 +30,19 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 }
 
 // ExtractMetricNameFromMatchers extracts the metric name from a set of matchers
-func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, error) {
+func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, bool, error) {
 	outMatchers := make([]*metric.LabelMatcher, len(matchers)-1)
 	for i, matcher := range matchers {
 		if matcher.Name != model.MetricNameLabel {
 			continue
 		}
 		if matcher.Type != metric.Equal {
-			return "", nil, fmt.Errorf("must have equality matcher for MetricNameLabel")
+			return "", nil, false, fmt.Errorf("must have equality matcher for MetricNameLabel")
 		}
 		metricName := matcher.Value
 		copy(outMatchers, matchers[:i])
 		copy(outMatchers[i:], matchers[i+1:])
-		return metricName, outMatchers, nil
+		return metricName, outMatchers, true, nil
 	}
-	return "", nil, fmt.Errorf("no matcher for MetricNameLabel")
+	return "", nil, false, nil
 }

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -29,20 +29,16 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 	return "", fmt.Errorf("no MetricNameLabel for chunk")
 }
 
-// ExtractMetricNameFromMatchers extracts the metric name from a set of matchers
-func ExtractMetricNameFromMatchers(matchers []*metric.LabelMatcher) (model.LabelValue, []*metric.LabelMatcher, bool) {
+// ExtractMetricNameMatcherFromMatchers extracts the metric name from a set of matchers
+func ExtractMetricNameMatcherFromMatchers(matchers []*metric.LabelMatcher) (*metric.LabelMatcher, []*metric.LabelMatcher, bool) {
 	outMatchers := make([]*metric.LabelMatcher, len(matchers)-1)
 	for i, matcher := range matchers {
 		if matcher.Name != model.MetricNameLabel {
 			continue
 		}
-		if matcher.Type != metric.Equal {
-			return "", nil, false
-		}
-		metricName := matcher.Value
 		copy(outMatchers, matchers[:i])
 		copy(outMatchers[i:], matchers[i+1:])
-		return metricName, outMatchers, true
+		return matcher, outMatchers, true
 	}
-	return "", nil, false
+	return nil, nil, false
 }

--- a/util/matchers.go
+++ b/util/matchers.go
@@ -32,6 +32,12 @@ func ExtractMetricNameFromMetric(m model.Metric) (model.LabelValue, error) {
 
 // ExtractMetricNameMatcherFromMatchers extracts the metric name from a set of matchers
 func ExtractMetricNameMatcherFromMatchers(matchers []*metric.LabelMatcher) (*metric.LabelMatcher, []*metric.LabelMatcher, bool) {
+	// Handle the case where there is no metric name and all matchers have been
+	// filtered out e.g. {foo=""}.
+	if len(matchers) == 0 {
+		return nil, matchers, false
+	}
+
 	outMatchers := make([]*metric.LabelMatcher, len(matchers)-1)
 	for i, matcher := range matchers {
 		if matcher.Name != model.MetricNameLabel {

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -32,36 +32,41 @@ func TestExtractMetricNameMatcherFromMatchers(t *testing.T) {
 	}
 
 	for i, tc := range []struct {
-		matchers       []*metric.LabelMatcher
-		expName        string
-		expOutMatchers []*metric.LabelMatcher
-		expOk          bool
+		matchers         []*metric.LabelMatcher
+		expMetricMatcher *metric.LabelMatcher
+		expOutMatchers   []*metric.LabelMatcher
+		expOk            bool
 	}{
 		{
-			matchers:       []*metric.LabelMatcher{metricMatcher, labelMatcher1, labelMatcher2},
-			expName:        "testmetric",
-			expOutMatchers: []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
-			expOk:          true,
+			matchers:         []*metric.LabelMatcher{metricMatcher},
+			expMetricMatcher: metricMatcher,
+			expOutMatchers:   []*metric.LabelMatcher{},
+			expOk:            true,
 		}, {
-			matchers:       []*metric.LabelMatcher{labelMatcher1, metricMatcher, labelMatcher2},
-			expName:        "testmetric",
-			expOutMatchers: []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
-			expOk:          true,
+			matchers:         []*metric.LabelMatcher{metricMatcher, labelMatcher1, labelMatcher2},
+			expMetricMatcher: metricMatcher,
+			expOutMatchers:   []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
+			expOk:            true,
 		}, {
-			matchers:       []*metric.LabelMatcher{labelMatcher1, labelMatcher2, metricMatcher},
-			expName:        "testmetric",
-			expOutMatchers: []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
-			expOk:          true,
+			matchers:         []*metric.LabelMatcher{labelMatcher1, metricMatcher, labelMatcher2},
+			expMetricMatcher: metricMatcher,
+			expOutMatchers:   []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
+			expOk:            true,
 		}, {
-			matchers:       []*metric.LabelMatcher{nonEqualityMetricMatcher},
-			expName:        "",
-			expOutMatchers: nil,
-			expOk:          false,
+			matchers:         []*metric.LabelMatcher{labelMatcher1, labelMatcher2, metricMatcher},
+			expMetricMatcher: metricMatcher,
+			expOutMatchers:   []*metric.LabelMatcher{labelMatcher1, labelMatcher2},
+			expOk:            true,
 		}, {
-			matchers:       []*metric.LabelMatcher{jobMatcher},
-			expName:        "",
-			expOutMatchers: nil,
-			expOk:          false,
+			matchers:         []*metric.LabelMatcher{nonEqualityMetricMatcher},
+			expMetricMatcher: nonEqualityMetricMatcher,
+			expOutMatchers:   []*metric.LabelMatcher{},
+			expOk:            true,
+		}, {
+			matchers:         []*metric.LabelMatcher{jobMatcher},
+			expMetricMatcher: nil,
+			expOutMatchers:   nil,
+			expOk:            false,
 		},
 	} {
 		matchersCopy := make([]*metric.LabelMatcher, len(tc.matchers))
@@ -73,8 +78,8 @@ func TestExtractMetricNameMatcherFromMatchers(t *testing.T) {
 			t.Fatalf("%d. Matchers got mutated; want %v, got %v", i, matchersCopy, tc.matchers)
 		}
 
-		if string(nameMatcher) != tc.expName {
-			t.Fatalf("%d. Wrong metric name; want '%q', got %q", i, tc.expName, name)
+		if !reflect.DeepEqual(tc.expMetricMatcher, nameMatcher) {
+			t.Fatalf("%d. Wrong metric matcher; want '%v', got %v", i, tc.expMetricMatcher, nameMatcher)
 		}
 
 		assert.Equal(t, tc.expOutMatchers, outMatchers, "unexpected outMatchers for test case %d", i)

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -65,7 +65,12 @@ func TestExtractMetricNameMatcherFromMatchers(t *testing.T) {
 		}, {
 			matchers:         []*metric.LabelMatcher{jobMatcher},
 			expMetricMatcher: nil,
-			expOutMatchers:   nil,
+			expOutMatchers:   []*metric.LabelMatcher{jobMatcher},
+			expOk:            false,
+		}, {
+			matchers:         []*metric.LabelMatcher{},
+			expMetricMatcher: nil,
+			expOutMatchers:   []*metric.LabelMatcher{},
 			expOk:            false,
 		},
 	} {

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractMetricNameFromMatchers(t *testing.T) {
+func TestExtractMetricNameMatcherFromMatchers(t *testing.T) {
 	metricMatcher, err := metric.NewLabelMatcher(metric.Equal, model.MetricNameLabel, "testmetric")
 	if err != nil {
 		t.Fatal(err)
@@ -67,13 +67,13 @@ func TestExtractMetricNameFromMatchers(t *testing.T) {
 		matchersCopy := make([]*metric.LabelMatcher, len(tc.matchers))
 		copy(matchersCopy, tc.matchers)
 
-		name, outMatchers, ok := ExtractMetricNameFromMatchers(tc.matchers)
+		nameMatcher, outMatchers, ok := ExtractMetricNameMatcherFromMatchers(tc.matchers)
 
 		if !reflect.DeepEqual(tc.matchers, matchersCopy) {
 			t.Fatalf("%d. Matchers got mutated; want %v, got %v", i, matchersCopy, tc.matchers)
 		}
 
-		if string(name) != tc.expName {
+		if string(nameMatcher) != tc.expName {
 			t.Fatalf("%d. Wrong metric name; want '%q', got %q", i, tc.expName, name)
 		}
 

--- a/util/matchers_test.go
+++ b/util/matchers_test.go
@@ -33,7 +33,7 @@ func TestExtractMetricNameFromMatchers(t *testing.T) {
 		matchersCopy := make([]*metric.LabelMatcher, len(matchers))
 		copy(matchersCopy, matchers)
 
-		name, outMatchers, err := ExtractMetricNameFromMatchers(matchers)
+		name, outMatchers, ok, err := ExtractMetricNameFromMatchers(matchers)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -48,5 +48,25 @@ func TestExtractMetricNameFromMatchers(t *testing.T) {
 
 		expOutMatchers := []*metric.LabelMatcher{labelMatcher1, labelMatcher2}
 		assert.Equal(t, expOutMatchers, outMatchers, "unexpected outMatchers for test case %d", i)
+
+		// Metric extracted
+		assert.True(t, ok)
 	}
+}
+
+func TestExtractMetricNameFromMatchersNoMetricLabel(t *testing.T) {
+	// Create matcher with no metric label
+	matcher, err := metric.NewLabelMatcher(metric.Equal, model.JobLabel, "testjob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchers := []*metric.LabelMatcher{matcher}
+
+	_, _, ok, err := ExtractMetricNameFromMatchers(matchers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No metric extracted
+	assert.False(t, ok)
 }


### PR DESCRIPTION
Add support for queries with no metric names. e.g. `{foo="bar"}` or `count({job="foo"}) by (__name__)`

Fixes #313 
- Add support to distributor and chunk store
- Create `v7Schema` to support writing metric name entries
- Refactor `IndexEntry` into `IndexEntry` and `IndexQuery` to make separation clearer
- Create a new range value type for metric names and split the code paths so we now support different types of range values
- Change `ExtractMetricNameFromMatchers` to `ExtractMetricNameMatcherFromMatchers` to support optimistations such as matching NotEqual metric name matchers. e.g. `{foo!="bar"}`
- Update bucket functions to return `Bucket`s instead of using callbacks
- Fix bug in hourly bucket where it was offsetting time by day not hour - created a test for this
