### PR TITLE
Test that the map itself is nil, not the pointer to it!

### DIFF
--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -81,7 +81,7 @@ func (ts Tags) String() string {
 
 // Set implements flag.Value
 func (ts *Tags) Set(s string) error {
-	if ts == nil {
+	if *ts == nil {
 		*ts = map[string]string{}
 	}
 

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -204,11 +204,8 @@ func TestTableManagerTags(t *testing.T) {
 
 	// Check after restarting table manager we get some tags.
 	{
-		cfg := TableManagerConfig{
-			TableTags: Tags{
-				"foo": "bar",
-			},
-		}
+		cfg := TableManagerConfig{}
+		cfg.TableTags.Set("foo=bar")
 		tableManager, err := NewTableManager(cfg, client)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Also, alter the unit test to pick this up.

Previously you'd get this traceback:
```
$ ./table-manager -dynamodb.table.tag=foo=bar
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/weaveworks/cortex/pkg/chunk.(*Tags).Set(0xc42007bfa0, 0x7fff5fbffc04, 0x7, 0x0, 0x0)
	/Users/twilkie/Documents/src/github.com/weaveworks/cortex/pkg/chunk/table_manager.go:92 +0x9c
flag.(*FlagSet).parseOne(0xc42006e060, 0xc42007bfa0, 0x1773370, 0x12)
	/usr/local/Cellar/go/1.8/libexec/src/flag/flag.go:894 +0x3c2
flag.(*FlagSet).Parse(0xc42006e060, 0xc420080070, 0x1, 0x1, 0x3, 0xc420287cb0)
	/usr/local/Cellar/go/1.8/libexec/src/flag/flag.go:913 +0x60
flag.Parse()
	/usr/local/Cellar/go/1.8/libexec/src/flag/flag.go:941 +0x72
main.main()
	/Users/twilkie/Documents/src/github.com/weaveworks/cortex/cmd/table-manager/main.go:27 +0x274
```