### PR TITLE
Revert "Allow pushing images from a fork"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Boiler plate for bulding Docker containers.
 # All this must go at top of file I'm afraid.
-IMAGE_PREFIX ?= quay.io/weaveworks/cortex-
+IMAGE_PREFIX := quay.io/weaveworks/cortex-
 IMAGE_TAG := $(shell ./tools/image-tag)
 UPTODATE := .uptodate
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   override:
     - |
         cd build-image && \
-        ../tools/rebuild-image ${IMAGE_PREFIX}build-image . build.sh Dockerfile && \
+        ../tools/rebuild-image quay.io/weaveworks/cortex-build-image . build.sh Dockerfile && \
         touch .uptodate
 
 test:
@@ -25,5 +25,5 @@ deployment:
     branch: master
     commands:
       - docker login -e "$DOCKER_REGISTRY_EMAIL" -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
-      - if [ -n "$QUAY_PASSWORD" ]; then docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io; fi
-      - ./push-images "$NOQUAY"
+      - docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io
+      - ./push-images

--- a/push-images
+++ b/push-images
@@ -4,43 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+QUAY_PREFIX=quay.io/
 IMAGES=$(make images)
 IMAGE_TAG=$(./tools/image-tag)
-QUAY_PREFIX=quay.io/
-NO_QUAY=
-
-usage() {
-    echo "$0 (-noquay)"
-    exit 2
-}
-
-while [ $# -gt 0 ]; do
-    case "$1" in
-        "-noquay")
-            NO_QUAY=true
-            shift 1
-            ;;
-        *)
-            usage
-            exit 2
-            ;;
-    esac
-done
 
 push_image() {
     local image="$1"
-    echo "Pushing ${image}:${IMAGE_TAG}"
     docker push ${image}:${IMAGE_TAG}
-
-    if [ -n "${NO_QUAY}" ]; then
-        return
-    fi
 
     # remove the quey prefix and push to docker hub
     docker_hub_image=${image#$QUAY_PREFIX}
     docker tag ${image}:${IMAGE_TAG} ${docker_hub_image}:${IMAGE_TAG}
-
-    echo "Pushing ${docker_hub_image}:${IMAGE_TAG}"
     docker push ${docker_hub_image}:${IMAGE_TAG}
 }
 


### PR DESCRIPTION
Reverts weaveworks/cortex#491

After adding `IMAGE_PREFIX=quay.io/weaveworks/cortex-` to the build environment variables, got the following error:

```
./push-images "$NOQUAY"
./push-images (-noquay)

./push-images "$NOQUAY" returned exit code 2

Action failed: ./push-images "$NOQUAY"
```

Reverting for now. Will try to look into this later today / this week.