### PR TITLE
Only set DynamoDB table tags if they exist

### DIFF
--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -328,6 +328,10 @@ func (m *mockDynamoDBClient) TagResourceWithContext(_ aws.Context, input *dynamo
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
+	if len(input.Tags) == 0 {
+		return nil, fmt.Errorf("tags are required")
+	}
+
 	if !strings.HasPrefix(*input.ResourceArn, arnPrefix) {
 		return nil, fmt.Errorf("not an arn: %v", *input.ResourceArn)
 	}

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -196,18 +196,15 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected Ta
 			return err
 		}
 
-		tags := expected.Tags.AWSTags()
-		if len(tags) > 0 {
-			return d.backoffAndRetry(ctx, func(ctx context.Context) error {
-				return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
-					_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
-						ResourceArn: tableARN,
-						Tags:        tags,
-					})
-					return err
+		return d.backoffAndRetry(ctx, func(ctx context.Context) error {
+			return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
+				_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
+					ResourceArn: tableARN,
+					Tags:        expected.Tags.AWSTags(),
 				})
+				return err
 			})
-		}
+		})
 	}
 	return nil
 }

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -111,15 +111,19 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc TableDesc) erro
 		return err
 	}
 
-	return d.backoffAndRetry(ctx, func(ctx context.Context) error {
-		return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
-			_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
-				ResourceArn: tableARN,
-				Tags:        desc.Tags.AWSTags(),
+	tags := desc.Tags.AWSTags()
+	if len(tags) > 0 {
+		return d.backoffAndRetry(ctx, func(ctx context.Context) error {
+			return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
+				_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
+					ResourceArn: tableARN,
+					Tags:        tags,
+				})
+				return err
 			})
-			return err
 		})
-	})
+	}
+	return nil
 }
 
 func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc TableDesc, status string, err error) {
@@ -192,15 +196,18 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected Ta
 			return err
 		}
 
-		return d.backoffAndRetry(ctx, func(ctx context.Context) error {
-			return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
-				_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
-					ResourceArn: tableARN,
-					Tags:        expected.Tags.AWSTags(),
+		tags := expected.Tags.AWSTags()
+		if len(tags) > 0 {
+			return d.backoffAndRetry(ctx, func(ctx context.Context) error {
+				return instrument.TimeRequestHistogram(ctx, "DynamoDB.TagResource", dynamoRequestDuration, func(ctx context.Context) error {
+					_, err := d.DynamoDB.TagResourceWithContext(ctx, &dynamodb.TagResourceInput{
+						ResourceArn: tableARN,
+						Tags:        tags,
+					})
+					return err
 				})
-				return err
 			})
-		})
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
DynamoDB raises an exception if you try to set empty tags. We have empty tags if they are not set via config (e.g. local).