### PR TITLE
Fix tracking of last sample time and value

### DIFF
--- a/ingester/series.go
+++ b/ingester/series.go
@@ -98,6 +98,10 @@ func (s *memorySeries) add(v model.SamplePair) error {
 		}
 	}
 
+	s.lastTime = v.Timestamp
+	s.lastSampleValue = v.Value
+	s.lastSampleValueSet = true
+
 	return nil
 }
 
@@ -164,7 +168,6 @@ func (s *memorySeries) setChunks(descs []*desc) error {
 	}
 
 	s.chunkDescs = descs
-	s.lastSampleValueSet = true
 	s.lastTime = descs[len(descs)-1].LastTime
 	return nil
 }


### PR DESCRIPTION
This fixes the tracking of the last sample time and value, which is
needed to detect duplicate or out-of-order samples upon ingestion.

To be totally correct, we would also need to set seriesLastSampleValue
in the transfer receiver code, but there's no good way to get at it, and
apparently we have had the same problem after unarchiving series or
after restoring from a checkpoint at startup:
https://github.com/prometheus/prometheus/issues/2602

But that is only a minor problem, as it only means that we will
misreport duplicate samples (same timestamp *and* same value) as
duplicate timestamp, but different value (error instead of silent noop).
Before trying to fix that here, I'd want to see what the reaction to the
upstream issue is, and whether that results in us adding an efficient
way to get the last sample value of a restored series in general.

So for now, this just removes the "lastSampleValueSet = true" after a
transfer from a different ingester, because that is totally a lie.

Fixes https://github.com/weaveworks/cortex/issues/355