### PR TITLE
Store chunks in DynamoDB

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -59,5 +59,6 @@ func main() {
 
 	client.RegisterIngesterServer(server.GRPC, ingester)
 	server.HTTP.Path("/ready").Handler(http.HandlerFunc(ingester.ReadinessHandler))
+	server.HTTP.Path("/flush").Handler(http.HandlerFunc(ingester.FlushHandler))
 	server.Run()
 }

--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -50,6 +50,7 @@ spec:
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
         - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -27,6 +27,7 @@ spec:
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
         - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -30,6 +30,7 @@ spec:
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
         - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms
         - -memcached.service=memcached

--- a/k8s/table-manager-dep.yaml
+++ b/k8s/table-manager-dep.yaml
@@ -20,5 +20,6 @@ spec:
         - -dynamodb.url=dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
         - -dynamodb.periodic-table.prefix=cortex_weekly_
         - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.chunk-table.from=2017-04-17
         ports:
         - containerPort: 80

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -427,7 +427,7 @@ func (a awsStorageClient) getS3Chunk(ctx context.Context, chunk Chunk) (Chunk, e
 	return chunk, nil
 }
 
-// As we're resuing the DynamoDB schema from the index for the chunk tables,
+// As we're re-using the DynamoDB schema from the index for the chunk tables,
 // we need to provide a non-null, non-empty value for the range value.
 var placeholder = []byte{'c'}
 

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -101,7 +101,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 // AWSStorageConfig specifies config for storing data on AWS.
 type AWSStorageConfig struct {
 	DynamoDBConfig
-	ChunkTableConfig
+	PeriodicChunkTableConfig
 
 	S3 util.URLValue
 }
@@ -109,7 +109,7 @@ type AWSStorageConfig struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *AWSStorageConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.DynamoDBConfig.RegisterFlags(f)
-	cfg.ChunkTableConfig.RegisterFlags(f)
+	cfg.PeriodicChunkTableConfig.RegisterFlags(f)
 
 	f.Var(&cfg.S3, "s3.url", "S3 endpoint URL with escaped Key and Secret encoded. "+
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<bucket-name> to use a mock in-memory implementation.")
@@ -660,8 +660,8 @@ func (b dynamoDBReadRequest) Add(tableName, hashValue string, rangeValue []byte)
 		b[tableName] = requests
 	}
 	requests.Keys = append(requests.Keys, map[string]*dynamodb.AttributeValue{
-		hashKey:  &dynamodb.AttributeValue{S: aws.String(hashValue)},
-		rangeKey: &dynamodb.AttributeValue{B: rangeValue},
+		hashKey:  {S: aws.String(hashValue)},
+		rangeKey: {B: rangeValue},
 	})
 }
 

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -347,7 +347,7 @@ func (a awsStorageClient) GetChunks(ctx context.Context, chunks []Chunk) ([]Chun
 	)
 
 	for _, chunk := range chunks {
-		if chunk.From.Before(a.cfg.ChunkTableFrom.Time) {
+		if !a.cfg.ChunkTableFrom.IsSet() || chunk.From.Before(a.cfg.ChunkTableFrom.Time) {
 			s3Chunks = append(s3Chunks, chunk)
 		} else {
 			dynamoDBChunks = append(dynamoDBChunks, chunk)
@@ -523,7 +523,7 @@ func (a awsStorageClient) PutChunks(ctx context.Context, chunks []Chunk, keys []
 	)
 
 	for i, chunk := range chunks {
-		if chunk.From.Before(a.cfg.ChunkTableFrom.Time) {
+		if !a.cfg.ChunkTableFrom.IsSet() || chunk.From.Before(a.cfg.ChunkTableFrom.Time) {
 			s3ChunkKeys = append(s3ChunkKeys, keys[i])
 			s3ChunkBufs = append(s3ChunkBufs, bufs[i])
 		} else {

--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -3,20 +3,29 @@ package chunk
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"math/rand"
 	"net/url"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
+
+	"github.com/weaveworks/cortex/pkg/util"
 )
 
 type mockDynamoDBClient struct {
@@ -99,6 +108,57 @@ func (m *mockDynamoDBClient) BatchWriteItemWithContext(_ aws.Context, input *dyn
 	return resp, nil
 }
 
+func (m *mockDynamoDBClient) BatchGetItemWithContext(_ aws.Context, input *dynamodb.BatchGetItemInput, _ ...request.Option) (*dynamodb.BatchGetItemOutput, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	resp := &dynamodb.BatchGetItemOutput{
+		Responses:       map[string][]map[string]*dynamodb.AttributeValue{},
+		UnprocessedKeys: map[string]*dynamodb.KeysAndAttributes{},
+	}
+
+	if m.provisionedErr > 0 {
+		m.provisionedErr--
+		return resp, awserr.New(provisionedThroughputExceededException, "", nil)
+	}
+
+	for tableName, readRequests := range input.RequestItems {
+		table, ok := m.tables[tableName]
+		if !ok {
+			return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("table not found")
+		}
+
+		unprocessed := &dynamodb.KeysAndAttributes{
+			AttributesToGet:          readRequests.AttributesToGet,
+			ConsistentRead:           readRequests.ConsistentRead,
+			ExpressionAttributeNames: readRequests.ExpressionAttributeNames,
+		}
+		for _, readRequest := range readRequests.Keys {
+			if m.unprocessed > 0 {
+				m.unprocessed--
+				unprocessed.Keys = append(unprocessed.Keys, readRequest)
+				resp.UnprocessedKeys[tableName] = unprocessed
+				continue
+			}
+
+			hashValue := *readRequest[hashKey].S
+			rangeValue := readRequest[rangeKey].B
+			items := table.items[hashValue]
+
+			// insert in order
+			i := sort.Search(len(items), func(i int) bool {
+				return bytes.Compare(items[i][rangeKey].B, rangeValue) >= 0
+			})
+			if i >= len(items) || !bytes.Equal(items[i][rangeKey].B, rangeValue) {
+				return &dynamodb.BatchGetItemOutput{}, fmt.Errorf("Couldn't find ite,")
+			}
+
+			resp.Responses[tableName] = append(resp.Responses[tableName], items[i])
+		}
+	}
+	return resp, nil
+}
+
 func (m *mockDynamoDBClient) queryRequest(_ context.Context, input *dynamodb.QueryInput) dynamoDBRequest {
 	result := &dynamodb.QueryOutput{
 		Items: []map[string]*dynamodb.AttributeValue{},
@@ -172,7 +232,46 @@ func (m *dynamoDBMockRequest) HasNextPage() bool {
 	return false
 }
 
-func TestDynamoDBClient(t *testing.T) {
+type mockS3 struct {
+	s3iface.S3API
+	sync.RWMutex
+	objects map[string][]byte
+}
+
+func newMockS3() *mockS3 {
+	return &mockS3{
+		objects: map[string][]byte{},
+	}
+}
+
+func (m *mockS3) PutObjectWithContext(_ aws.Context, req *s3.PutObjectInput, _ ...request.Option) (*s3.PutObjectOutput, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	m.objects[*req.Key] = buf
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockS3) GetObjectWithContext(_ aws.Context, req *s3.GetObjectInput, _ ...request.Option) (*s3.GetObjectOutput, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	buf, ok := m.objects[*req.Key]
+	if !ok {
+		return nil, fmt.Errorf("Not found")
+	}
+
+	return &s3.GetObjectOutput{
+		Body: ioutil.NopCloser(bytes.NewReader(buf)),
+	}, nil
+}
+
+func TestAWSStorageClient(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	client := awsStorageClient{
 		DynamoDB:       dynamoDB,
@@ -194,9 +293,9 @@ func TestDynamoDBClient(t *testing.T) {
 		}
 		var have []IndexEntry
 		err := client.QueryPages(context.Background(), entry, func(read ReadBatch, lastPage bool) bool {
-			for i := 0; i < read.Len(); i++ {
+			for j := 0; j < read.Len(); j++ {
 				have = append(have, IndexEntry{
-					RangeValue: read.RangeValue(i),
+					RangeValue: read.RangeValue(j),
 				})
 			}
 			return !lastPage
@@ -208,13 +307,84 @@ func TestDynamoDBClient(t *testing.T) {
 	}
 }
 
-func TestDynamoDBClientQueryPages(t *testing.T) {
-	dynamoDB := newMockDynamoDB(0, 0)
-	client := awsStorageClient{
-		DynamoDB:       dynamoDB,
-		queryRequestFn: dynamoDB.queryRequest,
+func TestAWSStorageClientChunks(t *testing.T) {
+	t.Run("S3 chunks", func(t *testing.T) {
+		dynamoDB := newMockDynamoDB(0, 0)
+		client := awsStorageClient{
+			DynamoDB:       dynamoDB,
+			S3:             newMockS3(),
+			queryRequestFn: dynamoDB.queryRequest,
+		}
+
+		testStorageClientChunks(t, client)
+	})
+
+	t.Run("DynamoDB chunks", func(t *testing.T) {
+		dynamoDB := newMockDynamoDB(0, 0)
+		client := awsStorageClient{
+			DynamoDB:       dynamoDB,
+			queryRequestFn: dynamoDB.queryRequest,
+			cfg: AWSStorageConfig{
+				PeriodicChunkTableConfig: PeriodicChunkTableConfig{
+					ChunkTableFrom:   util.NewDayValue(model.TimeFromUnix(0)),
+					ChunkTablePeriod: 1 * time.Minute,
+				},
+			},
+		}
+
+		testStorageClientChunks(t, client)
+	})
+}
+
+func testStorageClientChunks(t *testing.T, client StorageClient) {
+	const batchSize = 50
+
+	// Write a few batches of chunks.
+	written := []string{}
+	for i := 0; i < 50; i++ {
+		chunks := []Chunk{}
+		keys := []string{}
+		bufs := [][]byte{}
+		for j := 0; j < batchSize; j++ {
+			chunk := dummyChunkFor(model.Metric{
+				model.MetricNameLabel: "foo",
+				"index":               model.LabelValue(strconv.Itoa(i*batchSize + j)),
+			})
+			chunks = append(chunks, chunk)
+			buf, err := chunk.encode()
+			assert.NoError(t, err)
+			bufs = append(bufs, buf)
+			keys = append(keys, chunk.externalKey())
+		}
+		err := client.PutChunks(context.Background(), chunks, keys, bufs)
+		assert.NoError(t, err)
+
+		written = append(written, keys...)
 	}
 
+	// Get a few batches of chunks.
+	for i := 0; i < 50; i++ {
+		chunksToGet := []Chunk{}
+		for j := 0; j < batchSize; j++ {
+			key := written[rand.Intn(len(written))]
+			chunk, err := parseNewExternalKey(key)
+			assert.NoError(t, err)
+			chunksToGet = append(chunksToGet, chunk)
+		}
+
+		chunksWeGot, err := client.GetChunks(context.Background(), chunksToGet)
+		assert.NoError(t, err)
+
+		sort.Sort(ByKey(chunksToGet))
+		sort.Sort(ByKey(chunksWeGot))
+		require.Equal(t, len(chunksToGet), len(chunksWeGot))
+		for j := 0; j < len(chunksWeGot); j++ {
+			require.Equal(t, chunksToGet[i].externalKey(), chunksWeGot[i].externalKey())
+		}
+	}
+}
+
+func TestAWSStorageClientQueryPages(t *testing.T) {
 	entries := []IndexEntry{
 		{
 			TableName:  "table",
@@ -309,19 +479,25 @@ func TestDynamoDBClientQueryPages(t *testing.T) {
 		},
 	}
 
-	batch := client.NewWriteBatch()
-	for _, entry := range entries {
-		batch.Add(entry.TableName, entry.HashValue, entry.RangeValue, entry.Value)
-	}
-	dynamoDB.createTable("table")
-
-	err := client.BatchWrite(context.Background(), batch)
-	require.NoError(t, err)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			dynamoDB := newMockDynamoDB(0, 0)
+			client := awsStorageClient{
+				DynamoDB:       dynamoDB,
+				queryRequestFn: dynamoDB.queryRequest,
+			}
+
+			batch := client.NewWriteBatch()
+			for _, entry := range entries {
+				batch.Add(entry.TableName, entry.HashValue, entry.RangeValue, entry.Value)
+			}
+			dynamoDB.createTable("table")
+
+			err := client.BatchWrite(context.Background(), batch)
+			require.NoError(t, err)
+
 			var have []IndexEntry
-			err := client.QueryPages(context.Background(), tt.query, func(read ReadBatch, lastPage bool) bool {
+			err = client.QueryPages(context.Background(), tt.query, func(read ReadBatch, lastPage bool) bool {
 				for i := 0; i < read.Len(); i++ {
 					have = append(have, IndexEntry{
 						TableName:  tt.query.TableName,

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -97,19 +97,7 @@ func (c *Store) Put(ctx context.Context, chunks []Chunk) error {
 		return err
 	}
 
-	// Encode the chunk first - checksum is calculated as a side effect.
-	bufs := [][]byte{}
-	keys := []string{}
-	for i := range chunks {
-		encoded, err := chunks[i].encode()
-		if err != nil {
-			return err
-		}
-		bufs = append(bufs, encoded)
-		keys = append(keys, chunks[i].externalKey())
-	}
-
-	err = c.storage.PutChunks(ctx, chunks, keys, bufs)
+	err = c.storage.PutChunks(ctx, chunks)
 	if err != nil {
 		return err
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -109,44 +109,12 @@ func (c *Store) Put(ctx context.Context, chunks []Chunk) error {
 		keys = append(keys, chunks[i].externalKey())
 	}
 
-	err = c.putChunks(ctx, keys, bufs)
+	err = c.storage.PutChunks(ctx, chunks, keys, bufs)
 	if err != nil {
 		return err
 	}
 
 	return c.updateIndex(ctx, userID, chunks)
-}
-
-// putChunks writes a collection of chunks to S3 in parallel.
-func (c *Store) putChunks(ctx context.Context, keys []string, bufs [][]byte) error {
-	incomingErrors := make(chan error)
-	for i := range bufs {
-		go func(i int) {
-			incomingErrors <- c.putChunk(ctx, keys[i], bufs[i])
-		}(i)
-	}
-
-	var lastErr error
-	for range keys {
-		err := <-incomingErrors
-		if err != nil {
-			lastErr = err
-		}
-	}
-	return lastErr
-}
-
-// putChunk puts a chunk into S3.
-func (c *Store) putChunk(ctx context.Context, key string, buf []byte) error {
-	err := c.storage.PutChunk(ctx, key, buf)
-	if err != nil {
-		return err
-	}
-
-	if err := c.cache.StoreChunk(ctx, key, buf); err != nil {
-		log.Warnf("Could not store %v in chunk cache: %v", key, err)
-	}
-	return nil
 }
 
 func (c *Store) updateIndex(ctx context.Context, userID string, chunks []Chunk) error {
@@ -223,7 +191,7 @@ func (c *Store) Get(ctx context.Context, from, through model.Time, allMatchers .
 		log.Warnf("Error fetching from cache: %v", err)
 	}
 
-	fromS3, err := c.fetchChunkData(ctx, missing)
+	fromS3, err := c.storage.GetChunks(ctx, missing)
 	if err != nil {
 		return nil, promql.ErrStorage(err)
 	}
@@ -478,40 +446,6 @@ func (c *Store) convertIndexEntriesToChunks(ctx context.Context, entries []Index
 	// Return chunks sorted and deduped because they will be merged with other sets
 	sort.Sort(chunkSet)
 	return unique(chunkSet), nil
-}
-
-func (c *Store) fetchChunkData(ctx context.Context, chunkSet []Chunk) ([]Chunk, error) {
-	incomingChunks := make(chan Chunk)
-	incomingErrors := make(chan error)
-	for _, chunk := range chunkSet {
-		go func(chunk Chunk) {
-			buf, err := c.storage.GetChunk(ctx, chunk.externalKey())
-			if err != nil {
-				incomingErrors <- err
-				return
-			}
-			if err := chunk.decode(buf); err != nil {
-				incomingErrors <- err
-				return
-			}
-			incomingChunks <- chunk
-		}(chunk)
-	}
-
-	chunks := []Chunk{}
-	errors := []error{}
-	for i := 0; i < len(chunkSet); i++ {
-		select {
-		case chunk := <-incomingChunks:
-			chunks = append(chunks, chunk)
-		case err := <-incomingErrors:
-			errors = append(errors, err)
-		}
-	}
-	if len(errors) > 0 {
-		return nil, errors[0]
-	}
-	return chunks, nil
 }
 
 func (c *Store) writeBackCache(_ context.Context, chunks []Chunk) error {

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -125,12 +125,6 @@ func TestChunkStore(t *testing.T) {
 				chunks, err := store.Get(ctx, now.Add(-time.Hour), now, tc.matchers...)
 				require.NoError(t, err)
 
-				// Zero out the checksums, as the inputs above didn't have the checksums calculated
-				for i := range chunks {
-					chunks[i].Checksum = 0
-					chunks[i].ChecksumSet = false
-				}
-
 				if !reflect.DeepEqual(tc.expect, chunks) {
 					t.Fatalf("%s: wrong chunks - %s", tc.query, test.Diff(tc.expect, chunks))
 				}
@@ -257,12 +251,6 @@ func TestChunkStoreMetricNames(t *testing.T) {
 
 				chunks, err := store.Get(ctx, now.Add(-time.Hour), now, tc.matchers...)
 				require.NoError(t, err)
-
-				// Zero out the checksums, as the inputs above didn't have the checksums calculated
-				for i := range chunks {
-					chunks[i].Checksum = 0
-					chunks[i].ChecksumSet = false
-				}
 
 				if !reflect.DeepEqual(tc.expect, chunks) {
 					t.Fatalf("%s: wrong chunks - %s", tc.query, test.Diff(tc.expect, chunks))

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -31,6 +31,11 @@ func dummyChunkFor(metric model.Metric) Chunk {
 		now.Add(-time.Hour),
 		now,
 	)
+	// Force checksum calculation.
+	_, err := chunk.encode()
+	if err != nil {
+		panic(err)
+	}
 	return chunk
 }
 

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -229,26 +229,35 @@ func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback f
 	return nil
 }
 
-// PutChunk implements S3Client.
-func (m *MockStorage) PutChunk(_ context.Context, key string, buf []byte) error {
+// PutChunks implements StorageClient.
+func (m *MockStorage) PutChunks(_ context.Context, _ []Chunk, keys []string, bufs [][]byte) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	m.objects[key] = buf
+	for i := range keys {
+		m.objects[keys[i]] = bufs[i]
+	}
 	return nil
 }
 
-// GetChunk implements S3Client.
-func (m *MockStorage) GetChunk(_ context.Context, key string) ([]byte, error) {
+// GetChunks implements StorageClient.
+func (m *MockStorage) GetChunks(ctx context.Context, chunkSet []Chunk) ([]Chunk, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	buf, ok := m.objects[key]
-	if !ok {
-		return nil, fmt.Errorf("%v not found", key)
+	result := []Chunk{}
+	for _, chunk := range chunkSet {
+		key := chunk.externalKey()
+		buf, ok := m.objects[key]
+		if !ok {
+			return nil, fmt.Errorf("%v not found", key)
+		}
+		if err := chunk.decode(buf); err != nil {
+			return nil, err
+		}
+		result = append(result, chunk)
 	}
-
-	return buf, nil
+	return result, nil
 }
 
 type mockWriteBatch []struct {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -230,12 +230,16 @@ func (m *MockStorage) QueryPages(_ context.Context, query IndexQuery, callback f
 }
 
 // PutChunks implements StorageClient.
-func (m *MockStorage) PutChunks(_ context.Context, _ []Chunk, keys []string, bufs [][]byte) error {
+func (m *MockStorage) PutChunks(_ context.Context, chunks []Chunk) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	for i := range keys {
-		m.objects[keys[i]] = bufs[i]
+	for i := range chunks {
+		buf, err := chunks[i].encode()
+		if err != nil {
+			return err
+		}
+		m.objects[chunks[i].externalKey()] = buf
 	}
 	return nil
 }

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -49,6 +49,9 @@ type IndexQuery struct {
 	RangeValuePrefix []byte
 	RangeValueStart  []byte
 
+	// Used when fetching chunks
+	RangeValue []byte
+
 	// Filters for querying
 	ValueEqual []byte
 }

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -49,9 +49,6 @@ type IndexQuery struct {
 	RangeValuePrefix []byte
 	RangeValueStart  []byte
 
-	// Used when fetching chunks
-	RangeValue []byte
-
 	// Filters for querying
 	ValueEqual []byte
 }

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -19,8 +19,8 @@ type StorageClient interface {
 	QueryPages(ctx context.Context, query IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error
 
 	// For storing and retrieving chunks.
-	PutChunk(ctx context.Context, key string, data []byte) error
-	GetChunk(ctx context.Context, key string) ([]byte, error)
+	PutChunks(ctx context.Context, chunks []Chunk, keys []string, data [][]byte) error
+	GetChunks(ctx context.Context, chunks []Chunk) ([]Chunk, error)
 }
 
 // WriteBatch represents a batch of writes.

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -19,7 +19,7 @@ type StorageClient interface {
 	QueryPages(ctx context.Context, query IndexQuery, callback func(result ReadBatch, lastPage bool) (shouldContinue bool)) error
 
 	// For storing and retrieving chunks.
-	PutChunks(ctx context.Context, chunks []Chunk, keys []string, data [][]byte) error
+	PutChunks(ctx context.Context, chunks []Chunk) error
 	GetChunks(ctx context.Context, chunks []Chunk) ([]Chunk, error)
 }
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/model"
 	"golang.org/x/net/context"
 
 	"github.com/weaveworks/common/instrument"
@@ -55,6 +56,11 @@ type TableManagerConfig struct {
 	ProvisionedReadThroughput  int64
 	InactiveWriteThroughput    int64
 	InactiveReadThroughput     int64
+
+	ChunkTableProvisionedWriteThroughput int64
+	ChunkTableProvisionedReadThroughput  int64
+	ChunkTableInactiveWriteThroughput    int64
+	ChunkTableInactiveReadThroughput     int64
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -66,6 +72,10 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.ProvisionedReadThroughput, "dynamodb.periodic-table.read-throughput", 300, "DynamoDB periodic tables read throughput")
 	f.Int64Var(&cfg.InactiveWriteThroughput, "dynamodb.periodic-table.inactive-write-throughput", 1, "DynamoDB periodic tables write throughput for inactive tables.")
 	f.Int64Var(&cfg.InactiveReadThroughput, "dynamodb.periodic-table.inactive-read-throughput", 300, "DynamoDB periodic tables read throughput for inactive tables")
+	f.Int64Var(&cfg.ChunkTableProvisionedWriteThroughput, "dynamodb.chunk-table.write-throughput", 3000, "DynamoDB chunk tables write throughput")
+	f.Int64Var(&cfg.ChunkTableProvisionedReadThroughput, "dynamodb.chunk-table.read-throughput", 300, "DynamoDB chunk tables read throughput")
+	f.Int64Var(&cfg.ChunkTableInactiveWriteThroughput, "dynamodb.chunk-table.inactive-write-throughput", 1, "DynamoDB chunk tables write throughput for inactive tables.")
+	f.Int64Var(&cfg.ChunkTableInactiveReadThroughput, "dynamodb.chunk-table.inactive-read-throughput", 300, "DynamoDB chunk tables read throughput for inactive tables")
 
 	cfg.PeriodicTableConfig.RegisterFlags(f)
 }
@@ -79,6 +89,10 @@ type PeriodicTableConfig struct {
 	TablePrefix          string
 	TablePeriod          time.Duration
 	PeriodicTableStartAt util.DayValue
+
+	ChunkTableFrom   util.DayValue
+	ChunkTablePrefix string
+	ChunkTablePeriod time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -88,6 +102,10 @@ func (cfg *PeriodicTableConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.TablePrefix, "dynamodb.periodic-table.prefix", "cortex_", "DynamoDB table prefix for the periodic tables.")
 	f.DurationVar(&cfg.TablePeriod, "dynamodb.periodic-table.period", 7*24*time.Hour, "DynamoDB periodic tables period.")
 	f.Var(&cfg.PeriodicTableStartAt, "dynamodb.periodic-table.start", "DynamoDB periodic tables start time.")
+
+	f.Var(&cfg.ChunkTableFrom, "dynamodb.chunk-table.from", "Date after which to write chunks to DynamoDB.")
+	f.StringVar(&cfg.ChunkTablePrefix, "dynamodb.chunk-table.prefix", "cortex_chunks_", "DynamoDB table prefix for period chunk tables.")
+	f.DurationVar(&cfg.ChunkTablePeriod, "dynamodb.chunk-table.period", 7*24*time.Hour, "DynamoDB chunk tables period.")
 }
 
 // TableManager creates and manages the provisioned throughput on DynamoDB tables
@@ -191,7 +209,6 @@ func (m *TableManager) calculateExpectedTables() []tableDescription {
 		gracePeriodSecs = int64(m.cfg.CreationGracePeriod / time.Second)
 		maxChunkAgeSecs = int64(m.cfg.MaxChunkAge / time.Second)
 		firstTable      = m.cfg.PeriodicTableStartAt.Unix() / tablePeriodSecs
-		lastTable       = (mtime.Now().Unix() + gracePeriodSecs) / tablePeriodSecs
 		now             = mtime.Now().Unix()
 	)
 
@@ -211,23 +228,54 @@ func (m *TableManager) calculateExpectedTables() []tableDescription {
 		result = append(result, legacyTable)
 	}
 
-	for i := firstTable; i <= lastTable; i++ {
-		table := tableDescription{
-			// Name construction needs to be consistent with chunk_store.bigBuckets
-			name:             m.cfg.TablePrefix + strconv.Itoa(int(i)),
-			provisionedRead:  m.cfg.InactiveReadThroughput,
-			provisionedWrite: m.cfg.InactiveWriteThroughput,
-		}
+	result = append(result, periodicTables(
+		m.cfg.TablePrefix, m.cfg.PeriodicTableStartAt.Time, m.cfg.TablePeriod,
+		m.cfg.CreationGracePeriod, m.cfg.MaxChunkAge,
+		m.cfg.ProvisionedReadThroughput, m.cfg.ProvisionedWriteThroughput,
+		m.cfg.InactiveReadThroughput, m.cfg.InactiveWriteThroughput,
+	)...)
 
-		// if now is within table [start - grace, end + grace), then we need some write throughput
-		if (i*tablePeriodSecs)-gracePeriodSecs <= now && now < (i*tablePeriodSecs)+tablePeriodSecs+gracePeriodSecs+maxChunkAgeSecs {
-			table.provisionedRead = m.cfg.ProvisionedReadThroughput
-			table.provisionedWrite = m.cfg.ProvisionedWriteThroughput
-		}
-		result = append(result, table)
+	if m.cfg.ChunkTableFrom.IsSet() {
+		result = append(result, periodicTables(
+			m.cfg.ChunkTablePrefix, m.cfg.ChunkTableFrom.Time, m.cfg.ChunkTablePeriod,
+			m.cfg.CreationGracePeriod, m.cfg.MaxChunkAge,
+			m.cfg.ChunkTableProvisionedReadThroughput, m.cfg.ChunkTableProvisionedWriteThroughput,
+			m.cfg.ChunkTableInactiveReadThroughput, m.cfg.ChunkTableInactiveWriteThroughput,
+		)...)
 	}
 
 	sort.Sort(byName(result))
+	return result
+}
+
+func periodicTables(
+	prefix string, start model.Time, period, beginGrace, endGrace time.Duration,
+	activeRead, activeWrite, inactiveRead, inactiveWrite int64,
+) []tableDescription {
+	var (
+		periodSecs     = int64(period / time.Second)
+		beginGraceSecs = int64(beginGrace / time.Second)
+		endGraceSecs   = int64(endGrace / time.Second)
+		firstTable     = start.Unix() / periodSecs
+		lastTable      = (mtime.Now().Unix() + beginGraceSecs) / periodSecs
+		now            = mtime.Now().Unix()
+		result         = []tableDescription{}
+	)
+	for i := firstTable; i <= lastTable; i++ {
+		table := tableDescription{
+			// Name construction needs to be consistent with chunk_store.bigBuckets
+			name:             prefix + strconv.Itoa(int(i)),
+			provisionedRead:  inactiveRead,
+			provisionedWrite: inactiveWrite,
+		}
+
+		// if now is within table [start - grace, end + grace), then we need some write throughput
+		if (i*periodSecs)-beginGraceSecs <= now && now < (i*periodSecs)+periodSecs+endGraceSecs {
+			table.provisionedRead = activeRead
+			table.provisionedWrite = activeWrite
+		}
+		result = append(result, table)
+	}
 	return result
 }
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -48,6 +48,7 @@ type TableManagerConfig struct {
 	DynamoDBPollInterval time.Duration
 
 	PeriodicTableConfig
+	ChunkTableConfig
 
 	// duration a table will be created before it is needed.
 	CreationGracePeriod        time.Duration
@@ -78,6 +79,7 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.ChunkTableInactiveReadThroughput, "dynamodb.chunk-table.inactive-read-throughput", 300, "DynamoDB chunk tables read throughput for inactive tables")
 
 	cfg.PeriodicTableConfig.RegisterFlags(f)
+	cfg.ChunkTableConfig.RegisterFlags(f)
 }
 
 // PeriodicTableConfig for the use of periodic tables (ie, weekly tables).  Can
@@ -89,10 +91,6 @@ type PeriodicTableConfig struct {
 	TablePrefix          string
 	TablePeriod          time.Duration
 	PeriodicTableStartAt util.DayValue
-
-	ChunkTableFrom   util.DayValue
-	ChunkTablePrefix string
-	ChunkTablePeriod time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -102,7 +100,16 @@ func (cfg *PeriodicTableConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.TablePrefix, "dynamodb.periodic-table.prefix", "cortex_", "DynamoDB table prefix for the periodic tables.")
 	f.DurationVar(&cfg.TablePeriod, "dynamodb.periodic-table.period", 7*24*time.Hour, "DynamoDB periodic tables period.")
 	f.Var(&cfg.PeriodicTableStartAt, "dynamodb.periodic-table.start", "DynamoDB periodic tables start time.")
+}
 
+type ChunkTableConfig struct {
+	ChunkTableFrom   util.DayValue
+	ChunkTablePrefix string
+	ChunkTablePeriod time.Duration
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *ChunkTableConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.ChunkTableFrom, "dynamodb.chunk-table.from", "Date after which to write chunks to DynamoDB.")
 	f.StringVar(&cfg.ChunkTablePrefix, "dynamodb.chunk-table.prefix", "cortex_chunks_", "DynamoDB table prefix for period chunk tables.")
 	f.DurationVar(&cfg.ChunkTablePeriod, "dynamodb.chunk-table.period", 7*24*time.Hour, "DynamoDB chunk tables period.")

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -48,7 +48,7 @@ type TableManagerConfig struct {
 	DynamoDBPollInterval time.Duration
 
 	PeriodicTableConfig
-	ChunkTableConfig
+	PeriodicChunkTableConfig
 
 	// duration a table will be created before it is needed.
 	CreationGracePeriod        time.Duration
@@ -79,7 +79,7 @@ func (cfg *TableManagerConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&cfg.ChunkTableInactiveReadThroughput, "dynamodb.chunk-table.inactive-read-throughput", 300, "DynamoDB chunk tables read throughput for inactive tables")
 
 	cfg.PeriodicTableConfig.RegisterFlags(f)
-	cfg.ChunkTableConfig.RegisterFlags(f)
+	cfg.PeriodicChunkTableConfig.RegisterFlags(f)
 }
 
 // PeriodicTableConfig for the use of periodic tables (ie, weekly tables).  Can
@@ -102,14 +102,15 @@ func (cfg *PeriodicTableConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.PeriodicTableStartAt, "dynamodb.periodic-table.start", "DynamoDB periodic tables start time.")
 }
 
-type ChunkTableConfig struct {
+// PeriodicChunkTableConfig contains the various parameters for the chunk table.
+type PeriodicChunkTableConfig struct {
 	ChunkTableFrom   util.DayValue
 	ChunkTablePrefix string
 	ChunkTablePeriod time.Duration
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
-func (cfg *ChunkTableConfig) RegisterFlags(f *flag.FlagSet) {
+func (cfg *PeriodicChunkTableConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.ChunkTableFrom, "dynamodb.chunk-table.from", "Date after which to write chunks to DynamoDB.")
 	f.StringVar(&cfg.ChunkTablePrefix, "dynamodb.chunk-table.prefix", "cortex_chunks_", "DynamoDB table prefix for period chunk tables.")
 	f.DurationVar(&cfg.ChunkTablePeriod, "dynamodb.chunk-table.period", 7*24*time.Hour, "DynamoDB chunk tables period.")

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -13,14 +13,15 @@ import (
 )
 
 const (
-	tablePrefix   = "cortex_"
-	tablePeriod   = 7 * 24 * time.Hour
-	gracePeriod   = 15 * time.Minute
-	maxChunkAge   = 12 * time.Hour
-	inactiveWrite = 1
-	inactiveRead  = 2
-	write         = 200
-	read          = 100
+	tablePrefix      = "cortex_"
+	chunkTablePrefix = "chunks_"
+	tablePeriod      = 7 * 24 * time.Hour
+	gracePeriod      = 15 * time.Minute
+	maxChunkAge      = 12 * time.Hour
+	inactiveWrite    = 1
+	inactiveRead     = 2
+	write            = 200
+	read             = 100
 )
 
 func TestTableManager(t *testing.T) {
@@ -28,20 +29,28 @@ func TestTableManager(t *testing.T) {
 
 	cfg := TableManagerConfig{
 		PeriodicTableConfig: PeriodicTableConfig{
-			UsePeriodicTables: true,
-			TablePrefix:       tablePrefix,
-			TablePeriod:       tablePeriod,
-			PeriodicTableStartAt: util.DayValue{
-				Time: model.TimeFromUnix(0),
-			},
+			UsePeriodicTables:    true,
+			TablePrefix:          tablePrefix,
+			TablePeriod:          tablePeriod,
+			PeriodicTableStartAt: util.NewDayValue(model.TimeFromUnix(0)),
 		},
 
-		CreationGracePeriod:        gracePeriod,
-		MaxChunkAge:                maxChunkAge,
-		ProvisionedWriteThroughput: write,
-		ProvisionedReadThroughput:  read,
-		InactiveWriteThroughput:    inactiveWrite,
-		InactiveReadThroughput:     inactiveRead,
+		PeriodicChunkTableConfig: PeriodicChunkTableConfig{
+			ChunkTablePrefix: chunkTablePrefix,
+			ChunkTablePeriod: tablePeriod,
+			ChunkTableFrom:   util.NewDayValue(model.TimeFromUnix(0)),
+		},
+
+		CreationGracePeriod:                  gracePeriod,
+		MaxChunkAge:                          maxChunkAge,
+		ProvisionedWriteThroughput:           write,
+		ProvisionedReadThroughput:            read,
+		InactiveWriteThroughput:              inactiveWrite,
+		InactiveReadThroughput:               inactiveRead,
+		ChunkTableProvisionedWriteThroughput: write,
+		ChunkTableProvisionedReadThroughput:  read,
+		ChunkTableInactiveWriteThroughput:    inactiveWrite,
+		ChunkTableInactiveReadThroughput:     inactiveRead,
 	}
 	tableManager, err := NewTableManager(cfg, dynamoDB)
 	if err != nil {
@@ -66,6 +75,7 @@ func TestTableManager(t *testing.T) {
 		[]tableDescription{
 			{name: "", provisionedRead: read, provisionedWrite: write},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -76,6 +86,7 @@ func TestTableManager(t *testing.T) {
 		[]tableDescription{
 			{name: "", provisionedRead: read, provisionedWrite: write},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -86,6 +97,7 @@ func TestTableManager(t *testing.T) {
 		[]tableDescription{
 			{name: "", provisionedRead: read, provisionedWrite: write},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -96,6 +108,7 @@ func TestTableManager(t *testing.T) {
 		[]tableDescription{
 			{name: "", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -107,6 +120,8 @@ func TestTableManager(t *testing.T) {
 			{name: "", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 			{name: tablePrefix + "1", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "1", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -118,6 +133,8 @@ func TestTableManager(t *testing.T) {
 			{name: "", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "0", provisionedRead: read, provisionedWrite: write},
 			{name: tablePrefix + "1", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "1", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -129,6 +146,8 @@ func TestTableManager(t *testing.T) {
 			{name: "", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "0", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "1", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
+			{name: chunkTablePrefix + "1", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 
@@ -140,6 +159,8 @@ func TestTableManager(t *testing.T) {
 			{name: "", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "0", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
 			{name: tablePrefix + "1", provisionedRead: read, provisionedWrite: write},
+			{name: chunkTablePrefix + "0", provisionedRead: inactiveRead, provisionedWrite: inactiveWrite},
+			{name: chunkTablePrefix + "1", provisionedRead: read, provisionedWrite: write},
 		},
 	)
 }

--- a/pkg/ingester/BUILD
+++ b/pkg/ingester/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/common/log:go_default_library",
         "//vendor/github.com/prometheus/common/model:go_default_library",
+        "//vendor/github.com/prometheus/prometheus/promql:go_default_library",
         "//vendor/github.com/prometheus/prometheus/storage/local/chunk:go_default_library",
         "//vendor/github.com/prometheus/prometheus/storage/metric:go_default_library",
         "//vendor/github.com/weaveworks/common/user:go_default_library",

--- a/pkg/ingester/client/BUILD
+++ b/pkg/ingester/client/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "client.go",
         "cortex.pb.go",
+        "dep.go",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"golang.org/x/net/context"
@@ -18,6 +19,13 @@ const (
 	// position, not wallclock time.
 	flushBackoff = 1 * time.Second
 )
+
+// FlushHandler triggers a flush of all in memory chunks.  Mainly used for
+// local testing.
+func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
+	i.sweepUsers(true)
+	w.WriteHeader(http.StatusNoContent)
+}
 
 type flushOp struct {
 	from      model.Time


### PR DESCRIPTION
Part #141 

- After a certain time, store chunks in DynamoDB.
- Use the table manager to regularly rotate this table, and provision its capacity.
- Fetch chunks for DynamoDB in batches of 100.