### PR TITLE
Bump golang version to 1.8.3

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.1-stretch
+FROM golang:1.8.3-stretch
 RUN apt-get update && apt-get install -y python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \


### PR DESCRIPTION
It has a few fixes, and other things I'm building use 1.8.3 so I don't want to download 1.8.1 as well.
