### PR TITLE
Log details about out-of-order and duplicate samples

### DIFF
--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -57,15 +57,6 @@ var (
 		"The total number of series pending in the flush queue.",
 		nil, nil,
 	)
-
-	// ErrOutOfOrderSample is returned if a sample has a timestamp before the latest
-	// timestamp in the series it is appended to.
-	ErrOutOfOrderSample = fmt.Errorf("sample timestamp out of order")
-	// ErrDuplicateSampleForTimestamp is returned if a sample has the same
-	// timestamp as the latest sample in the series it is appended to but a
-	// different value. (Appending an identical sample is a no-op and does
-	// not cause an error.)
-	ErrDuplicateSampleForTimestamp = fmt.Errorf("sample with repeated timestamp but different value")
 )
 
 // Config for an Ingester.

--- a/ingester/ingester_test.go
+++ b/ingester/ingester_test.go
@@ -149,11 +149,11 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 
 	// Earlier sample than previous one.
 	err = ing.append(ctx, &model.Sample{Metric: m, Timestamp: 0, Value: 0})
-	require.EqualError(t, err, ErrOutOfOrderSample.Error())
+	require.Contains(t, err.Error(), "sample timestamp out of order")
 
 	// Same timestamp as previous sample, but different value.
 	err = ing.append(ctx, &model.Sample{Metric: m, Timestamp: 1, Value: 1})
-	require.EqualError(t, err, ErrDuplicateSampleForTimestamp.Error())
+	require.Contains(t, err.Error(), "sample with repeated timestamp but different value")
 }
 
 func TestIngesterUserSeriesLimitExceeded(t *testing.T) {

--- a/ingester/series.go
+++ b/ingester/series.go
@@ -64,11 +64,11 @@ func (s *memorySeries) add(v model.SamplePair) error {
 	}
 	if v.Timestamp == s.lastTime {
 		discardedSamples.WithLabelValues(duplicateSample).Inc()
-		return ErrDuplicateSampleForTimestamp // Caused by the caller.
+		return fmt.Errorf("sample with repeated timestamp but different value for series %v; last value: %v, incoming value: %v", s.metric, s.lastSampleValue, v.Value) // Caused by the caller.
 	}
 	if v.Timestamp < s.lastTime {
 		discardedSamples.WithLabelValues(outOfOrderTimestamp).Inc()
-		return ErrOutOfOrderSample // Caused by the caller.
+		return fmt.Errorf("sample timestamp out of order for series %v; last timestamp: %v, incoming timestamp: %v", s.metric, s.lastTime, v.Timestamp) // Caused by the caller.
 	}
 
 	if len(s.chunkDescs) == 0 || s.headChunkClosed {


### PR DESCRIPTION
We're still getting errors about duplicate and out-of-order samples in dev, so we need to log more to find out what series are the culprits.