### PR TITLE
Clear error before re-sending request

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -393,6 +393,9 @@ func (a dynamoDBRequestAdapter) Data() interface{} {
 }
 
 func (a dynamoDBRequestAdapter) Send() error {
+	// Clear error in case we are retrying the same operation - if we
+	// don't do this then the same error will come back again immediately
+	a.request.Error = nil
 	return a.request.Send()
 }
 


### PR DESCRIPTION
Looking at [the code](https://github.com/aws/aws-sdk-go/blob/353c163/aws/request/request.go#L452-L480) it is evident that somebody has to clear the value in `r.Error` before calling `Send()`.

This is important in the `pageQuery()` case, where we re-use the same request each time round the loop.  However, inside `pageQuery()` we don't have direct access to `Error`, so it seemed simplest and safer to clear on every `Send()`.

It does not seem particularly clear from the docs, or from the aws sdk itself.  I believe when they do retries it gets cleared [here](https://github.com/aws/aws-sdk-go/blob/353c1631448a44b91547377df96451e3de718490/aws/corehandlers/handlers.go#L229)

I really need to try forcing an error and see what happens, to prove out this theory.