### PR TITLE
Propagate promql.ErrStorage on the query path, so the user gets 500s where appropriate.

### DIFF
--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/metric"
 
 	billing "github.com/weaveworks/billing-client"
@@ -465,7 +466,7 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 		result, err = d.queryIngesters(ctx, ingesters, req)
 		return err
 	})
-	return result, err
+	return result, storage.InternalError(err)
 }
 
 // Query implements Querier.

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -16,7 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/metric"
 
 	billing "github.com/weaveworks/billing-client"
@@ -460,13 +460,13 @@ func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers .
 
 		ingesters, err := d.ring.Get(tokenFor(userID, []byte(metricName)), d.cfg.ReplicationFactor, ring.Read)
 		if err != nil {
-			return err
+			return promql.ErrStorage(err)
 		}
 
 		result, err = d.queryIngesters(ctx, ingesters, req)
-		return err
+		return promql.ErrStorage(err)
 	})
-	return result, storage.InternalError(err)
+	return result, err
 }
 
 // Query implements Querier.

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "6df59b41c76e20298414cbd96ff6579d5c05fd05d6bf7eeec2e4f7e19974f50f",
+    "memo": "4625ab214471adf7ec938dc3ca5180bc896e73e816861875116f51370e2fec93",
     "projects": [
         {
             "name": "cloud.google.com/go",
@@ -681,7 +681,7 @@
         {
             "name": "github.com/prometheus/prometheus",
             "branch": "2571-propagate-api-error",
-            "revision": "709352f367efe106883d59c13b33b1a704c380d9",
+            "revision": "86a16b40bc59aa4d6c4b7746aa95f7506df7f893",
             "repo": "github.com/weaveworks/prometheus",
             "packages": [
                 "config",
@@ -811,8 +811,8 @@
         },
         {
             "name": "github.com/weaveworks/billing-client",
-            "branch": "dep",
-            "revision": "12fb525d52318e5c6ab87b22cc92eabdeaece5d5",
+            "branch": "master",
+            "revision": "88bfaf9272c1fb3bb4fafa967304ee6d6ac96e9e",
             "packages": [
                 "."
             ]
@@ -847,7 +847,7 @@
         {
             "name": "golang.org/x/crypto",
             "branch": "master",
-            "revision": "573951cbe80bb6352881271bb276f48749eab6f4",
+            "revision": "c78caca803c95773f48a844d3dcab04b9bc4d6dd",
             "packages": [
                 "curve25519",
                 "nacl/box",

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "4625ab214471adf7ec938dc3ca5180bc896e73e816861875116f51370e2fec93",
+    "memo": "76d431d1c4519f327d8bd76fc2f6e25f602a87d2bd35e7152d29119b5ec9ab21",
     "projects": [
         {
             "name": "cloud.google.com/go",
@@ -680,9 +680,9 @@
         },
         {
             "name": "github.com/prometheus/prometheus",
-            "branch": "2571-propagate-api-error",
-            "revision": "86a16b40bc59aa4d6c4b7746aa95f7506df7f893",
-            "repo": "github.com/weaveworks/prometheus",
+            "branch": "master",
+            "revision": "516a96d9a355dd25444e002ff1b2a86f541b43a9",
+            "source": "github.com/prometheus/prometheus",
             "packages": [
                 "config",
                 "discovery",

--- a/manifest.json
+++ b/manifest.json
@@ -6,9 +6,6 @@
         "github.com/prometheus/prometheus": {
             "source": "github.com/weaveworks/prometheus",
             "branch": "2571-propagate-api-error"
-        },
-        "github.com/weaveworks/billing-client": {
-            "branch": "dep"
         }
     },
     "overrides": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
             "revision": "0ecc59076ca6b4cbb63252fa7720a3d89d1c81d3"
         },
         "github.com/prometheus/prometheus": {
-            "source": "github.com/weaveworks/prometheus",
-            "branch": "2571-propagate-api-error"
+            "source": "github.com/prometheus/prometheus",
+            "branch": "master"
         }
     },
     "overrides": {

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/local"
 	"github.com/prometheus/prometheus/storage/metric"
 	"golang.org/x/net/context"
@@ -62,7 +61,7 @@ func (q *ChunkQuerier) Query(ctx context.Context, from, to model.Time, matchers 
 	// Get chunks for all matching series from ChunkStore.
 	chunks, err := q.Store.Get(ctx, from, to, matchers...)
 	if err != nil {
-		return nil, storage.InternalError(err)
+		return nil, promql.ErrStorage(err)
 	}
 
 	return chunk.ChunksToMatrix(chunks)

--- a/querier/querier.go
+++ b/querier/querier.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/local"
 	"github.com/prometheus/prometheus/storage/metric"
 	"golang.org/x/net/context"
@@ -61,7 +62,7 @@ func (q *ChunkQuerier) Query(ctx context.Context, from, to model.Time, matchers 
 	// Get chunks for all matching series from ChunkStore.
 	chunks, err := q.Store.Get(ctx, from, to, matchers...)
 	if err != nil {
-		return nil, err
+		return nil, storage.InternalError(err)
 	}
 
 	return chunk.ChunksToMatrix(chunks)
@@ -114,7 +115,6 @@ func (qm MergeQuerier) Query(ctx context.Context, from, to model.Time, matchers 
 	matrix, err := mergeMatrices(matrices, errors, len(qm.Queriers))
 	if err != nil {
 		log.Errorf("Error in MergeQuerier.Query: %v", err)
-
 	}
 	return matrix, err
 }

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -217,6 +217,9 @@ type (
 	ErrQueryTimeout string
 	// ErrQueryCanceled is returned if a query was canceled during processing.
 	ErrQueryCanceled string
+	// ErrStorage is returned if an error was encountered in the storage layer
+	// during query handling.
+	ErrStorage error
 )
 
 func (e ErrQueryTimeout) Error() string  { return fmt.Sprintf("query timed out in %s", string(e)) }

--- a/vendor/github.com/prometheus/prometheus/retrieval/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/retrieval/scrape.go
@@ -178,8 +178,12 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) {
 
 	for fp, oldLoop := range sp.loops {
 		var (
-			t       = sp.targets[fp]
-			s       = &targetScraper{Target: t, client: sp.client}
+			t = sp.targets[fp]
+			s = &targetScraper{
+				Target:  t,
+				client:  sp.client,
+				timeout: timeout,
+			}
 			newLoop = sp.newLoop(sp.ctx, s, sp.appender, t.Labels(), sp.config)
 		)
 		wg.Add(1)
@@ -240,7 +244,12 @@ func (sp *scrapePool) sync(targets []*Target) {
 		uniqueTargets[hash] = struct{}{}
 
 		if _, ok := sp.targets[hash]; !ok {
-			s := &targetScraper{Target: t, client: sp.client}
+			s := &targetScraper{
+				Target:  t,
+				client:  sp.client,
+				timeout: timeout,
+			}
+
 			l := sp.newLoop(sp.ctx, s, sp.appender, t.Labels(), sp.config)
 
 			sp.targets[hash] = t
@@ -283,7 +292,8 @@ type scraper interface {
 // targetScraper implements the scraper interface for a target.
 type targetScraper struct {
 	*Target
-	client *http.Client
+	client  *http.Client
+	timeout time.Duration
 }
 
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,*/*;q=0.1`
@@ -297,6 +307,7 @@ func (s *targetScraper) scrape(ctx context.Context, ts time.Time) (model.Samples
 	}
 	req.Header.Add("Accept", acceptHeader)
 	req.Header.Set("User-Agent", userAgentHeader)
+	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", fmt.Sprintf("%f", s.timeout.Seconds()))
 
 	resp, err := ctxhttp.Do(ctx, s.client, req)
 	if err != nil {
@@ -489,7 +500,7 @@ func (sl *scrapeLoop) append(samples model.Samples) (int, error) {
 		var wrappedBufApp storage.SampleAppender
 		wrappedBufApp, countingApp = sl.wrapAppender(bufApp)
 		for _, s := range samples {
-			// Ignore errors as bufferedAppender always succeds.
+			// Ignore errors as bufferedAppender always succeeds.
 			wrappedBufApp.Append(s)
 		}
 		samples = bufApp.buffer

--- a/vendor/github.com/prometheus/prometheus/retrieval/scrape_test.go
+++ b/vendor/github.com/prometheus/prometheus/retrieval/scrape_test.go
@@ -581,8 +581,20 @@ func TestScrapeLoopRun(t *testing.T) {
 }
 
 func TestTargetScraperScrapeOK(t *testing.T) {
+	const (
+		configTimeout   = 1500 * time.Millisecond
+		expectedTimeout = "1.500000"
+	)
+
 	server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			timeout := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds")
+			if timeout != expectedTimeout {
+				t.Errorf("Scrape timeout did not match expected timeout")
+				t.Errorf("Expected: %v", expectedTimeout)
+				t.Fatalf("Got: %v", timeout)
+			}
+
 			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
 			w.Write([]byte("metric_a 1\nmetric_b 2\n"))
 		}),
@@ -601,7 +613,8 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 				model.AddressLabel: model.LabelValue(serverURL.Host),
 			},
 		},
-		client: http.DefaultClient,
+		client:  http.DefaultClient,
+		timeout: configTimeout,
 	}
 	now := time.Now()
 

--- a/vendor/github.com/prometheus/prometheus/storage/local/codable/codable.go
+++ b/vendor/github.com/prometheus/prometheus/storage/local/codable/codable.go
@@ -123,6 +123,8 @@ func DecodeUint64(r io.Reader) (uint64, error) {
 // encodeString writes the varint encoded length followed by the bytes of s to
 // b.
 func encodeString(b *bytes.Buffer, s string) error {
+	// Note that this should have used EncodeUvarint but a glitch happened
+	// while designing the checkpoint format.
 	if _, err := EncodeVarint(b, int64(len(s))); err != nil {
 		return err
 	}
@@ -135,6 +137,9 @@ func encodeString(b *bytes.Buffer, s string) error {
 // decodeString decodes a string encoded by encodeString.
 func decodeString(b byteReader) (string, error) {
 	length, err := binary.ReadVarint(b)
+	if length < 0 {
+		err = fmt.Errorf("found negative string length during decoding: %d", length)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -155,6 +160,8 @@ type Metric model.Metric
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (m Metric) MarshalBinary() ([]byte, error) {
 	buf := &bytes.Buffer{}
+	// Note that this should have used EncodeUvarint but a glitch happened
+	// while designing the checkpoint format.
 	if _, err := EncodeVarint(buf, int64(len(m))); err != nil {
 		return nil, err
 	}
@@ -180,6 +187,9 @@ func (m *Metric) UnmarshalBinary(buf []byte) error {
 // Metric.
 func (m *Metric) UnmarshalFromReader(r byteReader) error {
 	numLabelPairs, err := binary.ReadVarint(r)
+	if numLabelPairs < 0 {
+		err = fmt.Errorf("found negative numLabelPairs during unmarshaling: %d", numLabelPairs)
+	}
 	if err != nil {
 		return err
 	}
@@ -344,6 +354,8 @@ type LabelValueSet map[model.LabelValue]struct{}
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (vs LabelValueSet) MarshalBinary() ([]byte, error) {
 	buf := &bytes.Buffer{}
+	// Note that this should have used EncodeUvarint but a glitch happened
+	// while designing the checkpoint format.
 	if _, err := EncodeVarint(buf, int64(len(vs))); err != nil {
 		return nil, err
 	}
@@ -359,6 +371,9 @@ func (vs LabelValueSet) MarshalBinary() ([]byte, error) {
 func (vs *LabelValueSet) UnmarshalBinary(buf []byte) error {
 	r := bytes.NewReader(buf)
 	numValues, err := binary.ReadVarint(r)
+	if numValues < 0 {
+		err = fmt.Errorf("found negative number of values during unmarshaling: %d", numValues)
+	}
 	if err != nil {
 		return err
 	}
@@ -382,6 +397,8 @@ type LabelValues model.LabelValues
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (vs LabelValues) MarshalBinary() ([]byte, error) {
 	buf := &bytes.Buffer{}
+	// Note that this should have used EncodeUvarint but a glitch happened
+	// while designing the checkpoint format.
 	if _, err := EncodeVarint(buf, int64(len(vs))); err != nil {
 		return nil, err
 	}
@@ -397,6 +414,9 @@ func (vs LabelValues) MarshalBinary() ([]byte, error) {
 func (vs *LabelValues) UnmarshalBinary(buf []byte) error {
 	r := bytes.NewReader(buf)
 	numValues, err := binary.ReadVarint(r)
+	if numValues < 0 {
+		err = fmt.Errorf("found negative number of values during unmarshaling: %d", numValues)
+	}
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/prometheus/prometheus/storage/storage.go
+++ b/vendor/github.com/prometheus/prometheus/storage/storage.go
@@ -74,7 +74,3 @@ func (f Fanout) NeedsThrottling() bool {
 	}
 	return false
 }
-
-// InternalError can be returned by Query and will be returned as a 500 Internal
-// Server Error by the API
-type InternalError error

--- a/vendor/github.com/prometheus/prometheus/storage/storage.go
+++ b/vendor/github.com/prometheus/prometheus/storage/storage.go
@@ -74,3 +74,7 @@ func (f Fanout) NeedsThrottling() bool {
 	}
 	return false
 }
+
+// InternalError can be returned by Query and will be returned as a 500 Internal
+// Server Error by the API
+type InternalError error

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/retrieval"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/local"
 	"github.com/prometheus/prometheus/storage/metric"
 	"github.com/prometheus/prometheus/util/httputil"
@@ -196,7 +195,7 @@ func (api *API) query(r *http.Request) (interface{}, *apiError) {
 			return nil, &apiError{errorCanceled, res.Err}
 		case promql.ErrQueryTimeout:
 			return nil, &apiError{errorTimeout, res.Err}
-		case storage.InternalError:
+		case promql.ErrStorage:
 			return nil, &apiError{errorInternal, res.Err}
 		}
 		return nil, &apiError{errorExec, res.Err}

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
@@ -95,7 +95,7 @@ func TestEndpoints(t *testing.T) {
 		params   map[string]string
 		query    url.Values
 		response interface{}
-		errType  ErrorType
+		errType  errorType
 	}{
 		{
 			endpoint: api.query,
@@ -182,7 +182,7 @@ func TestEndpoints(t *testing.T) {
 				"end":   []string{"2"},
 				"step":  []string{"1"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		{
 			endpoint: api.queryRange,
@@ -191,7 +191,7 @@ func TestEndpoints(t *testing.T) {
 				"start": []string{"0"},
 				"step":  []string{"1"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		{
 			endpoint: api.queryRange,
@@ -200,7 +200,7 @@ func TestEndpoints(t *testing.T) {
 				"start": []string{"0"},
 				"end":   []string{"2"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		// Bad query expression.
 		{
@@ -209,7 +209,7 @@ func TestEndpoints(t *testing.T) {
 				"query": []string{"invalid][query"},
 				"time":  []string{"1970-01-01T01:02:03+01:00"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		{
 			endpoint: api.queryRange,
@@ -219,7 +219,7 @@ func TestEndpoints(t *testing.T) {
 				"end":   []string{"100"},
 				"step":  []string{"1"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		// Invalid step.
 		{
@@ -230,7 +230,7 @@ func TestEndpoints(t *testing.T) {
 				"end":   []string{"2"},
 				"step":  []string{"0"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		// Start after end.
 		{
@@ -241,7 +241,7 @@ func TestEndpoints(t *testing.T) {
 				"end":   []string{"1"},
 				"step":  []string{"1"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		// Start overflows int64 internally.
 		{
@@ -252,7 +252,7 @@ func TestEndpoints(t *testing.T) {
 				"end":   []string{"1489667272.372"},
 				"step":  []string{"1"},
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		{
 			endpoint: api.labelValues,
@@ -280,7 +280,7 @@ func TestEndpoints(t *testing.T) {
 			params: map[string]string{
 				"name": "not!!!allowed",
 			},
-			errType: ErrorBadData,
+			errType: errorBadData,
 		},
 		{
 			endpoint: api.series,
@@ -413,11 +413,11 @@ func TestEndpoints(t *testing.T) {
 		// Missing match[] query params in series requests.
 		{
 			endpoint: api.series,
-			errType:  ErrorBadData,
+			errType:  errorBadData,
 		},
 		{
 			endpoint: api.dropSeries,
-			errType:  ErrorBadData,
+			errType:  errorBadData,
 		},
 		// The following tests delete time series from the test storage. They
 		// must remain at the end and are fixed in their order.
@@ -489,7 +489,7 @@ func TestEndpoints(t *testing.T) {
 		}
 		resp, apiErr := test.endpoint(req)
 		if apiErr != nil {
-			if test.errType == ErrorNone {
+			if test.errType == errorNone {
 				t.Fatalf("Unexpected error: %s", apiErr)
 			}
 			if test.errType != apiErr.typ {
@@ -497,7 +497,7 @@ func TestEndpoints(t *testing.T) {
 			}
 			continue
 		}
-		if apiErr == nil && test.errType != ErrorNone {
+		if apiErr == nil && test.errType != errorNone {
 			t.Fatalf("Expected error of type %q but got none", test.errType)
 		}
 		if !reflect.DeepEqual(resp, test.response) {
@@ -547,7 +547,7 @@ func TestRespondSuccess(t *testing.T) {
 
 func TestRespondError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		respondError(w, &APIError{ErrorTimeout, errors.New("message")}, "test")
+		respondError(w, &apiError{errorTimeout, errors.New("message")}, "test")
 	}))
 	defer s.Close()
 
@@ -576,7 +576,7 @@ func TestRespondError(t *testing.T) {
 	exp := &response{
 		Status:    statusError,
 		Data:      "test",
-		ErrorType: ErrorTimeout,
+		ErrorType: errorTimeout,
 		Error:     "message",
 	}
 	if !reflect.DeepEqual(&res, exp) {

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
@@ -453,7 +453,7 @@ func TestEndpoints(t *testing.T) {
 			endpoint: api.targets,
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
-					&Target{
+					{
 						DiscoveredLabels: model.LabelSet{},
 						Labels:           model.LabelSet{},
 						ScrapeURL:        "http://example.com:8080/metrics",
@@ -465,7 +465,7 @@ func TestEndpoints(t *testing.T) {
 			endpoint: api.alertmanagers,
 			response: &AlertmanagerDiscovery{
 				ActiveAlertmanagers: []*AlertmanagerTarget{
-					&AlertmanagerTarget{
+					{
 						URL: "http://alertmanager.example.com:8080/api/v1/alerts",
 					},
 				},


### PR DESCRIPTION
Fixes #382 

Uses fork of Prometheus container weaveworks/prometheus/2571-propagate-api-error until https://github.com/prometheus/prometheus/issues/2571 is fixed.