### PR TITLE
Update dynamo_query_retry_count bucket sizes

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -83,7 +83,7 @@ var (
 		Namespace: "cortex",
 		Name:      "dynamo_query_retry_count",
 		Help:      "Number of retries per DynamoDB operation.",
-		Buckets:   []float64{0, 1, 2, 3, 5, 10, 15, 20},
+		Buckets:   prometheus.LinearBuckets(0, 1, 21),
 	}, []string{"operation"})
 	s3RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "cortex",


### PR DESCRIPTION
Use linear buckets as there are only 20 options. Include 21 so we can see how many hit 20 retries.