### PR TITLE
Rename write throughput autoscale flags

### DIFF
--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -180,7 +180,7 @@ func (cfg *periodicTableConfig) RegisterFlags(argPrefix, tablePrefix string, f *
 	f.Int64Var(&cfg.InactiveReadThroughput, argPrefix+".inactive-read-throughput", 300, "DynamoDB table read throughput for inactive tables.")
 	f.Var(&cfg.From, argPrefix+".start", fmt.Sprintf("Deprecated: use '%s.from'.", argPrefix))
 
-	cfg.WriteScale.RegisterFlags(argPrefix+".write-scale", f)
+	cfg.WriteScale.RegisterFlags(argPrefix+".write-throughput.scale", f)
 }
 
 type autoScalingConfig struct {


### PR DESCRIPTION
Rename `write-scale` to `write-throughput-autoscale` to make it clear that it relates to the `write-throughput` flag.

Ok to rename as it is currently not in use (we only merged it a couple of hours ago).