### PR TITLE
Use longer period in test to make troubleshooting easier

### DIFF
--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -490,7 +490,7 @@ func TestAWSStorageClientChunks(t *testing.T) {
 			schemaConfig := SchemaConfig{
 				ChunkTables: periodicTableConfig{
 					From:   util.NewDayValue(model.Now()),
-					Period: 1 * time.Minute,
+					Period: 10 * time.Minute,
 					Prefix: "chunks",
 				},
 			}


### PR DESCRIPTION
The test creates tables for every period from the beginning of the day to now; with a 1 min period that means between 1 and 1440 tables.

Changing to 10 min cuts the number of tables hence number of log lines, etc., and makes finding issues much easier.

I looked for a way to make the overall interval fixed-length, but it seems you can only start from a day-value and you can only sync up to now.