### PR TITLE
Slow down Consul operations in 'lite' mode

### DIFF
--- a/pkg/ring/consul_client_mock.go
+++ b/pkg/ring/consul_client_mock.go
@@ -23,8 +23,9 @@ func NewInMemoryKVClient() KVClient {
 	m.cond = sync.NewCond(&m.mtx)
 	go m.loop()
 	return &consulClient{
-		kv:    &m,
-		codec: ProtoCodec{Factory: ProtoDescFactory},
+		kv:               &m,
+		codec:            ProtoCodec{Factory: ProtoDescFactory},
+		longPollDuration: time.Minute,
 	}
 }
 


### PR DESCRIPTION
To reduce log spam, allow `longPollDuration` to be configured per-client, and set it to a minute when the 'mock consul' is in operation (e.g. in `lite`).