### PR TITLE
Fix builtin `time` command not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(EXES) $(PROTO_GOS) lint test shell: build-image/$(UPTODATE)
 	$(SUDO) time docker run $(RM) -ti \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/go/src/github.com/weaveworks/cortex \
-		$(IMAGE_PREFIX)build-image $@
+		$(IMAGE_PREFIX)build-image $@;
 
 configs-integration-test: build-image/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg


### PR DESCRIPTION
Needs trailing `;` for shells where time is a reserved word (builtin command).

Full error:

    make: time: Command not found

See also weaveworks/billing#84