### PR TITLE
Filter equality matchers on the dynamo side

### DIFF
--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -241,11 +241,11 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 	}
 
 	// Filters
-	if entry.ValueEqual != nil {
+	if query.ValueEqual != nil {
 		input.FilterExpression = aws.String(fmt.Sprintf("%s = :v", valueKey))
 		input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
 			":v": {
-				B: entry.ValueEqual,
+				B: query.ValueEqual,
 			},
 		}
 	}

--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -240,6 +240,16 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 		}
 	}
 
+	// Filters
+	if entry.ValueEq != nil {
+		input.KeyConditions[valueKey] = &dynamodb.Condition{
+			AttributeValueList: []*dynamodb.AttributeValue{
+				{B: entry.ValueEq},
+			},
+			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorEq),
+		}
+	}
+
 	request := a.queryRequestFn(input)
 	backoff := minBackoff
 	for page := request; page != nil; page = page.NextPage() {

--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -242,11 +242,11 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 
 	// Filters
 	if entry.ValueEqual != nil {
-		input.KeyConditions[valueKey] = &dynamodb.Condition{
-			AttributeValueList: []*dynamodb.AttributeValue{
-				{B: entry.ValueEqual},
+		input.FilterExpression = aws.String(fmt.Sprintf("%s = :v", valueKey))
+		input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+			":v": {
+				B: entry.ValueEqual,
 			},
-			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorEq),
 		}
 	}
 

--- a/chunk/aws_storage_client.go
+++ b/chunk/aws_storage_client.go
@@ -241,10 +241,10 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 	}
 
 	// Filters
-	if entry.ValueEq != nil {
+	if entry.ValueEqual != nil {
 		input.KeyConditions[valueKey] = &dynamodb.Condition{
 			AttributeValueList: []*dynamodb.AttributeValue{
-				{B: entry.ValueEq},
+				{B: entry.ValueEqual},
 			},
 			ComparisonOperator: aws.String(dynamodb.ComparisonOperatorEq),
 		}

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -124,16 +124,16 @@ func (m *mockDynamoDBClient) queryRequest(input *dynamodb.QueryInput) dynamoDBRe
 	items := m.tables[*input.TableName].items[hashValue]
 	for _, item := range items {
 		rangeValue := item[rangeKey].B
-		if rangeValueFilterType == "GE" && bytes.Compare(rangeValue, rangeValueFilter) < 0 {
+		if rangeValueFilterType == dynamodb.ComparisonOperatorGe && bytes.Compare(rangeValue, rangeValueFilter) < 0 {
 			continue
 		}
-		if rangeValueFilterType == "BEGINS_WITH" && !bytes.HasPrefix(rangeValue, rangeValueFilter) {
+		if rangeValueFilterType == dynamodb.ComparisonOperatorBeginsWith && !bytes.HasPrefix(rangeValue, rangeValueFilter) {
 			continue
 		}
 
 		if item[valueKey] != nil {
 			value := item[valueKey].B
-			if valueFilter != nil && *valueFilterType == "EQ" && !bytes.Equal(value, valueFilter) {
+			if valueFilter != nil && *valueFilterType == dynamodb.ComparisonOperatorEq && !bytes.Equal(value, valueFilter) {
 				continue
 			}
 		}

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -101,11 +101,43 @@ func (m *mockDynamoDBClient) queryRequest(input *dynamodb.QueryInput) dynamoDBRe
 		Items: []map[string]*dynamodb.AttributeValue{},
 	}
 
+	// Required filters
 	hashValue := *input.KeyConditions[hashKey].AttributeValueList[0].S
-	items := m.tables[*input.TableName].items[hashValue]
 
-	// TODO we should also filter by range value
+	// Optional filters
+	var (
+		rangeValueFilter     []byte
+		rangeValueFilterType string
+		valueFilter          []byte
+		valueFilterType      *string
+	)
+	if input.KeyConditions[rangeKey] != nil {
+		rangeValueFilter = input.KeyConditions[rangeKey].AttributeValueList[0].B
+		rangeValueFilterType = *input.KeyConditions[rangeKey].ComparisonOperator
+	}
+	if input.KeyConditions[valueKey] != nil {
+		valueFilter = input.KeyConditions[valueKey].AttributeValueList[0].B
+		valueFilterType = input.KeyConditions[valueKey].ComparisonOperator
+	}
+
+	// Filter by HashValue, RangeValue and Value if it exists
+	items := m.tables[*input.TableName].items[hashValue]
 	for _, item := range items {
+		rangeValue := item[rangeKey].B
+		if rangeValueFilterType == "GE" && bytes.Compare(rangeValue, rangeValueFilter) < 0 {
+			continue
+		}
+		if rangeValueFilterType == "BEGINS_WITH" && !bytes.HasPrefix(rangeValue, rangeValueFilter) {
+			continue
+		}
+
+		if item[valueKey] != nil {
+			value := item[valueKey].B
+			if valueFilter != nil && *valueFilterType == "EQ" && !bytes.Equal(value, valueFilter) {
+				continue
+			}
+		}
+
 		result.Items = append(result.Items, item)
 	}
 
@@ -167,6 +199,136 @@ func TestDynamoDBClient(t *testing.T) {
 		require.Equal(t, []IndexEntry{
 			{RangeValue: []byte(fmt.Sprintf("range%d", i))},
 		}, have)
+	}
+}
+
+func TestDynamoDBClientQueryPages(t *testing.T) {
+	dynamoDB := newMockDynamoDB(0, 0)
+	client := awsStorageClient{
+		DynamoDB:       dynamoDB,
+		queryRequestFn: dynamoDB.queryRequest,
+	}
+
+	entries := []IndexEntry{
+		{
+			TableName:  "table",
+			HashValue:  "foo",
+			RangeValue: []byte("bar:1"),
+			Value:      []byte("10"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "foo",
+			RangeValue: []byte("bar:2"),
+			Value:      []byte("20"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "foo",
+			RangeValue: []byte("bar:3"),
+			Value:      []byte("30"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "foo",
+			RangeValue: []byte("baz:1"),
+			Value:      []byte("10"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "foo",
+			RangeValue: []byte("baz:2"),
+			Value:      []byte("20"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "flip",
+			RangeValue: []byte("bar:1"),
+			Value:      []byte("abc"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "flip",
+			RangeValue: []byte("bar:2"),
+			Value:      []byte("abc"),
+		},
+		{
+			TableName:  "table",
+			HashValue:  "flip",
+			RangeValue: []byte("bar:3"),
+			Value:      []byte("abc"),
+		},
+	}
+
+	tests := []struct {
+		name  string
+		entry IndexEntry
+		want  []IndexEntry
+	}{
+		{
+			"check HashValue only",
+			IndexEntry{
+				TableName: "table",
+				HashValue: "flip",
+			},
+			[]IndexEntry{entries[5], entries[6], entries[7]},
+		},
+		{
+			"check RangeValueStart",
+			IndexEntry{
+				TableName:       "table",
+				HashValue:       "foo",
+				RangeValueStart: []byte("bar:2"),
+			},
+			[]IndexEntry{entries[1], entries[2], entries[3], entries[4]},
+		},
+		{
+			"check RangeValuePrefix",
+			IndexEntry{
+				TableName:        "table",
+				HashValue:        "foo",
+				RangeValuePrefix: []byte("baz:"),
+			},
+			[]IndexEntry{entries[3], entries[4]},
+		},
+		{
+			"check ValueEq",
+			IndexEntry{
+				TableName:        "table",
+				HashValue:        "foo",
+				RangeValuePrefix: []byte("bar"),
+				ValueEq:          []byte("20"),
+			},
+			[]IndexEntry{entries[1]},
+		},
+	}
+
+	batch := client.NewWriteBatch()
+	for _, entry := range entries {
+		batch.Add(entry.TableName, entry.HashValue, entry.RangeValue, entry.Value)
+	}
+	dynamoDB.createTable("table")
+
+	err := client.BatchWrite(context.Background(), batch)
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var have []IndexEntry
+			err := client.QueryPages(context.Background(), tt.entry, func(read ReadBatch, lastPage bool) bool {
+				for i := 0; i < read.Len(); i++ {
+					have = append(have, IndexEntry{
+						TableName:  tt.entry.TableName,
+						HashValue:  tt.entry.HashValue,
+						RangeValue: read.RangeValue(i),
+						Value:      read.Value(i),
+					})
+				}
+				return !lastPage
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.want, have)
+		})
 	}
 }
 

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -111,13 +111,13 @@ func (m *mockDynamoDBClient) queryRequest(input *dynamodb.QueryInput) dynamoDBRe
 		valueFilter          []byte
 		valueFilterType      *string
 	)
-	if input.KeyConditions[rangeKey] != nil {
-		rangeValueFilter = input.KeyConditions[rangeKey].AttributeValueList[0].B
-		rangeValueFilterType = *input.KeyConditions[rangeKey].ComparisonOperator
+	if c, ok := input.KeyConditions[rangeKey]; ok {
+		rangeValueFilter = c.AttributeValueList[0].B
+		rangeValueFilterType = *c.ComparisonOperator
 	}
-	if input.KeyConditions[valueKey] != nil {
-		valueFilter = input.KeyConditions[valueKey].AttributeValueList[0].B
-		valueFilterType = input.KeyConditions[valueKey].ComparisonOperator
+	if c, ok := input.KeyConditions[valueKey]; ok {
+		valueFilter = c.AttributeValueList[0].B
+		valueFilterType = c.ComparisonOperator
 	}
 
 	// Filter by HashValue, RangeValue and Value if it exists

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -292,12 +292,12 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 			[]IndexEntry{entries[3], entries[4]},
 		},
 		{
-			"check ValueEq",
+			"check ValueEqual",
 			IndexEntry{
 				TableName:        "table",
 				HashValue:        "foo",
 				RangeValuePrefix: []byte("bar"),
-				ValueEq:          []byte("20"),
+				ValueEqual:       []byte("20"),
 			},
 			[]IndexEntry{entries[1]},
 		},

--- a/chunk/aws_storage_client_test.go
+++ b/chunk/aws_storage_client_test.go
@@ -266,12 +266,12 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		entry IndexEntry
+		query IndexQuery
 		want  []IndexEntry
 	}{
 		{
 			"check HashValue only",
-			IndexEntry{
+			IndexQuery{
 				TableName: "table",
 				HashValue: "flip",
 			},
@@ -279,7 +279,7 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 		},
 		{
 			"check RangeValueStart",
-			IndexEntry{
+			IndexQuery{
 				TableName:       "table",
 				HashValue:       "foo",
 				RangeValueStart: []byte("bar:2"),
@@ -288,7 +288,7 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 		},
 		{
 			"check RangeValuePrefix",
-			IndexEntry{
+			IndexQuery{
 				TableName:        "table",
 				HashValue:        "foo",
 				RangeValuePrefix: []byte("baz:"),
@@ -297,7 +297,7 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 		},
 		{
 			"check ValueEqual",
-			IndexEntry{
+			IndexQuery{
 				TableName:        "table",
 				HashValue:        "foo",
 				RangeValuePrefix: []byte("bar"),
@@ -319,11 +319,11 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var have []IndexEntry
-			err := client.QueryPages(context.Background(), tt.entry, func(read ReadBatch, lastPage bool) bool {
+			err := client.QueryPages(context.Background(), tt.query, func(read ReadBatch, lastPage bool) bool {
 				for i := 0; i < read.Len(); i++ {
 					have = append(have, IndexEntry{
-						TableName:  tt.entry.TableName,
-						HashValue:  tt.entry.HashValue,
+						TableName:  tt.query.TableName,
+						HashValue:  tt.query.HashValue,
 						RangeValue: read.RangeValue(i),
 						Value:      read.Value(i),
 					})

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -208,12 +208,12 @@ func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback f
 	}
 
 	// Filters
-	if entry.ValueEqual != nil {
-		log.Debugf("Filter Value EQ = %s", entry.ValueEqual)
+	if query.ValueEqual != nil {
+		log.Debugf("Filter Value EQ = %s", query.ValueEqual)
 
 		filtered := make([]mockItem, 0)
 		for _, v := range items {
-			if bytes.Equal(v.value, entry.ValueEqual) {
+			if bytes.Equal(v.value, query.ValueEqual) {
 				filtered = append(filtered, v)
 			}
 		}

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -208,12 +208,12 @@ func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback f
 	}
 
 	// Filters
-	if entry.ValueEq != nil {
-		log.Debugf("Filter Value EQ = %s", entry.ValueEq)
+	if entry.ValueEqual != nil {
+		log.Debugf("Filter Value EQ = %s", entry.ValueEqual)
 
 		filtered := make([]mockItem, 0)
 		for _, v := range items {
-			if bytes.Equal(v.value, entry.ValueEq) {
+			if bytes.Equal(v.value, entry.ValueEqual) {
 				filtered = append(filtered, v)
 			}
 		}

--- a/chunk/inmemory_storage_client.go
+++ b/chunk/inmemory_storage_client.go
@@ -207,6 +207,19 @@ func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback f
 		log.Debugf("Lookup %s/* (%d)", query.HashValue, len(items))
 	}
 
+	// Filters
+	if entry.ValueEq != nil {
+		log.Debugf("Filter Value EQ = %s", entry.ValueEq)
+
+		filtered := make([]mockItem, 0)
+		for _, v := range items {
+			if bytes.Equal(v.value, entry.ValueEq) {
+				filtered = append(filtered, v)
+			}
+		}
+		items = filtered
+	}
+
 	result := mockReadBatch{}
 	for _, item := range items {
 		result = append(result, item)

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -48,6 +48,9 @@ type IndexQuery struct {
 	// - If neither is set, must read all keys for that row.
 	RangeValuePrefix []byte
 	RangeValueStart  []byte
+
+	// Filters for querying
+	ValueEq []byte
 }
 
 // IndexEntry describes an entry in the chunk index
@@ -492,6 +495,7 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.
 			TableName:       bucket.tableName,
 			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 			RangeValueStart: encodeRangeKey(encodedFromBytes),
+			ValueEq:         []byte(labelValue),
 		},
 	}, nil
 }

--- a/chunk/schema.go
+++ b/chunk/schema.go
@@ -50,7 +50,7 @@ type IndexQuery struct {
 	RangeValueStart  []byte
 
 	// Filters for querying
-	ValueEq []byte
+	ValueEqual []byte
 }
 
 // IndexEntry describes an entry in the chunk index
@@ -495,7 +495,7 @@ func (v6Entries) GetReadMetricLabelValueQueries(bucket Bucket, metricName model.
 			TableName:       bucket.tableName,
 			HashValue:       fmt.Sprintf("%s:%s:%s", bucket.hashKey, metricName, labelName),
 			RangeValueStart: encodeRangeKey(encodedFromBytes),
-			ValueEq:         []byte(labelValue),
+			ValueEqual:      []byte(labelValue),
 		},
 	}, nil
 }


### PR DESCRIPTION
Fixes #398

Created some extra tests for the aws storage client and started filtering by range key.
Added simple field to IndexEntry which is then used to add the filter condition to dynamo if it exists

Tested locally with `http_requests_total{job="cortex/ingester"}`

Reverted change: #400