### PR TITLE
Use shfmt v1.3.0 instead of gopkg.in's v1

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && apt-get install -y python-requests python-yaml file jq unz
 RUN go clean -i net && \
 	go install -tags netgo std && \
 	go install -race -tags netgo std
+RUN curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
+	chmod +x shfmt && \
+	mv shfmt /usr/bin
 RUN go get -tags netgo \
 		github.com/fzipp/gocyclo \
 		github.com/golang/lint/golint \
@@ -13,8 +16,7 @@ RUN go get -tags netgo \
 		github.com/jteeuwen/go-bindata/go-bindata \
 		github.com/golang/protobuf/protoc-gen-go \
 		github.com/gogo/protobuf/protoc-gen-gogoslick \
-		github.com/gogo/protobuf/gogoproto \
-		gopkg.in/mvdan/sh.v1/cmd/shfmt && \
+		github.com/gogo/protobuf/gogoproto && \
 	rm -rf /go/pkg /go/src
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]


### PR DESCRIPTION
As mentioned on https://github.com/weaveworks/build-tools/pull/99#issuecomment-302365357 and raised on https://github.com/mvdan/sh/issues/107 `gopkg.in` currently does not behave as it should for `shfmt`, which leads to build failures like:

```
Step 4/6 : RUN go get -tags netgo     github.com/fzipp/gocyclo    github.com/golang/lint/golint     github.com/kisielk/errcheck     github.com/mjibson/esc    github.com/client9/misspell/cmd/misspell    github.com/jteeuwen/go-bindata/go-bindata     github.com/golang/protobuf/protoc-gen-go    github.com/gogo/protobuf/protoc-gen-gogoslick     github.com/gogo/protobuf/gogoproto    gopkg.in/mvdan/sh.v1/cmd/shfmt &&   rm -rf /go/pkg /go/src
 ---> Running in 05f8079c66fb
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:26: undefined: "github.com/mvdan/sh/syntax".ParseMode
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:27: undefined: "github.com/mvdan/sh/syntax".PrintConfig
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:46: undefined: "github.com/mvdan/sh/syntax".ParseComments
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:48: undefined: "github.com/mvdan/sh/syntax".PosixConformant
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:73: undefined: "github.com/mvdan/sh/syntax".Parse
src/gopkg.in/mvdan/sh.v1/cmd/shfmt/main.go:139: undefined: "github.com/mvdan/sh/syntax".Parse
The command '/bin/sh -c go get -tags netgo    github.com/fzipp/gocyclo    github.com/golang/lint/golint     github.com/kisielk/errcheck   github.com/mjibson/esc    github.com/client9/misspell/cmd/misspell    github.com/jteeuwen/go-bindata/go-bindata     github.com/golang/protobuf/protoc-gen-go    github.com/gogo/protobuf/protoc-gen-gogoslick     github.com/gogo/protobuf/gogoproto    gopkg.in/mvdan/sh.v1/cmd/shfmt &&   rm -rf /go/pkg /go/src' returned a non-zero code: 2
make: *** [build-image/.uptodate] Error 2
```

This change works around the issue by building from the tag, which is quite involved, but more deterministic than using a moving target, e.g.:
```
go get github.com/mvdan/sh/cmd/shfmt
```