### PR TITLE
Reduce likelihood of a race between rules evaluation and alerts scheduling

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -282,7 +282,9 @@ func NewServer(cfg Config, ruler *Ruler) (*Server, error) {
 		Timeout: cfg.ClientTimeout,
 	}
 	// TODO: Separate configuration for polling interval.
-	s := newScheduler(c, cfg.EvaluationInterval, cfg.EvaluationInterval)
+	// N.B.: there is currently a race condition between rules evaluation and alerts scheduling,
+	// so we offset the interval, but only by a small amount, to minimise the odds of the race happening.
+	s := newScheduler(c, cfg.EvaluationInterval, cfg.EvaluationInterval+10*time.Millisecond)
 	if cfg.NumWorkers <= 0 {
 		return nil, fmt.Errorf("must have at least 1 worker, got %d", cfg.NumWorkers)
 	}


### PR DESCRIPTION
Identified by @bboreham, all credits go to him :+1:.

This is a quick change to (hopefully) help identify an issue with alerts periodically going back to pending, and not firing; and reduce the likelihood of the race condition interfering with this investigation.

Alternatives considered: 
- add half-an-interval to, but this would still lead to a race 50% of the time,
- add one second, but this would still lead to a race every 15 seconds (the current default interval),
- randomise, but could actually make it harder to identify issues,
- add 10 ms (current state): this should be long enough to avoid a race condition, and short enough to maximise the time before the two schedules overlap again (if the race is happening 100% of the time every 15 seconds, then, with 10 ms offset, it would only happen 1/1500 of the time).

Note that the first interval is used by a timer, and the second in a `Defer` instruction, so one would think the execution of the scheduled work would add enough noise to avoid races (?).

A proper fix and the implementation of  `TODO: Separate configuration for polling interval.` should follow, once the incident is resolved.