### PR TITLE
Create v8Schema with series index

### DIFF
--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -57,6 +57,7 @@ func TestChunkStore(t *testing.T) {
 		{"v5 schema", v5Schema},
 		{"v6 schema", v6Schema},
 		{"v7 schema", v7Schema},
+		{"v8 schema", v8Schema},
 	}
 
 	nameMatcher := mustNewLabelMatcher(metric.Equal, model.MetricNameLabel, "foo")
@@ -282,6 +283,7 @@ func TestChunkStoreRandom(t *testing.T) {
 		{name: "v5 schema", fn: v5Schema},
 		{name: "v6 schema", fn: v6Schema},
 		{name: "v7 schema", fn: v7Schema},
+		{name: "v8 schema", fn: v8Schema},
 	}
 
 	for i := range schemas {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -139,9 +139,10 @@ func (m *MockStorage) BatchWrite(_ context.Context, batch WriteBatch) error {
 			items = append(items, mockItem{})
 			copy(items[i+1:], items[i:])
 		} else {
-			// Return error if duplicate write and not metric name entry
+			// Return error if duplicate write and not metric name entry or series entry
 			itemComponents := decodeRangeKey(items[i].rangeValue)
-			if !bytes.Equal(itemComponents[3], metricNameRangeKeyV1) {
+			if !bytes.Equal(itemComponents[3], metricNameRangeKeyV1) &&
+				!bytes.Equal(itemComponents[3], seriesRangeKeyV1) {
 				return fmt.Errorf("Dupe write")
 			}
 		}

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -2,7 +2,6 @@ package chunk
 
 import (
 	"crypto/sha1"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -559,9 +558,7 @@ func (entries v8Entries) GetWriteEntries(bucket Bucket, metricName model.LabelVa
 		return nil, err
 	}
 
-	fingerprintBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(fingerprintBytes, uint64(labels.Fingerprint()))
-
+	seriesID := metricSeriesID(labels)
 	seriesBytes, err := json.Marshal(labels)
 	if err != nil {
 		return nil, err
@@ -571,7 +568,7 @@ func (entries v8Entries) GetWriteEntries(bucket Bucket, metricName model.LabelVa
 	indexEntries = append(indexEntries, IndexEntry{
 		TableName:  bucket.tableName,
 		HashValue:  bucket.hashKey,
-		RangeValue: encodeRangeKey(encodeBase64Bytes(fingerprintBytes), nil, nil, seriesRangeKeyV1),
+		RangeValue: encodeRangeKey([]byte(seriesID), nil, nil, seriesRangeKeyV1),
 		Value:      seriesBytes,
 	})
 

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -574,3 +574,12 @@ func (entries v8Entries) GetWriteEntries(bucket Bucket, metricName model.LabelVa
 
 	return indexEntries, nil
 }
+
+func (v8Entries) GetReadQueries(bucket Bucket) ([]IndexQuery, error) {
+	return []IndexQuery{
+		{
+			TableName: bucket.tableName,
+			HashValue: bucket.hashKey,
+		},
+	}, nil
+}

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -41,6 +41,9 @@ type SchemaConfig struct {
 
 	// After this time, we will read and write v7 schemas.
 	V7SchemaFrom util.DayValue
+
+	// After this time, we will read and write v8 schemas.
+	V8SchemaFrom util.DayValue
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -53,6 +56,7 @@ func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.V5SchemaFrom, "dynamodb.v5-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v5 schema.")
 	f.Var(&cfg.V6SchemaFrom, "dynamodb.v6-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v6 schema.")
 	f.Var(&cfg.V7SchemaFrom, "dynamodb.v7-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v7 schema.")
+	f.Var(&cfg.V8SchemaFrom, "dynamodb.v8-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v8 schema.")
 }
 
 func (cfg *SchemaConfig) tableForBucket(bucketStart int64) string {
@@ -175,6 +179,10 @@ func newCompositeSchema(cfg SchemaConfig) (Schema, error) {
 
 	if cfg.V7SchemaFrom.IsSet() {
 		schemas = append(schemas, compositeSchemaEntry{cfg.V7SchemaFrom.Time, v7Schema(cfg)})
+	}
+
+	if cfg.V8SchemaFrom.IsSet() {
+		schemas = append(schemas, compositeSchemaEntry{cfg.V8SchemaFrom.Time, v8Schema(cfg)})
 	}
 
 	if !sort.IsSorted(byStart(schemas)) {

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -236,6 +238,7 @@ func TestSchemaHashKeys(t *testing.T) {
 const (
 	MetricNameRangeValue = iota + 1
 	ChunkTimeRangeValue
+	SeriesRangeValue
 )
 
 // parseRangeValueType returns the type of rangeValue
@@ -269,6 +272,10 @@ func parseRangeValueType(rangeValue []byte) (int, error) {
 	case bytes.Equal(components[3], metricNameRangeKeyV1):
 		return MetricNameRangeValue, nil
 
+	// series range values
+	case bytes.Equal(components[3], seriesRangeKeyV1):
+		return SeriesRangeValue, nil
+
 	default:
 		return 0, fmt.Errorf("unrecognised range value type. version: '%v'", string(components[3]))
 	}
@@ -295,6 +302,7 @@ func TestSchemaRangeKey(t *testing.T) {
 		tsRangeKeys   = v5Schema(cfg)
 		v6RangeKeys   = v6Schema(cfg)
 		v7RangeKeys   = v7Schema(cfg)
+		v8RangeKeys   = v8Schema(cfg)
 		metric        = model.Metric{
 			model.MetricNameLabel: metricName,
 			"bar": "bary",
@@ -302,6 +310,11 @@ func TestSchemaRangeKey(t *testing.T) {
 		}
 		fooSha1Hash = sha1.Sum([]byte("foo"))
 	)
+
+	metricFingerprintBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(metricFingerprintBytes, uint64(metric.Fingerprint()))
+	metricBytes, err := json.Marshal(metric)
+	require.NoError(t, err)
 
 	mkEntries := func(hashKey string, callback func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte)) []IndexEntry {
 		result := []IndexEntry{}
@@ -434,6 +447,34 @@ func TestSchemaRangeKey(t *testing.T) {
 				},
 			},
 		},
+		{
+			v8RangeKeys,
+			[]IndexEntry{
+				{
+					TableName:  table,
+					HashValue:  "userid:d0",
+					RangeValue: append(encodeBase64Bytes(metricFingerprintBytes), []byte("\x00\x00\x007\x00")...),
+					Value:      metricBytes,
+				},
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x003\x00"),
+				},
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo:bar",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
+					Value:      []byte("bary"),
+				},
+				{
+					TableName:  table,
+					HashValue:  "userid:d0:foo:baz",
+					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
+					Value:      []byte("bazy"),
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("TestSchameRangeKey[%d]", i), func(t *testing.T) {
 			have, err := tc.Schema.GetWriteEntries(
@@ -461,6 +502,9 @@ func TestSchemaRangeKey(t *testing.T) {
 					require.NoError(t, err)
 				case ChunkTimeRangeValue:
 					_, _, _, err := parseChunkTimeRangeValue(entry.RangeValue, entry.Value)
+					require.NoError(t, err)
+				case SeriesRangeValue:
+					_, err := parseSeriesRangeValue(entry.RangeValue, entry.Value)
 					require.NoError(t, err)
 				}
 			}

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -311,8 +310,7 @@ func TestSchemaRangeKey(t *testing.T) {
 		fooSha1Hash = sha1.Sum([]byte("foo"))
 	)
 
-	metricFingerprintBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(metricFingerprintBytes, uint64(metric.Fingerprint()))
+	seriesID := metricSeriesID(metric)
 	metricBytes, err := json.Marshal(metric)
 	require.NoError(t, err)
 
@@ -453,7 +451,7 @@ func TestSchemaRangeKey(t *testing.T) {
 				{
 					TableName:  table,
 					HashValue:  "userid:d0",
-					RangeValue: append(encodeBase64Bytes(metricFingerprintBytes), []byte("\x00\x00\x007\x00")...),
+					RangeValue: append([]byte(seriesID), []byte("\x00\x00\x007\x00")...),
 					Value:      metricBytes,
 				},
 				{

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -105,7 +105,7 @@ func parseSeriesRangeValue(rangeValue []byte, value []byte) (model.Metric, error
 	case len(components) < 4:
 		return nil, fmt.Errorf("invalid metric range value: %x", rangeValue)
 
-	// v1 has the metric name as the value (with the hash as the first component)
+	// v1 has the encoded json metric as the value (with the fingerprint as the first component)
 	case bytes.Equal(components[3], seriesRangeKeyV1):
 		var series model.Metric
 		if err := json.Unmarshal(value, &series); err != nil {

--- a/pkg/chunk/schema_util.go
+++ b/pkg/chunk/schema_util.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -11,6 +12,11 @@ import (
 
 	"github.com/prometheus/common/model"
 )
+
+func metricSeriesID(m model.Metric) string {
+	h := sha256.Sum256([]byte(m.String()))
+	return string(encodeBase64Bytes(h[:]))
+}
 
 func encodeRangeKey(ss ...[]byte) []byte {
 	length := 0

--- a/pkg/chunk/schema_util_test.go
+++ b/pkg/chunk/schema_util_test.go
@@ -13,6 +13,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMetricSeriesID(t *testing.T) {
+	for _, c := range []struct {
+		metric   model.Metric
+		expected string
+	}{
+		{
+			model.Metric{model.MetricNameLabel: "foo"},
+			"LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564",
+		},
+		{
+			model.Metric{
+				model.MetricNameLabel: "foo",
+				"bar":  "baz",
+				"toms": "code",
+				"flip": "flop",
+			},
+			"KrbXMezYneba+o7wfEdtzOdAWhbfWcDrlVfs1uOCX3M",
+		},
+		{
+			model.Metric{},
+			"RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o",
+		},
+	} {
+		seriesID := metricSeriesID(c.metric)
+		assert.Equal(t, c.expected, seriesID)
+	}
+}
+
 func TestSchemaTimeEncoding(t *testing.T) {
 	assert.Equal(t, uint32(0), decodeTime(encodeTime(0)), "0")
 	assert.Equal(t, uint32(math.MaxUint32), decodeTime(encodeTime(math.MaxUint32)), "MaxUint32")


### PR DESCRIPTION
First step for #416.

This index will be used to fetch series from the index. It will replace the metric name index and we will make the switch after the next steps are complete.

Decided to encode the `model.Metric` as JSON because it already implements the `json.Unmarshaler` interface.

Used sha256 for identifying the series as the variant of fnv64a which if used for fingerprints is not unique enough for indexing and using sha256 keeps it simple (we don't have to deal with collision logic).

**Test plan**
- Tests pass