### PR TITLE
Add dynamoQueryPagesCount metric

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -273,6 +273,9 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 	request := a.queryRequestFn(ctx, input)
 	backoff := minBackoff
 	pageCount := 0
+	defer func() {
+		dynamoQueryPagesCount.Observe(float64(pageCount))
+	}()
 	for page := request; page != nil; page = page.NextPage() {
 		pageCount++
 		err := instrument.TimeRequestHistogram(ctx, "DynamoDB.QueryPages", dynamoRequestDuration, func(_ context.Context) error {
@@ -306,7 +309,6 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 
 		backoff = minBackoff
 	}
-	dynamoQueryPagesCount.Observe(float64(pageCount))
 
 	return nil
 }

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -74,6 +74,9 @@ var (
 		Namespace: "cortex",
 		Name:      "dynamo_query_pages_count",
 		Help:      "Number of pages per query.",
+		// Most queries will have one page, however this may increase with fuzzy
+		// metric names.
+		Buckets: prometheus.ExponentialBuckets(1, 4, 6),
 	})
 	s3RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",


### PR DESCRIPTION
Metric for the number of pages we see per query inside QueryPages.

Test plan: `rate(cortex_dynamo_query_pages_count_sum[1m]) / rate(cortex_dynamo_query_pages_count_count[1m])` locally shows average page size of 1 which is expected.