### PR TITLE
Add counter for number of config updates the sheduler has made

### DIFF
--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -28,6 +28,11 @@ var (
 		Name:      "configs",
 		Help:      "How many configs the scheduler knows about.",
 	})
+	configUpdates = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "cortex",
+		Name:      "scheduler_config_updates_total",
+		Help:      "How many config updates the scheduler has made.",
+	})
 	configsRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",
 		Name:      "configs_request_duration_seconds",
@@ -39,6 +44,7 @@ var (
 func init() {
 	prometheus.MustRegister(configsRequestDuration)
 	prometheus.MustRegister(totalConfigs)
+	prometheus.MustRegister(configUpdates)
 }
 
 type workItem struct {
@@ -185,6 +191,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.View) {
 		s.addWorkItem(workItem{userID, rules, now})
 		s.cfgs[userID] = config.Config
 	}
+	configUpdates.Add(float64(len(cfgs)))
 	totalConfigs.Set(float64(len(s.cfgs)))
 }
 


### PR DESCRIPTION
I'm half convinced that this won't show anything interesting, since it's a less indirect version of 
`rate(cortex_request_duration_seconds_count{job="cortex/configs", method="POST"}[1m])` but I thought I'd post it anyway!