### PR TITLE
Avoid CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To use the Prometheus Service with Grafana, configure your Grafana instance to h
 
 - Type: Prometheus
 - Url: https://cloud.weave.works/api/prom
-- Access: Direct
+- Access: Proxy
 - Http Auth: Basic Auth
 - User: `user` (this is ignored, but must be non-empty)
 - Password: <Service Token> (the same one your retrieval agent uses)


### PR DESCRIPTION
Attempting direct access to Cortex from browser results in failed requests due to CORS. Changing the default to proxy through the Grafana backend is more reliable.

Before:
![screen shot 2017-05-17 at 12 34 19](https://cloud.githubusercontent.com/assets/264658/26152291/4259d698-3afe-11e7-9086-61fefed670dd.png)

After:
![screen shot 2017-05-17 at 12 38 44](https://cloud.githubusercontent.com/assets/264658/26152297/480a793a-3afe-11e7-8684-9eb61c397678.png)
