### PR TITLE
Extract awsConfigFromURL function to weaveworks/common

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -535,8 +535,8 @@
 [[projects]]
   branch = "master"
   name = "github.com/weaveworks/common"
-  packages = ["errors","httpgrpc","httpgrpc/server","instrument","logging","mflag","mflagext","middleware","mtime","server","signals","test","user"]
-  revision = "9d0d55ac26906ec5438e1db8837c78cad26c2428"
+  packages = ["aws","errors","httpgrpc","httpgrpc/server","instrument","logging","mflag","mflagext","middleware","mtime","server","signals","test","user"]
+  revision = "b811bc96d43d51edbae6693e7d1b0a367114595b"
 
 [[projects]]
   name = "github.com/weaveworks/mesh"
@@ -636,6 +636,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8be12a636608cb17b57d70dba3863bc0a42c6845db85421306b96a356539f059"
+  inputs-digest = "66364b9ca354031a147a4cc7f92dcb00ff3a323a95ae1a6459714fddc65d7f39"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
@@ -707,85 +705,5 @@ func TestAWSStorageClientQueryPages(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.want, have)
 		})
-	}
-}
-
-func TestAWSConfigFromURL(t *testing.T) {
-	for _, tc := range []struct {
-		url            string
-		expectedKey    string
-		expectedSecret string
-		expectedRegion string
-		expectedEp     string
-
-		expectedNotSpecifiedUserErr bool
-	}{
-		{
-			"s3://abc:123@s3.default.svc.cluster.local:4569",
-			"abc",
-			"123",
-			"dummy",
-			"http://s3.default.svc.cluster.local:4569",
-			false,
-		},
-		{
-			"dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex",
-			"user",
-			"pass",
-			"dummy",
-			"http://dynamodb.default.svc.cluster.local:8000",
-			false,
-		},
-		{
-			// Not escaped password.
-			"s3://abc:123/@s3.default.svc.cluster.local:4569",
-			"",
-			"",
-			"",
-			"",
-			true,
-		},
-		{
-			// Not escaped username.
-			"s3://abc/:123@s3.default.svc.cluster.local:4569",
-			"",
-			"",
-			"",
-			"",
-			true,
-		},
-		{
-			"s3://keyWithEscapedSlashAtTheEnd%2F:%24%2C%26%2C%2B%2C%27%2C%2F%2C%3A%2C%3B%2C%3D%2C%3F%2C%40@eu-west-2/bucket1",
-			"keyWithEscapedSlashAtTheEnd/",
-			"$,&,+,',/,:,;,=,?,@",
-			"eu-west-2",
-			"",
-			false,
-		},
-	} {
-		parsedURL, err := url.Parse(tc.url)
-		require.NoError(t, err)
-
-		cfg, err := awsConfigFromURL(parsedURL)
-		if tc.expectedNotSpecifiedUserErr {
-			require.Error(t, err)
-			continue
-		}
-		require.NoError(t, err)
-
-		require.NotNil(t, cfg.Credentials)
-		val, err := cfg.Credentials.Get()
-		require.NoError(t, err)
-
-		assert.Equal(t, tc.expectedKey, val.AccessKeyID)
-		assert.Equal(t, tc.expectedSecret, val.SecretAccessKey)
-
-		require.NotNil(t, cfg.Region)
-		assert.Equal(t, tc.expectedRegion, *cfg.Region)
-
-		if tc.expectedEp != "" {
-			require.NotNil(t, cfg.Endpoint)
-			assert.Equal(t, tc.expectedEp, *cfg.Endpoint)
-		}
 	}
 }

--- a/vendor/github.com/weaveworks/common/aws/config.go
+++ b/vendor/github.com/weaveworks/common/aws/config.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// ConfigFromURL returns AWS config from given URL. It expects escaped
+// AWS Access key ID & Secret Access Key to be encoded in the URL. It
+// also expects region specified as a host (letting AWS generate full
+// endpoint) or fully valid endpoint with dummy region assumed (e.g
+// for URLs to emulated services).
+func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
+	if awsURL.User == nil {
+		return nil, fmt.Errorf("must specify escaped Access Key & Secret Access in URL")
+	}
+
+	password, _ := awsURL.User.Password()
+	creds := credentials.NewStaticCredentials(awsURL.User.Username(), password, "")
+	config := aws.NewConfig().
+		WithCredentials(creds).
+		// Use a custom http.Client with the golang defaults but also specifying
+		// MaxIdleConnsPerHost because of a bug in golang https://github.com/golang/go/issues/13801
+		// where MaxIdleConnsPerHost does not work as expected.
+		WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				MaxIdleConnsPerHost:   100,
+				TLSHandshakeTimeout:   3 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		})
+	if strings.Contains(awsURL.Host, ".") {
+		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion("dummy"), nil
+	}
+
+	// Let AWS generate default endpoint based on region passed as a host in URL.
+	return config.WithRegion(awsURL.Host), nil
+}

--- a/vendor/github.com/weaveworks/common/aws/config_test.go
+++ b/vendor/github.com/weaveworks/common/aws/config_test.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSConfigFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		url            string
+		expectedKey    string
+		expectedSecret string
+		expectedRegion string
+		expectedEp     string
+
+		expectedNotSpecifiedUserErr bool
+	}{
+		{
+			"s3://abc:123@s3.default.svc.cluster.local:4569",
+			"abc",
+			"123",
+			"dummy",
+			"http://s3.default.svc.cluster.local:4569",
+			false,
+		},
+		{
+			"dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex",
+			"user",
+			"pass",
+			"dummy",
+			"http://dynamodb.default.svc.cluster.local:8000",
+			false,
+		},
+		{
+			// Not escaped password.
+			"s3://abc:123/@s3.default.svc.cluster.local:4569",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+		{
+			// Not escaped username.
+			"s3://abc/:123@s3.default.svc.cluster.local:4569",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+		{
+			"s3://keyWithEscapedSlashAtTheEnd%2F:%24%2C%26%2C%2B%2C%27%2C%2F%2C%3A%2C%3B%2C%3D%2C%3F%2C%40@eu-west-2/bucket1",
+			"keyWithEscapedSlashAtTheEnd/",
+			"$,&,+,',/,:,;,=,?,@",
+			"eu-west-2",
+			"",
+			false,
+		},
+	} {
+		parsedURL, err := url.Parse(tc.url)
+		require.NoError(t, err)
+
+		cfg, err := ConfigFromURL(parsedURL)
+		if tc.expectedNotSpecifiedUserErr {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.Credentials)
+		val, err := cfg.Credentials.Get()
+		require.NoError(t, err)
+
+		assert.Equal(t, tc.expectedKey, val.AccessKeyID)
+		assert.Equal(t, tc.expectedSecret, val.SecretAccessKey)
+
+		require.NotNil(t, cfg.Region)
+		assert.Equal(t, tc.expectedRegion, *cfg.Region)
+
+		if tc.expectedEp != "" {
+			require.NotNil(t, cfg.Endpoint)
+			assert.Equal(t, tc.expectedEp, *cfg.Endpoint)
+		}
+	}
+}

--- a/vendor/github.com/weaveworks/common/user/id.go
+++ b/vendor/github.com/weaveworks/common/user/id.go
@@ -35,8 +35,8 @@ func ExtractOrgID(ctx context.Context) (string, error) {
 }
 
 // InjectOrgID returns a derived context containing the org ID.
-func InjectOrgID(ctx context.Context, userID string) context.Context {
-	return context.WithValue(ctx, interface{}(orgIDContextKey), userID)
+func InjectOrgID(ctx context.Context, orgID string) context.Context {
+	return context.WithValue(ctx, interface{}(orgIDContextKey), orgID)
 }
 
 // ExtractUserID gets the user ID from the context.

--- a/vendor/github.com/weaveworks/common/user/logging.go
+++ b/vendor/github.com/weaveworks/common/user/logging.go
@@ -10,11 +10,11 @@ import (
 func LogFields(ctx context.Context) log.Fields {
 	fields := log.Fields{}
 	userID, err := ExtractUserID(ctx)
-	if err != nil {
+	if err == nil {
 		fields["userID"] = userID
 	}
 	orgID, err := ExtractOrgID(ctx)
-	if err != nil {
+	if err == nil {
 		fields["orgID"] = orgID
 	}
 	return fields


### PR DESCRIPTION
The code for `awsConfigFromURL()` moves verbatim with the exception of the `.WithMaxRetries(0)`

This update to `weaveworks/common` picks up a couple of logging fixes too.
