### PR TITLE
Fix TestLazySeriesIterator_RangeValues intermittent test failure

### DIFF
--- a/pkg/chunk/iterator_test.go
+++ b/pkg/chunk/iterator_test.go
@@ -3,6 +3,7 @@ package chunk
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/metric"
@@ -106,7 +107,7 @@ func TestLazySeriesIterator_RangeValues(t *testing.T) {
 		}{
 			{
 				iterator:        iterator,
-				interval:        metric.Interval{OldestInclusive: now, NewestInclusive: now},
+				interval:        metric.Interval{OldestInclusive: now.Add(-time.Minute), NewestInclusive: now.Add(time.Minute)},
 				expectedSamples: dummySamples,
 			},
 		} {


### PR DESCRIPTION
Fixes #505.

`dummyChunks` creates a sample at `model.Now()` however the test case creates a query with range `model.Now()`-`model.Now()` which is evaluated afterwards. In most cases, the local machine is fast enough for `model.Now()` to be the same which was enough for the mistake not to be caught during development.