### PR TITLE
Various chunk store / DynamoDB config refactorings.

### DIFF
--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -20,18 +20,18 @@ func main() {
 				middleware.ServerUserHeaderInterceptor,
 			},
 		}
-		dynamoTableClientConfig = chunk.DynamoTableClientConfig{}
-		tableManagerConfig      = chunk.TableManagerConfig{}
+		dynamoDBConfig     = chunk.DynamoDBConfig{}
+		tableManagerConfig = chunk.TableManagerConfig{}
 	)
-	util.RegisterFlags(&serverConfig, &dynamoTableClientConfig, &tableManagerConfig)
+	util.RegisterFlags(&serverConfig, &dynamoDBConfig, &tableManagerConfig)
 	flag.Parse()
 
-	dynamoClient, err := chunk.NewDynamoTableClient(dynamoTableClientConfig)
+	tableClient, err := chunk.NewDynamoDBTableClient(dynamoDBConfig)
 	if err != nil {
-		log.Fatalf("Error initializing DynamoDB client: %v", err)
+		log.Fatalf("Error initializing DynamoDB table client: %v", err)
 	}
 
-	tableManager, err := chunk.NewDynamoTableManager(tableManagerConfig, dynamoClient)
+	tableManager, err := chunk.NewTableManager(tableManagerConfig, tableClient)
 	if err != nil {
 		log.Fatalf("Error initializing DynamoDB table manager: %v", err)
 	}

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -22,7 +22,7 @@ import (
 // newTestStore creates a new Store for testing.
 func newTestChunkStore(t *testing.T, cfg StoreConfig) *Store {
 	storage := NewMockStorage()
-	tableManager, err := NewDynamoTableManager(TableManagerConfig{}, storage)
+	tableManager, err := NewTableManager(TableManagerConfig{}, storage)
 	require.NoError(t, err)
 	err = tableManager.syncTables(context.Background())
 	require.NoError(t, err)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -22,7 +22,6 @@ const (
 // SchemaConfig contains the config for our chunk index schemas
 type SchemaConfig struct {
 	PeriodicTableConfig
-	OriginalTableName string
 
 	// After midnight on this day, we start bucketing indexes by day instead of by
 	// hour.  Only the day matters, not the time within the day.
@@ -48,7 +47,6 @@ type SchemaConfig struct {
 func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.PeriodicTableConfig.RegisterFlags(f)
 
-	flag.StringVar(&cfg.OriginalTableName, "dynamodb.original-table-name", "", "The name of the DynamoDB table used before versioned schemas were introduced.")
 	f.Var(&cfg.DailyBucketsFrom, "dynamodb.daily-buckets-from", "The date (in the format YYYY-MM-DD) of the first day for which DynamoDB index buckets should be day-sized vs. hour-sized.")
 	f.Var(&cfg.Base64ValuesFrom, "dynamodb.base64-buckets-from", "The date (in the format YYYY-MM-DD) after which we will stop querying to non-base64 encoded values.")
 	f.Var(&cfg.V4SchemaFrom, "dynamodb.v4-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v4 schema.")

--- a/pkg/chunk/schema_config_test.go
+++ b/pkg/chunk/schema_config_test.go
@@ -15,7 +15,11 @@ func TestHourlyBuckets(t *testing.T) {
 		metricName = model.LabelValue("name")
 		tableName  = "table"
 	)
-	var cfg = SchemaConfig{OriginalTableName: tableName}
+	var cfg = SchemaConfig{
+		PeriodicTableConfig: PeriodicTableConfig{
+			OriginalTableName: tableName,
+		},
+	}
 
 	type args struct {
 		from    model.Time
@@ -99,7 +103,11 @@ func TestDailyBuckets(t *testing.T) {
 		metricName = model.LabelValue("name")
 		tableName  = "table"
 	)
-	var cfg = SchemaConfig{OriginalTableName: tableName}
+	var cfg = SchemaConfig{
+		PeriodicTableConfig: PeriodicTableConfig{
+			OriginalTableName: tableName,
+		},
+	}
 
 	type args struct {
 		from    model.Time

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -72,9 +72,8 @@ func TestSchemaHashKeys(t *testing.T) {
 	)
 
 	cfg := SchemaConfig{
-		OriginalTableName: table,
-
 		PeriodicTableConfig: PeriodicTableConfig{
+			OriginalTableName:    table,
 			UsePeriodicTables:    true,
 			TablePrefix:          periodicPrefix,
 			TablePeriod:          2 * 24 * time.Hour,
@@ -285,7 +284,9 @@ func TestSchemaRangeKey(t *testing.T) {
 
 	var (
 		cfg = SchemaConfig{
-			OriginalTableName: table,
+			PeriodicTableConfig: PeriodicTableConfig{
+				OriginalTableName: table,
+			},
 		}
 		hourlyBuckets = v1Schema(cfg)
 		dailyBuckets  = v2Schema(cfg)

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -2,14 +2,14 @@ package chunk
 
 import (
 	"flag"
-	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"golang.org/x/net/context"
@@ -42,48 +42,11 @@ func init() {
 	prometheus.MustRegister(tableCapacity)
 }
 
-// DynamoTableClient is a client for telling Dynamo what to do with tables.
-type DynamoTableClient interface {
-	ListTables(ctx context.Context) ([]string, error)
-	CreateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error
-	DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error)
-	UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error
-}
-
-// DynamoTableClientConfig configures the DynamoDB table client.
-type DynamoTableClientConfig struct {
-	DynamoClient string
-	DynamoDBConfig
-}
-
-// RegisterFlags adds the flags required to configure this flag set.
-func (cfg *DynamoTableClientConfig) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&cfg.DynamoClient, "table-manager.dynamo-client", "aws", "Which DynamoDB table client to use (aws, inmemory).")
-	cfg.DynamoDBConfig.RegisterFlags(f)
-}
-
-// NewDynamoTableClient creates a new DynamoTableClient.
-func NewDynamoTableClient(cfg DynamoTableClientConfig) (DynamoTableClient, error) {
-	switch cfg.DynamoClient {
-	case "inmemory":
-		return NewMockStorage(), nil
-	case "aws":
-		path := strings.TrimPrefix(cfg.DynamoDB.URL.Path, "/")
-		if len(path) > 0 {
-			log.Warnf("Ignoring DynamoDB URL path: %v.", path)
-		}
-		return newDynamoTableClient(cfg.DynamoDBConfig)
-	default:
-		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, inmemory", cfg.DynamoClient)
-	}
-}
-
 // TableManagerConfig is the config for a DynamoTableManager
 type TableManagerConfig struct {
 	DynamoDBPollInterval time.Duration
 
 	PeriodicTableConfig
-	OriginalTableName string
 
 	// duration a table will be created before it is needed.
 	CreationGracePeriod        time.Duration
@@ -105,14 +68,13 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.InactiveReadThroughput, "dynamodb.periodic-table.inactive-read-throughput", 300, "DynamoDB periodic tables read throughput for inactive tables")
 
 	cfg.PeriodicTableConfig.RegisterFlags(f)
-	// XXX: Should this be in PeriodicTableConfig?
-	flag.StringVar(&cfg.OriginalTableName, "dynamodb.original-table-name", "", "The name of the DynamoDB table used before versioned schemas were introduced.")
 }
 
 // PeriodicTableConfig for the use of periodic tables (ie, weekly tables).  Can
 // control when to start the periodic tables, how long the period should be,
 // and the prefix to give the tables.
 type PeriodicTableConfig struct {
+	OriginalTableName    string
 	UsePeriodicTables    bool
 	TablePrefix          string
 	TablePeriod          time.Duration
@@ -121,42 +83,43 @@ type PeriodicTableConfig struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *PeriodicTableConfig) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cfg.OriginalTableName, "dynamodb.original-table-name", "", "The name of the DynamoDB table used before versioned schemas were introduced.")
 	f.BoolVar(&cfg.UsePeriodicTables, "dynamodb.use-periodic-tables", true, "Should we use periodic tables.")
 	f.StringVar(&cfg.TablePrefix, "dynamodb.periodic-table.prefix", "cortex_", "DynamoDB table prefix for the periodic tables.")
 	f.DurationVar(&cfg.TablePeriod, "dynamodb.periodic-table.period", 7*24*time.Hour, "DynamoDB periodic tables period.")
 	f.Var(&cfg.PeriodicTableStartAt, "dynamodb.periodic-table.start", "DynamoDB periodic tables start time.")
 }
 
-// DynamoTableManager creates and manages the provisioned throughput on DynamoDB tables
-type DynamoTableManager struct {
-	dynamoDB DynamoTableClient
+// TableManager creates and manages the provisioned throughput on DynamoDB tables
+type TableManager struct {
+	dynamoDB TableClient
 	cfg      TableManagerConfig
 	done     chan struct{}
 	wait     sync.WaitGroup
 }
 
-// NewDynamoTableManager makes a new DynamoTableManager
-func NewDynamoTableManager(cfg TableManagerConfig, dynamoDBClient DynamoTableClient) (*DynamoTableManager, error) {
-	return &DynamoTableManager{
+// NewTableManager makes a new DynamoTableManager
+func NewTableManager(cfg TableManagerConfig, tableClient TableClient) (*TableManager, error) {
+	return &TableManager{
 		cfg:      cfg,
-		dynamoDB: dynamoDBClient,
+		dynamoDB: tableClient,
 		done:     make(chan struct{}),
 	}, nil
 }
 
 // Start the DynamoTableManager
-func (m *DynamoTableManager) Start() {
+func (m *TableManager) Start() {
 	m.wait.Add(1)
 	go m.loop()
 }
 
 // Stop the DynamoTableManager
-func (m *DynamoTableManager) Stop() {
+func (m *TableManager) Stop() {
 	close(m.done)
 	m.wait.Wait()
 }
 
-func (m *DynamoTableManager) loop() {
+func (m *TableManager) loop() {
 	defer m.wait.Done()
 
 	ticker := time.NewTicker(m.cfg.DynamoDBPollInterval)
@@ -182,7 +145,7 @@ func (m *DynamoTableManager) loop() {
 	}
 }
 
-func (m *DynamoTableManager) syncTables(ctx context.Context) error {
+func (m *TableManager) syncTables(ctx context.Context) error {
 	expected := m.calculateExpectedTables()
 	log.Infof("Expecting %d tables", len(expected))
 
@@ -210,7 +173,7 @@ func (a byName) Len() int           { return len(a) }
 func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byName) Less(i, j int) bool { return a[i].name < a[j].name }
 
-func (m *DynamoTableManager) calculateExpectedTables() []tableDescription {
+func (m *TableManager) calculateExpectedTables() []tableDescription {
 	if !m.cfg.UsePeriodicTables {
 		return []tableDescription{
 			{
@@ -269,7 +232,7 @@ func (m *DynamoTableManager) calculateExpectedTables() []tableDescription {
 }
 
 // partitionTables works out tables that need to be created vs tables that need to be updated
-func (m *DynamoTableManager) partitionTables(ctx context.Context, descriptions []tableDescription) ([]tableDescription, []tableDescription, error) {
+func (m *TableManager) partitionTables(ctx context.Context, descriptions []tableDescription) ([]tableDescription, []tableDescription, error) {
 	existingTables, err := m.dynamoDB.ListTables(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -300,7 +263,7 @@ func (m *DynamoTableManager) partitionTables(ctx context.Context, descriptions [
 	return toCreate, toCheckThroughput, nil
 }
 
-func (m *DynamoTableManager) createTables(ctx context.Context, descriptions []tableDescription) error {
+func (m *TableManager) createTables(ctx context.Context, descriptions []tableDescription) error {
 	for _, desc := range descriptions {
 		log.Infof("Creating table %s", desc.name)
 		err := m.dynamoDB.CreateTable(ctx, desc.name, desc.provisionedRead, desc.provisionedWrite)
@@ -311,7 +274,7 @@ func (m *DynamoTableManager) createTables(ctx context.Context, descriptions []ta
 	return nil
 }
 
-func (m *DynamoTableManager) updateTables(ctx context.Context, descriptions []tableDescription) error {
+func (m *TableManager) updateTables(ctx context.Context, descriptions []tableDescription) error {
 	for _, desc := range descriptions {
 		log.Infof("Checking provisioned throughput on table %s", desc.name)
 		readCapacity, writeCapacity, status, err := m.dynamoDB.DescribeTable(ctx, desc.name)
@@ -339,4 +302,101 @@ func (m *DynamoTableManager) updateTables(ctx context.Context, descriptions []ta
 		}
 	}
 	return nil
+}
+
+// TableClient is a client for telling Dynamo what to do with tables.
+type TableClient interface {
+	ListTables(ctx context.Context) ([]string, error)
+	CreateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error
+	DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error)
+	UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error
+}
+
+type dynamoTableClient struct {
+	DynamoDB dynamodbiface.DynamoDBAPI
+}
+
+// NewDynamoDBTableClient makes a new DynamoTableClient.
+func NewDynamoDBTableClient(cfg DynamoDBConfig) (TableClient, error) {
+	dynamoDB, err := dynamoClientFromURL(cfg.DynamoDB.URL)
+	if err != nil {
+		return nil, err
+	}
+	return dynamoTableClient{
+		DynamoDB: dynamoDB,
+	}, nil
+}
+
+func (d dynamoTableClient) ListTables(ctx context.Context) ([]string, error) {
+	table := []string{}
+	err := instrument.TimeRequestHistogram(ctx, "DynamoDB.ListTablesPages", dynamoRequestDuration, func(_ context.Context) error {
+		return d.DynamoDB.ListTablesPages(&dynamodb.ListTablesInput{}, func(resp *dynamodb.ListTablesOutput, _ bool) bool {
+			for _, s := range resp.TableNames {
+				table = append(table, *s)
+			}
+			return true
+		})
+	})
+	return table, err
+}
+
+func (d dynamoTableClient) CreateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
+	return instrument.TimeRequestHistogram(ctx, "DynamoDB.CreateTable", dynamoRequestDuration, func(_ context.Context) error {
+		input := &dynamodb.CreateTableInput{
+			TableName: aws.String(name),
+			AttributeDefinitions: []*dynamodb.AttributeDefinition{
+				{
+					AttributeName: aws.String(hashKey),
+					AttributeType: aws.String(dynamodb.ScalarAttributeTypeS),
+				},
+				{
+					AttributeName: aws.String(rangeKey),
+					AttributeType: aws.String(dynamodb.ScalarAttributeTypeB),
+				},
+			},
+			KeySchema: []*dynamodb.KeySchemaElement{
+				{
+					AttributeName: aws.String(hashKey),
+					KeyType:       aws.String(dynamodb.KeyTypeHash),
+				},
+				{
+					AttributeName: aws.String(rangeKey),
+					KeyType:       aws.String(dynamodb.KeyTypeRange),
+				},
+			},
+			ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+				ReadCapacityUnits:  aws.Int64(readCapacity),
+				WriteCapacityUnits: aws.Int64(writeCapacity),
+			},
+		}
+		_, err := d.DynamoDB.CreateTable(input)
+		return err
+	})
+}
+
+func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (readCapacity, writeCapacity int64, status string, err error) {
+	var out *dynamodb.DescribeTableOutput
+	instrument.TimeRequestHistogram(ctx, "DynamoDB.DescribeTable", dynamoRequestDuration, func(_ context.Context) error {
+		out, err = d.DynamoDB.DescribeTable(&dynamodb.DescribeTableInput{
+			TableName: aws.String(name),
+		})
+		readCapacity = *out.Table.ProvisionedThroughput.ReadCapacityUnits
+		writeCapacity = *out.Table.ProvisionedThroughput.WriteCapacityUnits
+		status = *out.Table.TableStatus
+		return err
+	})
+	return
+}
+
+func (d dynamoTableClient) UpdateTable(ctx context.Context, name string, readCapacity, writeCapacity int64) error {
+	return instrument.TimeRequestHistogram(ctx, "DynamoDB.UpdateTable", dynamoRequestDuration, func(_ context.Context) error {
+		_, err := d.DynamoDB.UpdateTable(&dynamodb.UpdateTableInput{
+			TableName: aws.String(name),
+			ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+				ReadCapacityUnits:  aws.Int64(readCapacity),
+				WriteCapacityUnits: aws.Int64(writeCapacity),
+			},
+		})
+		return err
+	})
 }

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -43,7 +43,7 @@ func TestDynamoTableManager(t *testing.T) {
 		InactiveWriteThroughput:    inactiveWrite,
 		InactiveReadThroughput:     inactiveRead,
 	}
-	tableManager, err := NewDynamoTableManager(cfg, dynamoDB)
+	tableManager, err := NewTableManager(cfg, dynamoDB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestDynamoTableManager(t *testing.T) {
 	)
 }
 
-func expectTables(ctx context.Context, t *testing.T, dynamo DynamoTableClient, expected []tableDescription) {
+func expectTables(ctx context.Context, t *testing.T, dynamo TableClient, expected []tableDescription) {
 	tables, err := dynamo.ListTables(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -23,7 +23,7 @@ const (
 	read          = 100
 )
 
-func TestDynamoTableManager(t *testing.T) {
+func TestTableManager(t *testing.T) {
 	dynamoDB := NewMockStorage()
 
 	cfg := TableManagerConfig{

--- a/pkg/ingester/client/dep.go
+++ b/pkg/ingester/client/dep.go
@@ -1,4 +1,4 @@
-package cortex
+package client
 
 import (
 	// This import exists to trick dep into vendoring the required protos


### PR DESCRIPTION
(Motivation: tidying a few things up before handling #141)

- Move /dep.go into /pkg/ingester/client, where is belongs.
- Rename DynamoTableManager to TableManager, as there is nothing DynamoDB-specific about it - it would be useful to BigTable too.
- Rename DynamoTableClient interface to TableClient, as there is nothing DynamoDB-specici about it - it would be useful to BigTable too.
- Move dynamoTableClient (implementation of TableClient) into /pkg/chunk/table_manager.go, where it belongs.
- Delete chunk.DynamoTableClientConfig, as the table-manager-specific in-memory construction wasn't used.
- Move warning about unused DynamoDB table name in path to dynamoClientFromURL.
- Move duplicated OriginalTableName into PeriodicTableConfig, as per comment.
- Fix usage of flag.StringVar - should be f.StringVar.