### PR TITLE
Consolidate /configs and /configs/api Config types

### DIFF
--- a/alertmanager/multitenant.go
+++ b/alertmanager/multitenant.go
@@ -18,7 +18,8 @@ import (
 
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/user"
-	configs "github.com/weaveworks/cortex/configs/client"
+	"github.com/weaveworks/cortex/configs"
+	configs_client "github.com/weaveworks/cortex/configs/client"
 	"github.com/weaveworks/cortex/util"
 	"github.com/weaveworks/mesh"
 )
@@ -87,15 +88,15 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet) {
 type MultitenantAlertmanager struct {
 	cfg *MultitenantAlertmanagerConfig
 
-	configsAPI configs.AlertManagerConfigsAPI
+	configsAPI configs_client.AlertManagerConfigsAPI
 
 	// All the organization configurations that we have. Only used for instrumentation.
-	cfgs map[string]configs.CortexConfig
+	cfgs map[string]configs.Config
 
 	alertmanagersMtx sync.Mutex
 	alertmanagers    map[string]*Alertmanager
 
-	latestConfig configs.ConfigID
+	latestConfig configs.ID
 	latestMutex  sync.RWMutex
 
 	meshRouter *gossipFactory
@@ -118,7 +119,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 
 	mrouter.ConnectionMaker.InitiateConnections(cfg.MeshPeers.slice(), true)
 
-	configsAPI := configs.AlertManagerConfigsAPI{
+	configsAPI := configs_client.AlertManagerConfigsAPI{
 		URL:     cfg.ConfigsAPIURL.URL,
 		Timeout: cfg.ClientTimeout,
 	}
@@ -127,7 +128,7 @@ func NewMultitenantAlertmanager(cfg *MultitenantAlertmanagerConfig) (*Multitenan
 	return &MultitenantAlertmanager{
 		cfg:           cfg,
 		configsAPI:    configsAPI,
-		cfgs:          map[string]configs.CortexConfig{},
+		cfgs:          map[string]configs.Config{},
 		alertmanagers: map[string]*Alertmanager{},
 		meshRouter:    &gf,
 		stop:          make(chan struct{}),
@@ -168,7 +169,7 @@ func (am *MultitenantAlertmanager) Stop() {
 
 // Load the full set of configurations from the server, retrying with backoff
 // until we can get them.
-func (am *MultitenantAlertmanager) loadAllConfigs() map[string]configs.CortexConfigView {
+func (am *MultitenantAlertmanager) loadAllConfigs() map[string]configs.View {
 	backoff := minBackoff
 	for {
 		cfgs, err := am.poll()
@@ -195,9 +196,9 @@ func (am *MultitenantAlertmanager) updateConfigs(now time.Time) error {
 }
 
 // poll the configuration server. Not re-entrant.
-func (am *MultitenantAlertmanager) poll() (map[string]configs.CortexConfigView, error) {
+func (am *MultitenantAlertmanager) poll() (map[string]configs.View, error) {
 	configID := am.latestConfig
-	var cfgs *configs.CortexConfigsResponse
+	var cfgs *configs_client.ConfigsResponse
 	err := instrument.TimeRequestHistogram(context.Background(), "Configs.GetOrgConfigs", configsRequestDuration, func(_ context.Context) error {
 		var err error
 		cfgs, err = am.configsAPI.GetConfigs(configID)
@@ -213,7 +214,7 @@ func (am *MultitenantAlertmanager) poll() (map[string]configs.CortexConfigView, 
 	return cfgs.Configs, nil
 }
 
-func (am *MultitenantAlertmanager) addNewConfigs(cfgs map[string]configs.CortexConfigView) {
+func (am *MultitenantAlertmanager) addNewConfigs(cfgs map[string]configs.View) {
 	// TODO: instrument how many configs we have, both valid & invalid.
 	log.Debugf("Adding %d configurations", len(cfgs))
 	for userID, config := range cfgs {
@@ -230,8 +231,8 @@ func (am *MultitenantAlertmanager) addNewConfigs(cfgs map[string]configs.CortexC
 
 // setConfig applies the given configuration to the alertmanager for `userID`,
 // creating an alertmanager if it doesn't already exist.
-func (am *MultitenantAlertmanager) setConfig(userID string, config configs.CortexConfig) error {
-	amConfig, err := config.GetAlertmanagerConfig()
+func (am *MultitenantAlertmanager) setConfig(userID string, config configs.Config) error {
+	amConfig, err := configs_client.AlertmanagerConfigFromConfig(config)
 	if err != nil {
 		// XXX: This means that if a user has a working configuration and
 		// they submit a broken one, we'll keep processing the last known

--- a/configs/api/api.go
+++ b/configs/api/api.go
@@ -160,14 +160,14 @@ func validateAlertmanagerConfig(cfg string) error {
 	return nil
 }
 
-// ConfigsView renders multiple configurations, mapping userID to ConfigView.
+// ConfigsView renders multiple configurations, mapping userID to configs.View.
 // Exposed only for tests.
 type ConfigsView struct {
-	Configs map[string]configs.ConfigView `json:"configs"`
+	Configs map[string]configs.View `json:"configs"`
 }
 
 func (a *API) getConfigs(w http.ResponseWriter, r *http.Request) {
-	var cfgs map[string]configs.ConfigView
+	var cfgs map[string]configs.View
 	var err error
 	rawSince := r.FormValue("since")
 	if rawSince == "" {

--- a/configs/api/helpers_test.go
+++ b/configs/api/helpers_test.go
@@ -69,29 +69,27 @@ func makeUserID() string {
 
 // makeConfig makes some arbitrary configuration.
 func makeConfig() configs.Config {
-	arbitraryKey := makeString("key%d")
-	arbitraryValue := makeString("value%d")
-	return configs.Config{arbitraryKey: arbitraryValue}
+	return configs.Config{
+		AlertmanagerConfig: makeString(`
+		    # Config no. %d.
+		    route:
+		      receiver: noop
+
+		    receivers:
+		    - name: noop`),
+		RulesFiles: nil,
+	}
 }
 
-type jsonObject map[string]interface{}
-
-func (j jsonObject) Reader(t *testing.T) io.Reader {
-	b, err := json.Marshal(j)
+func readerFromConfig(t *testing.T, config configs.Config) io.Reader {
+	b, err := json.Marshal(config)
 	require.NoError(t, err)
 	return bytes.NewReader(b)
 }
 
-func parseJSON(t *testing.T, b []byte) jsonObject {
-	var f jsonObject
-	err := json.Unmarshal(b, &f)
-	require.NoError(t, err, "Could not unmarshal JSON: %v", string(b))
-	return f
-}
-
-// parseConfigView parses a ConfigView from JSON.
-func parseConfigView(t *testing.T, b []byte) configs.ConfigView {
-	var x configs.ConfigView
+// parseView parses a configs.View from JSON.
+func parseView(t *testing.T, b []byte) configs.View {
+	var x configs.View
 	err := json.Unmarshal(b, &x)
 	require.NoError(t, err, "Could not unmarshal JSON: %v", string(b))
 	return x

--- a/configs/client/configs_test.go
+++ b/configs/client/configs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/cortex/configs"
 )
 
 func TestJSONDecoding(t *testing.T) {
@@ -23,10 +24,10 @@ func TestJSONDecoding(t *testing.T) {
 }
 `))
 	assert.Nil(t, err)
-	expected := CortexConfigsResponse{Configs: map[string]CortexConfigView{
+	expected := ConfigsResponse{Configs: map[string]configs.View{
 		"2": {
-			ConfigID: 1,
-			Config: CortexConfig{
+			ID: 1,
+			Config: configs.Config{
 				RulesFiles: map[string]string{
 					"recording.rules": ":scope_authfe_request_duration_seconds:99quantile = histogram_quantile(0.99, sum(rate(scope_request_duration_seconds_bucket{ws=\"false\",job=\"authfe\",route!~\"(admin|metrics).*\"}[5m])) by (le))\n",
 				},

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,15 +1,23 @@
 package configs
 
-// ID is the unique ID given to each configuration. When a configuration
-// changes, it gets a new ID.
+// An ID is the ID of a single users's Cortex configuration. When a
+// configuration changes, it gets a new ID.
 type ID int
 
-// Config is a configuration of a subsystem. It's a map of arbitrary field
-// names to arbitrary values.
-type Config map[string]interface{}
+// A Config is a Cortex configuration for a single user.
+type Config struct {
+	// RulesFiles maps from a rules filename to file contents.
+	RulesFiles         map[string]string `json:"rules_files"`
+	AlertmanagerConfig string            `json:"alertmanager_config"`
+}
 
-// ConfigView is what users get when they get a config.
-type ConfigView struct {
+// View is what's returned from the Weave Cloud configs service
+// when we ask for all Cortex configurations.
+//
+// The configs service is essentially a JSON blob store that gives each
+// _version_ of a configuration a unique ID and guarantees that later versions
+// have greater IDs.
+type View struct {
 	ID     ID     `json:"id"`
 	Config Config `json:"config"`
 }

--- a/configs/db/db.go
+++ b/configs/db/db.go
@@ -24,11 +24,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // DB is the interface for the database.
 type DB interface {
-	GetConfig(userID string) (configs.ConfigView, error)
+	GetConfig(userID string) (configs.View, error)
 	SetConfig(userID string, cfg configs.Config) error
 
-	GetAllConfigs() (map[string]configs.ConfigView, error)
-	GetConfigs(since configs.ID) (map[string]configs.ConfigView, error)
+	GetAllConfigs() (map[string]configs.View, error)
+	GetConfigs(since configs.ID) (map[string]configs.View, error)
 
 	Close() error
 }

--- a/configs/db/memory/memory.go
+++ b/configs/db/memory/memory.go
@@ -11,8 +11,8 @@ type config struct {
 	id  configs.ID
 }
 
-func (c config) toView() configs.ConfigView {
-	return configs.ConfigView{
+func (c config) toView() configs.View {
+	return configs.View{
 		ID:     c.id,
 		Config: c.cfg,
 	}
@@ -33,10 +33,10 @@ func New(_, _ string) (*DB, error) {
 }
 
 // GetConfig gets the user's configuration.
-func (d *DB) GetConfig(userID string) (configs.ConfigView, error) {
+func (d *DB) GetConfig(userID string) (configs.View, error) {
 	c, ok := d.cfgs[userID]
 	if !ok {
-		return configs.ConfigView{}, sql.ErrNoRows
+		return configs.View{}, sql.ErrNoRows
 	}
 	return c.toView(), nil
 }
@@ -49,8 +49,8 @@ func (d *DB) SetConfig(userID string, cfg configs.Config) error {
 }
 
 // GetAllConfigs gets all of the configs.
-func (d *DB) GetAllConfigs() (map[string]configs.ConfigView, error) {
-	cfgs := map[string]configs.ConfigView{}
+func (d *DB) GetAllConfigs() (map[string]configs.View, error) {
+	cfgs := map[string]configs.View{}
 	for user, c := range d.cfgs {
 		cfgs[user] = c.toView()
 	}
@@ -58,8 +58,8 @@ func (d *DB) GetAllConfigs() (map[string]configs.ConfigView, error) {
 }
 
 // GetConfigs gets all of the configs that have changed recently.
-func (d *DB) GetConfigs(since configs.ID) (map[string]configs.ConfigView, error) {
-	cfgs := map[string]configs.ConfigView{}
+func (d *DB) GetConfigs(since configs.ID) (map[string]configs.View, error) {
+	cfgs := map[string]configs.View{}
 	for user, c := range d.cfgs {
 		if c.id > since {
 			cfgs[user] = c.toView()

--- a/configs/db/postgres/postgres.go
+++ b/configs/db/postgres/postgres.go
@@ -61,7 +61,7 @@ func New(uri, migrationsDir string) (DB, error) {
 
 var statementBuilder = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).RunWith
 
-func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.ConfigView, error) {
+func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.View, error) {
 	rows, err := d.Select("id", "owner_id", "config").
 		Options("DISTINCT ON (owner_id)").
 		From("configs").
@@ -72,9 +72,9 @@ func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.ConfigView,
 		return nil, err
 	}
 	defer rows.Close()
-	cfgs := map[string]configs.ConfigView{}
+	cfgs := map[string]configs.View{}
 	for rows.Next() {
-		var cfg configs.ConfigView
+		var cfg configs.View
 		var cfgBytes []byte
 		var userID string
 		err = rows.Scan(&cfg.ID, &userID, &cfgBytes)
@@ -91,8 +91,8 @@ func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.ConfigView,
 }
 
 // GetConfig gets a configuration.
-func (d DB) GetConfig(userID string) (configs.ConfigView, error) {
-	var cfgView configs.ConfigView
+func (d DB) GetConfig(userID string) (configs.View, error) {
+	var cfgView configs.View
 	var cfgBytes []byte
 	err := d.Select("id", "config").
 		From("configs").
@@ -121,12 +121,12 @@ func (d DB) SetConfig(userID string, cfg configs.Config) error {
 }
 
 // GetAllConfigs gets all of the configs.
-func (d DB) GetAllConfigs() (map[string]configs.ConfigView, error) {
+func (d DB) GetAllConfigs() (map[string]configs.View, error) {
 	return d.findConfigs(activeConfig)
 }
 
 // GetConfigs gets all of the configs that have changed recently.
-func (d DB) GetConfigs(since configs.ID) (map[string]configs.ConfigView, error) {
+func (d DB) GetConfigs(since configs.ID) (map[string]configs.View, error) {
 	return d.findConfigs(squirrel.And{
 		activeConfig,
 		squirrel.Gt{"id": since},

--- a/configs/db/timed.go
+++ b/configs/db/timed.go
@@ -38,7 +38,7 @@ func (t timed) timeRequest(method string, f func(context.Context) error) error {
 	return instrument.TimeRequestHistogramStatus(context.TODO(), method, databaseRequestDuration, t.errorCode, f)
 }
 
-func (t timed) GetConfig(userID string) (cfg configs.ConfigView, err error) {
+func (t timed) GetConfig(userID string) (cfg configs.View, err error) {
 	t.timeRequest("GetConfig", func(_ context.Context) error {
 		cfg, err = t.d.GetConfig(userID)
 		return err
@@ -52,7 +52,7 @@ func (t timed) SetConfig(userID string, cfg configs.Config) (err error) {
 	})
 }
 
-func (t timed) GetAllConfigs() (cfgs map[string]configs.ConfigView, err error) {
+func (t timed) GetAllConfigs() (cfgs map[string]configs.View, err error) {
 	t.timeRequest("GetAllConfigs", func(_ context.Context) error {
 		cfgs, err = t.d.GetAllConfigs()
 		return err
@@ -60,7 +60,7 @@ func (t timed) GetAllConfigs() (cfgs map[string]configs.ConfigView, err error) {
 	return
 }
 
-func (t timed) GetConfigs(since configs.ID) (cfgs map[string]configs.ConfigView, err error) {
+func (t timed) GetConfigs(since configs.ID) (cfgs map[string]configs.View, err error) {
 	t.timeRequest("GetConfigs", func(_ context.Context) error {
 		cfgs, err = t.d.GetConfigs(since)
 		return err

--- a/configs/db/traced.go
+++ b/configs/db/traced.go
@@ -14,7 +14,7 @@ func (t traced) trace(name string, args ...interface{}) {
 	logrus.Debugf("%s: %#v", name, args)
 }
 
-func (t traced) GetConfig(userID string) (cfg configs.ConfigView, err error) {
+func (t traced) GetConfig(userID string) (cfg configs.View, err error) {
 	defer func() { t.trace("GetConfig", userID, cfg, err) }()
 	return t.d.GetConfig(userID)
 }
@@ -24,12 +24,12 @@ func (t traced) SetConfig(userID string, cfg configs.Config) (err error) {
 	return t.d.SetConfig(userID, cfg)
 }
 
-func (t traced) GetAllConfigs() (cfgs map[string]configs.ConfigView, err error) {
+func (t traced) GetAllConfigs() (cfgs map[string]configs.View, err error) {
 	defer func() { t.trace("GetAllConfigs", cfgs, err) }()
 	return t.d.GetAllConfigs()
 }
 
-func (t traced) GetConfigs(since configs.ID) (cfgs map[string]configs.ConfigView, err error) {
+func (t traced) GetConfigs(since configs.ID) (cfgs map[string]configs.View, err error) {
 	defer func() { t.trace("GetConfigs", since, cfgs, err) }()
 	return t.d.GetConfigs(since)
 }


### PR DESCRIPTION
Now that the configuration DB, API, and client lives in Cortex, we
should consolidate the various config types to only use the more typed
versions.