### PR TITLE
Minor preparatory updates

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,12 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "gazelle")
 
 go_prefix("github.com/weaveworks/cortex")
+gazelle(
+    name = "gazelle",
+    args = [
+        "-build_file_name",
+        "BUILD.bazel",
+    ],
+    external = "vendored",
+    prefix = "github.com/weaveworks/cortex",
+)

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,7 @@ clean:
 # and https://github.com/bazelbuild/rules_go/issues/423.  If you ever regenerate
 # the BUILD files, watch out for the rules in vendor/golang.org/x/crypto/curve25519
 update-gazelle: $(PROTOS_GO)
-	gazelle -go_prefix github.com/weaveworks/cortex -external vendored \
-		-build_file_name BUILD.bazel
+	bazel run //:gazelle
 
 update-vendor:
 	dep ensure && dep prune

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,13 @@
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.5.4",
+    url = "https://codeload.github.com/bazelbuild/rules_go/zip/bd13f2d59c804acae7ca8c18fdeb4bf0ecfa1e93",
+    strip_prefix = "rules_go-bd13f2d59c804acae7ca8c18fdeb4bf0ecfa1e93",
+    sha256 = "c69276b005648bfd6f9961f943b14742b221958cc88ff71ffda30e2605e3b599",
+    type = "zip",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
-go_repositories()
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
+proto_register_toolchains()


### PR DESCRIPTION
Add gazelle rule and use them from makefile
Update rules_go to a much newer version needed for photo rules, and use an http archive rule with a commit id instead of a git rule with a tag.