### PR TITLE
Don't rename proto package name, as its part of the contract.

### DIFF
--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-package client;
+package cortex;
+
+option go_package = "client";
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 


### PR DESCRIPTION
Fixes #413 