### PR TITLE
Only change provisioned capacity and tags if they have changed.

### DIFF
--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -86,7 +86,7 @@ func (m *MockStorage) DescribeTable(_ context.Context, name string) (desc TableD
 }
 
 // UpdateTable implements StorageClient.
-func (m *MockStorage) UpdateTable(_ context.Context, desc TableDesc) error {
+func (m *MockStorage) UpdateTable(_ context.Context, _, desc TableDesc) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 

--- a/pkg/chunk/table_client.go
+++ b/pkg/chunk/table_client.go
@@ -7,7 +7,7 @@ type TableClient interface {
 	ListTables(ctx context.Context) ([]string, error)
 	CreateTable(ctx context.Context, desc TableDesc) error
 	DescribeTable(ctx context.Context, name string) (desc TableDesc, status string, err error)
-	UpdateTable(ctx context.Context, desc TableDesc) error
+	UpdateTable(ctx context.Context, current, expected TableDesc) error
 }
 
 // TableDesc describes a table.


### PR DESCRIPTION
Turns out `UpdateTable` is not idempotent, and errors when trying to 'update' the provisioned throughput to something thats the same:

```
time="2017-05-24T13:07:58Z" level=error msg="Error syncing tables: ValidationException: The provisioned throughput for the table will not change. The requested value equals the current value. Current ReadCapacityUnits provisioned for the table: 300. Requested ReadCapacityUnits: 300. Current WriteCapacityUnits provisioned for the table: 300. Requested WriteCapacityUnits: 300. Refer to the Amazon DynamoDB Developer Guide for current limits and how to request higher limits.
```