### PR TITLE
Check numRetries for getDynamoDBChunks

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -532,6 +532,10 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 		backoff = minBackoff
 		numRetries = 0
 	}
+
+	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
+		return nil, fmt.Errorf("failed to query chunks after %d retries, %d values remaining", numRetries, valuesLeft)
+	}
 	return result, nil
 }
 

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -477,7 +477,7 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 	result := []Chunk{}
 	unprocessed := dynamoDBReadRequest{}
 	backoff, numRetries := minBackoff, 0
-	for outstanding.Len()+unprocessed.Len() > 0 {
+	for outstanding.Len()+unprocessed.Len() > 0 && numRetries < maxRetries {
 		requests := dynamoDBReadRequest{}
 		requests.TakeReqs(unprocessed, dynamoDBMaxReadBatchSize)
 		requests.TakeReqs(outstanding, dynamoDBMaxReadBatchSize)


### PR DESCRIPTION
Fixes part of #516.

`numRetries` was not checked against `maxRetries` which meant it was possible for requests to backoff indefinitely.