### PR TITLE
Include more info when logging capacity

### DIFF
--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -278,11 +278,11 @@ func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDes
 		tableCapacity.WithLabelValues(writeLabel, expected.Name).Set(float64(current.ProvisionedWrite))
 
 		if expected.Equals(current) {
-			log.Infof("  Provisioned throughput: read = %d, write = %d, skipping.", current.ProvisionedRead, current.ProvisionedWrite)
+			log.Infof("  Provisioned throughput on table %s: read = %d, write = %d, skipping.", current.Name, current.ProvisionedRead, current.ProvisionedWrite)
 			continue
 		}
 
-		log.Infof("  Updating provisioned throughput on table %s to read = %d, write = %d", expected.Name, expected.ProvisionedRead, expected.ProvisionedWrite)
+		log.Infof("  Updating provisioned throughput on table %s from read = %d, write = %d to read = %d, write = %d", expected.Name, current.ProvisionedRead, current.ProvisionedWrite, expected.ProvisionedRead, expected.ProvisionedWrite)
 		err = m.client.UpdateTable(ctx, current, expected)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently we get logs like this:

```
time="2017-08-25T08:47:26Z" level=info msg="Checking provisioned throughput on table prod_chunk_data_weekly_2482" source="table_manager.go:266" 
time="2017-08-25T08:47:28Z" level=info msg="  Provisioned throughput: read = 300, write = 1, skipping." source="table_manager.go:281" 
```

which is not too useful when you are grepping for a particular table

And the update was a little on the enigmatic side too.