### PR TITLE
Fix table manager autoscaling flag check

### DIFF
--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -28,7 +28,7 @@ func main() {
 	util.RegisterFlags(&serverConfig, &storageConfig, &schemaConfig)
 	flag.Parse()
 
-	if schemaConfig.ChunkTables.WriteScale.Enabled && storageConfig.ApplicationAutoScaling.URL != nil {
+	if schemaConfig.ChunkTables.WriteScale.Enabled && storageConfig.ApplicationAutoScaling.URL == nil {
 		log.Fatal("WriteScale is enabled but no ApplicationAutoScaling URL has been provided")
 	}
 


### PR DESCRIPTION
Fix flag check merged in https://github.com/weaveworks/cortex/pull/507.

Should raise an error if autoscaling is enabled and the application auto scaling url **is** nil.