### PR TITLE
Move logging of valid http errors from Error to Debug

### DIFF
--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -34,10 +34,11 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := d.Push(r.Context(), &req); err != nil {
-		logger.Errorf("Push error: %v", err)
 		if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+			logger.Debugf("Push error: %v", err)
 			http.Error(w, string(httpResp.Body), int(httpResp.Code))
 		} else {
+			logger.Errorf("Push error: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return


### PR DESCRIPTION
If the ingester has returned a properly-formed error then it will have logged what happened; the distributor only needs to log if something went wrong in talking to the ingester.