### PR TITLE
Autoscale last N inactive DynamoDB tables

### DIFF
--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -28,7 +28,11 @@ func main() {
 	util.RegisterFlags(&serverConfig, &storageConfig, &schemaConfig)
 	flag.Parse()
 
-	if schemaConfig.ChunkTables.WriteScale.Enabled && storageConfig.ApplicationAutoScaling.URL == nil {
+	if (schemaConfig.ChunkTables.WriteScale.Enabled ||
+		schemaConfig.IndexTables.WriteScale.Enabled ||
+		schemaConfig.ChunkTables.InactiveWriteScale.Enabled ||
+		schemaConfig.IndexTables.InactiveWriteScale.Enabled) &&
+		storageConfig.ApplicationAutoScaling.URL == nil {
 		log.Fatal("WriteScale is enabled but no ApplicationAutoScaling URL has been provided")
 	}
 


### PR DESCRIPTION
Small change to allow us to enable write autoscaling for the last N inactive tables. This is to clear any old metrics, resolving https://github.com/weaveworks/cortex/issues/518 for now.