### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Cortex is a [Weaveworks](https://weave.works) project that forms the monitoring backend of [Weave Cloud](https://cloud.weave.works).
 
-It provides horizontally scalable, long term storage for [Prometheus](https://prometheus.io) metrics when used as a [remote write](https://prometheus.io/docs/operating/configuration/#remote_write) destination.
+It provides horizontally scalable, long term storage for [Prometheus](https://prometheus.io) metrics when used as a [remote write](https://prometheus.io/docs/operating/configuration/#remote_write) destination, and a horizontally scalable, Prometheus-compatible query API.
 
 If you would like to use Cortex, we recommend signing up for [Weave Cloud](https://cloud.weave.works) and following the instructions there.
 
@@ -47,7 +47,7 @@ To update dependencies, run
 
 ## Further reading
 
-To learn more about Cortex, consult the follow documents / talks:
+To learn more about Cortex, consult the following documents / talks:
 
 - [Original design document for Project Frankenstein](http://goo.gl/prdUYV)
 - PromCon 2016 Talk: "Project Frankenstein: Multitenant, Scale-Out Prometheus": [video](https://youtu.be/3Tb4Wc0kfCM), [slides](http://www.slideshare.net/weaveworks/project-frankenstein-a-multitenant-horizontally-scalable-prometheus-as-a-service)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ To learn more about Cortex, consult the following documents / talks:
 
 If you have any questions regarding Cortex, or on using Prometheus with Weave Cloud:
 
-- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> Slack channel
+
+- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> Slack channel. To invite yourself to the Weave Community Slack channel, visit https://weaveworks.github.io/community-slack/.
 - Join the <a href="https://www.meetup.com/pro/Weave/"> Weave User Group </a> and get invited to online talks, hands-on training and meetups in your area.
 - Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
 - <a href="https://github.com/weaveworks/cortex/issues/new">File an issue.</a>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ Cortex is a [Weaveworks](https://weave.works) project that forms the monitoring 
 
 It provides horizontally scalable, long term storage for [Prometheus](https://prometheus.io) metrics when used as a [remote write](https://prometheus.io/docs/operating/configuration/#remote_write) destination, and a horizontally scalable, Prometheus-compatible query API.
 
-If you would like to use Cortex, we recommend signing up for [Weave Cloud](https://cloud.weave.works) and following the instructions there.
+To use Cortex, sign up for [Weave Cloud](https://cloud.weave.works) and follow the instructions there.
+
+Additional help can also be found in the [Weave Cloud documentation](https://www.weave.works/docs/cloud/latest/overview/):
+
+* [Installing the Weave Cloud Agents](https://www.weave.works/docs/cloud/latest/install/installing-agents/#weave-cloud-supported)
+* [Prometheus Monitoring in Weave Cloud](https://www.weave.works/docs/cloud/latest/concepts/prometheus-monitoring/)
+* [Instrumenting Your App: Best Practises](https://www.weave.works/docs/cloud/latest/concepts/prometheus-monitoring/)
 
 ## Developing
 
@@ -57,7 +63,7 @@ To learn more about Cortex, consult the following documents / talks:
 
 If you have any questions regarding Cortex, or on using Prometheus with Weave Cloud:
 
-- Join us on [our Slack channel](https://slack.weave.works) and ask us directly!
+- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> Slack channel
 - Join the <a href="https://www.meetup.com/pro/Weave/"> Weave User Group </a> and get invited to online talks, hands-on training and meetups in your area.
 - Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
 - <a href="https://github.com/weaveworks/cortex/issues/new">File an issue.</a>

--- a/README.md
+++ b/README.md
@@ -5,69 +5,11 @@
 [![Circle CI](https://circleci.com/gh/weaveworks/cortex/tree/master.svg?style=shield)](https://circleci.com/gh/weaveworks/cortex/tree/master)
 [![Slack Status](https://slack.weave.works/badge.svg)](https://slack.weave.works)
 
-*NB this is a pre-beta service. Availability is not 100%. APIs might change. Data could be lost.*
-
-Cortex is an API compatible [Prometheus](https://prometheus.io) implementation, that natively supports multitenancy and horizontal scale-out clustering.
-
 Cortex is a [Weaveworks](https://weave.works) project that forms the monitoring backend of [Weave Cloud](https://cloud.weave.works).
 
+It provides horizontally scalable, long term storage for [Prometheus](https://prometheus.io) metrics when used as a [remote write](https://prometheus.io/docs/operating/configuration/#remote_write) destination.
 
-## Getting Started with Weave Cloud & Kubernetes
-
-Go to https://cloud.weave.works and sign up. Follow the steps to create a new instance.
-
-Once you have created your instance, note down the 'Service Token' listed underneath 'Probes' in the box on the right of the screen. You will use this token to authenticate your local Prometheus with Weave Cloud.
-
-<p align="center"><img src="imgs/weave-cloud-token.png" alt="Weave Cloud Token"></p>
-
-Install the Cortex agent (an unmodified OSS Prometheus) on your Kubernetes cluster using the following command:
-
-    $ kubectl apply -n kube-system -f "https://cloud.weave.works/k8s/cortex.yaml?service-token=<token>&k8s-version=$(kubectl version | base64 | tr -d '\n')"
-
-Click Monitor to access the Cortex service in the Weave Cloud UI:
-
-<p align="center"><img src="imgs/monitor-cortex.png" alt="Prometheus Monitoring with Weave Cortex"></p>
-
-Weave Cloud gives you some example queries that displays general system information.  You can of course [write your own Prometheus queries](https://prometheus.io/docs/querying/basics/).
-
-
-## About Weave Cortex
-
-To learn more about Weave Cortex, consult the follow documents / talks:
-
-- [Original design document for Project Frankenstein](http://goo.gl/prdUYV)
-- PromCon 2016 Talk: "Project Frankenstein: Multitenant, Scale-Out Prometheus": [video](https://youtu.be/3Tb4Wc0kfCM), [slides](http://www.slideshare.net/weaveworks/project-frankenstein-a-multitenant-horizontally-scalable-prometheus-as-a-service)
-- KubeCon Prometheus Day talk "Weave Cortex: Multi-tenant, horizontally scalable Prometheus as a Service" [slides](http://www.slideshare.net/weaveworks/weave-cortex-multitenant-horizontally-scalable-prometheus-as-a-service)
-- Or join us on [our Slack channel](https://slack.weave.works) and ask us directly!
-
-## Using Cortex on Other Platforms
-
-Cortex can be used to monitor virtually any application on any platform, as the local agent is a specially configured unmodified OSS Prometheus binary.  You can [download Prometheus from its website](https://prometheus.io/download/).  You will need v1.2.1 or later.
-
-When you've got Prometheus, you will need to [configure it to discover your services](https://prometheus.io/docs/operating/configuration/) and configure it to send its data to Weave Cloud by adding the following top-level stanza to `prometheus.yml`:
-
-    remote_write:
-    - url: https://cloud.weave.works/api/prom/push
-      basic_auth:
-        password: <token>
-
-Where `<token>` is the Service Token you obtained from Weave Cloud.
-
-Once your local Prometheus is running you can enter Prometheus queries into
-Weave Cloud. Go to https://cloud.weave.works and click Monitor from Weave Cloud header:
-
-<p align="center"><img src="imgs/monitor-cortex.png" alt="Prometheus Monitoring with Weave Cortex"></p>
-
-## Using Cortex to power Grafana dashboards
-
-To use the Prometheus Service with Grafana, configure your Grafana instance to have a datasource with the following parameters:
-
-- Type: Prometheus
-- Url: https://cloud.weave.works/api/prom
-- Access: Proxy
-- Http Auth: Basic Auth
-- User: `user` (this is ignored, but must be non-empty)
-- Password: <Service Token> (the same one your retrieval agent uses)
+If you would like to use Cortex, we recommend signing up for [Weave Cloud](https://cloud.weave.works) and following the instructions there.
 
 ## Developing
 
@@ -103,12 +45,19 @@ To update dependencies, run
 
     dep ensure --update && dep prune
 
+## Further reading
+
+To learn more about Cortex, consult the follow documents / talks:
+
+- [Original design document for Project Frankenstein](http://goo.gl/prdUYV)
+- PromCon 2016 Talk: "Project Frankenstein: Multitenant, Scale-Out Prometheus": [video](https://youtu.be/3Tb4Wc0kfCM), [slides](http://www.slideshare.net/weaveworks/project-frankenstein-a-multitenant-horizontally-scalable-prometheus-as-a-service)
+- KubeCon Prometheus Day talk "Weave Cortex: Multi-tenant, horizontally scalable Prometheus as a Service" [slides](http://www.slideshare.net/weaveworks/weave-cortex-multitenant-horizontally-scalable-prometheus-as-a-service)
+
 ## <a name="help"></a>Getting Help
 
-If you have any questions regarding Cortex our hosted Prometheus as a service:
+If you have any questions regarding Cortex, or on using Prometheus with Weave Cloud:
 
-- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank"> #weave-community </a> slack channel.
-- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> slack channel.
+- Join us on [our Slack channel](https://slack.weave.works) and ask us directly!
 - Join the <a href="https://www.meetup.com/pro/Weave/"> Weave User Group </a> and get invited to online talks, hands-on training and meetups in your area.
 - Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
 - <a href="https://github.com/weaveworks/cortex/issues/new">File an issue.</a>


### PR DESCRIPTION
Alexis asked us to update the README to

- Remove the availability warning
- Focus on telling people how to build
- Direct people to the Weave Cloud website for more information
- Move language away from replacement Prometheus and toward how it relates to Prometheus community/ecosystem

This PR makes those changes. 

Anita, I welcome feedback from you, especially wrt how this relates to the rest of our documentation architecture.

Aaron, I'm particularly keen to make sure that this ties in with the onboarding work you're doing. i.e. that people who come to this GitHub page, think "I want to use Cortex with Weave Cloud", and follow the cloud.weave.works link will be given enough information to actually begin using cortex on Weave Cloud.