### PR TITLE
Generate .pb.go files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ workspace(name = "com_github_weaveworks_cortex")
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://codeload.github.com/bazelbuild/rules_go/zip/0fb90c43c5fab2a0b2d7a8684f26f6995d9aa212",
-    strip_prefix = "rules_go-0fb90c43c5fab2a0b2d7a8684f26f6995d9aa212",
+    url = "https://codeload.github.com/bazelbuild/rules_go/zip/5a08d3fc11190fede27b55bded93bda152abae68",
+    strip_prefix = "rules_go-5a08d3fc11190fede27b55bded93bda152abae68",
     type = "zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,10 +9,8 @@ http_archive(
 
 load("//tools/build/bazel:gogo.bzl", "gogo_dependencies")
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
 
 gogo_dependencies()
 go_rules_dependencies()
 
 go_register_toolchains()
-proto_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,18 @@
+workspace(name = "com_github_weaveworks_cortex")
+
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://codeload.github.com/bazelbuild/rules_go/zip/bd13f2d59c804acae7ca8c18fdeb4bf0ecfa1e93",
-    strip_prefix = "rules_go-bd13f2d59c804acae7ca8c18fdeb4bf0ecfa1e93",
-    sha256 = "c69276b005648bfd6f9961f943b14742b221958cc88ff71ffda30e2605e3b599",
+    url = "https://codeload.github.com/bazelbuild/rules_go/zip/0fb90c43c5fab2a0b2d7a8684f26f6995d9aa212",
+    strip_prefix = "rules_go-0fb90c43c5fab2a0b2d7a8684f26f6995d9aa212",
     type = "zip",
 )
 
+load("//tools/build/bazel:gogo.bzl", "gogo_dependencies")
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+
+gogo_dependencies()
 go_rules_dependencies()
+
 go_register_toolchains()
 proto_register_toolchains()

--- a/pkg/ingester/client/BUILD.bazel
+++ b/pkg/ingester/client/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "cortex_proto",
@@ -8,13 +8,13 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-go_grpc_library(
+go_proto_library(
     name = "cortex_go_proto",
     proto = ":cortex_proto",
     importpath = "github.com/weaveworks/cortex/pkg/ingester/client",
+    compiler = "//tools/build/bazel:gogo_grpc",
     deps = [
         "//pkg/util/wire:go_default_library",
-        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
     ],
     visibility = ["//visibility:public"],
 )

--- a/pkg/ingester/client/BUILD.bazel
+++ b/pkg/ingester/client/BUILD.bazel
@@ -1,12 +1,31 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+
+proto_library(
+    name = "cortex_proto",
+    srcs = ["cortex.proto"],
+    deps = ["@internal_gogo_proto_repository//github.com/gogo/protobuf/gogoproto"],
+    visibility = ["//visibility:public"],
+)
+
+go_grpc_library(
+    name = "cortex_go_proto",
+    proto = ":cortex_proto",
+    importpath = "github.com/weaveworks/cortex/pkg/ingester/client",
+    deps = [
+        "//pkg/util/wire:go_default_library",
+        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
+    ],
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",
     srcs = [
         "client.go",
-        "cortex.pb.go",
         "dep.go",
     ],
+    embed = [":cortex_go_proto"],
     importpath = "github.com/weaveworks/cortex/pkg/ingester/client",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package cortex;
 
-option go_package = "client";
+option go_package = "github.com/weaveworks/cortex/pkg/ingester/client";
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 

--- a/pkg/ring/BUILD.bazel
+++ b/pkg/ring/BUILD.bazel
@@ -1,5 +1,20 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "ring_proto",
+    srcs = ["ring.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "ring_go_proto",
+    proto = ":ring_proto",
+    importpath = "github.com/weaveworks/cortex/pkg/ring",
+    visibility = ["//visibility:public"],
+)
+
 go_library(
     name = "go_default_library",
     srcs = [
@@ -8,9 +23,9 @@ go_library(
         "http.go",
         "model.go",
         "ring.go",
-        "ring.pb.go",
         "util.go",
     ],
+    embed = [":ring_go_proto"],
     importpath = "github.com/weaveworks/cortex/pkg/ring",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/ring/BUILD.bazel
+++ b/pkg/ring/BUILD.bazel
@@ -12,6 +12,7 @@ go_proto_library(
     name = "ring_go_proto",
     proto = ":ring_proto",
     importpath = "github.com/weaveworks/cortex/pkg/ring",
+    compiler = "//tools/build/bazel:gogo_proto",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/ring/ring.proto
+++ b/pkg/ring/ring.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package ring;
 
+option go_package = "github.com/weaveworks/cortex/pkg/ring";
+
 message Desc {
 	map<string,IngesterDesc> ingesters = 1;
 	repeated TokenDesc tokens = 2;

--- a/tools/build/bazel/BUILD.bazel
+++ b/tools/build/bazel/BUILD.bazel
@@ -1,7 +1,7 @@
-load('@io_bazel_rules_go//proto:toolchain.bzl', 'go_proto_toolchain')
+load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 
-go_proto_toolchain(
-    name = "gogo_impl",
+go_proto_compiler(
+    name = "gogo_proto",
     deps = [
         "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
@@ -11,16 +11,8 @@ go_proto_toolchain(
     visibility = ["//visibility:public"],
 )
 
-toolchain(
-    name = "gogo",
-    toolchain_type = "@io_bazel_rules_go//proto:go_proto",
-    exec_compatible_with = [],
-    target_compatible_with = [],
-    toolchain = "//tools/build/bazel:gogo_impl",
-)
-
-go_proto_toolchain(
-    name = "gogo_grpc_impl",
+go_proto_compiler(
+    name = "gogo_grpc",
     deps = [
         "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
@@ -31,12 +23,4 @@ go_proto_toolchain(
     plugin = "@com_github_gogo_protobuf//protoc-gen-gogoslick",
     options = ["plugins=grpc"],
     visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "gogo_grpc",
-    toolchain_type = "@io_bazel_rules_go//proto:go_grpc",
-    exec_compatible_with = [],
-    target_compatible_with = [],
-    toolchain = "//tools/build/bazel:gogo_grpc_impl",
 )

--- a/tools/build/bazel/BUILD.bazel
+++ b/tools/build/bazel/BUILD.bazel
@@ -1,0 +1,42 @@
+load('@io_bazel_rules_go//proto:toolchain.bzl', 'go_proto_toolchain')
+
+go_proto_toolchain(
+    name = "gogo_impl",
+    deps = [
+        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
+    ],
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gogoslick",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "gogo",
+    toolchain_type = "@io_bazel_rules_go//proto:go_proto",
+    exec_compatible_with = [],
+    target_compatible_with = [],
+    toolchain = "//tools/build/bazel:gogo_impl",
+)
+
+go_proto_toolchain(
+    name = "gogo_grpc_impl",
+    deps = [
+        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/golang.org/x/net/context:go_default_library",
+    ],
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gogoslick",
+    options = ["plugins=grpc"],
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "gogo_grpc",
+    toolchain_type = "@io_bazel_rules_go//proto:go_grpc",
+    exec_compatible_with = [],
+    target_compatible_with = [],
+    toolchain = "//tools/build/bazel:gogo_grpc_impl",
+)

--- a/tools/build/bazel/gogo.bzl
+++ b/tools/build/bazel/gogo.bzl
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+
+
+_BUILD_FILE = """
+proto_library(
+    name = "gogoproto",
+    srcs = ["gogo.proto"],
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _go_repository_impl(ctx):
+  ctx.file("BUILD.bazel", content="")
+  ctx.file("github.com/gogo/protobuf/gogoproto/BUILD.bazel", content=_BUILD_FILE)
+  ctx.template("github.com/gogo/protobuf/gogoproto/gogo.proto", ctx.attr._proto)
+
+_gogo_proto_repository = repository_rule(
+    implementation = _go_repository_impl,
+    attrs = {
+        "_proto": attr.label(default="//vendor/github.com/gogo/protobuf/gogoproto:gogo.proto"),
+    },
+)
+
+def gogo_dependencies():
+  go_repository(
+      name = "com_github_gogo_protobuf",
+      importpath = "github.com/gogo/protobuf",
+      urls = ["https://codeload.github.com/ianthehat/protobuf/zip/2adc21fd136931e0388e278825291678e1d98309"],
+      strip_prefix = "protobuf-2adc21fd136931e0388e278825291678e1d98309",
+      type = "zip",
+  )
+  native.register_toolchains(
+      "@io_bazel_rules_go//proto:proto",
+      "//tools/build/bazel:gogo",
+      "//tools/build/bazel:gogo_grpc",
+  )
+  _gogo_proto_repository(name = "internal_gogo_proto_repository")

--- a/tools/build/bazel/gogo.bzl
+++ b/tools/build/bazel/gogo.bzl
@@ -32,9 +32,4 @@ def gogo_dependencies():
       strip_prefix = "protobuf-2adc21fd136931e0388e278825291678e1d98309",
       type = "zip",
   )
-  native.register_toolchains(
-      "@io_bazel_rules_go//proto:proto",
-      "//tools/build/bazel:gogo",
-      "//tools/build/bazel:gogo_grpc",
-  )
   _gogo_proto_repository(name = "internal_gogo_proto_repository")

--- a/tools/build/bazel/gogo.bzl
+++ b/tools/build/bazel/gogo.bzl
@@ -31,5 +31,6 @@ def gogo_dependencies():
       urls = ["https://codeload.github.com/ianthehat/protobuf/zip/2adc21fd136931e0388e278825291678e1d98309"],
       strip_prefix = "protobuf-2adc21fd136931e0388e278825291678e1d98309",
       type = "zip",
+      build_file_proto_mode="disable",
   )
   _gogo_proto_repository(name = "internal_gogo_proto_repository")


### PR DESCRIPTION
This uses the gogo repository and new proto rules to generate the .pb.go
files on demand.

Note that this has to use my fork of gogo/protobuf (the bazel rules are not in a good enough shape to ask them to accept them yet, just good enough to use the plugins) and my fork of rules go (although the changes are already in a pull request so that won't be for long)