### PR TITLE
Fix latest config id reverting to 0

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -340,9 +340,11 @@ func (am *MultitenantAlertmanager) poll() (map[string]configs.View, error) {
 		log.Warnf("MultitenantAlertmanager: configs server poll failed: %v", err)
 		return nil, err
 	}
-	am.latestMutex.Lock()
-	am.latestConfig = cfgs.GetLatestConfigID()
-	am.latestMutex.Unlock()
+	if len(cfgs.Configs) > 0 {
+		am.latestMutex.Lock()
+		am.latestConfig = cfgs.GetLatestConfigID()
+		am.latestMutex.Unlock()
+	}
 	return cfgs.Configs, nil
 }
 

--- a/pkg/configs/client/configs.go
+++ b/pkg/configs/client/configs.go
@@ -33,8 +33,8 @@ func configsFromJSON(body io.Reader) (*ConfigsResponse, error) {
 }
 
 // GetLatestConfigID returns the last config ID from a set of configs.
-func (c ConfigsResponse) GetLatestConfigID(min configs.ID) configs.ID {
-	latest := min
+func (c ConfigsResponse) GetLatestConfigID() configs.ID {
+	latest := configs.ID(0)
 	for _, config := range c.Configs {
 		if config.ID > latest {
 			latest = config.ID

--- a/pkg/configs/client/configs.go
+++ b/pkg/configs/client/configs.go
@@ -33,8 +33,8 @@ func configsFromJSON(body io.Reader) (*ConfigsResponse, error) {
 }
 
 // GetLatestConfigID returns the last config ID from a set of configs.
-func (c ConfigsResponse) GetLatestConfigID() configs.ID {
-	latest := configs.ID(0)
+func (c ConfigsResponse) GetLatestConfigID(min configs.ID) configs.ID {
+	latest := min
 	for _, config := range c.Configs {
 		if config.ID > latest {
 			latest = config.ID

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -168,9 +168,11 @@ func (s *scheduler) poll() (map[string]configs.View, error) {
 		log.Warnf("Scheduler: configs server poll failed: %v", err)
 		return nil, err
 	}
-	s.latestMutex.Lock()
-	s.latestConfig = cfgs.GetLatestConfigID(configID)
-	s.latestMutex.Unlock()
+	if len(cfgs.Configs) > 0 {
+		s.latestMutex.Lock()
+		s.latestConfig = cfgs.GetLatestConfigID()
+		s.latestMutex.Unlock()
+	}
 	return cfgs.Configs, nil
 }
 

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -169,7 +169,7 @@ func (s *scheduler) poll() (map[string]configs.View, error) {
 		return nil, err
 	}
 	s.latestMutex.Lock()
-	s.latestConfig = cfgs.GetLatestConfigID()
+	s.latestConfig = cfgs.GetLatestConfigID(configID)
 	s.latestMutex.Unlock()
 	return cfgs.Configs, nil
 }


### PR DESCRIPTION
If no config changes happened since last poll, we'd have an empty response, and revert to 0.