### PR TITLE
Limit number of label names in series

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -33,6 +33,7 @@ const (
 	outOfOrderTimestamp     = "timestamp_out_of_order"
 	duplicateSample         = "multiple_values_for_timestamp"
 	greaterThanMaxSampleAge = "greater_than_max_sample_age"
+	maxLabelNamesPerSeries  = "max_label_names_per_series"
 
 	// DefaultConcurrentFlush is the number of series to flush concurrently
 	DefaultConcurrentFlush = 50
@@ -40,10 +41,13 @@ const (
 	DefaultMaxSeriesPerUser = 5000000
 	// DefaultMaxSeriesPerMetric is the maximum number of series in one metric (of a single user).
 	DefaultMaxSeriesPerMetric = 50000
+
 	// DefaultMaxLengthLabelName is the maximum length a label name can be.
 	DefaultMaxLengthLabelName = 1024
 	// DefaultMaxLengthLabelValue is the maximum length a label value can be.
 	DefaultMaxLengthLabelValue = 2048
+	// DefaultMaxLabelNamesPerSeries is the maximum number of label names in one series.
+	DefaultMaxLabelNamesPerSeries = 64
 )
 
 var (
@@ -81,13 +85,13 @@ type Config struct {
 	ConcurrentFlushes int
 	ChunkEncoding     string
 
-	// Config for rejecting old samples
+	// Config for rejecting old samples.
 	RejectOldSamples       bool
 	RejectOldSamplesMaxAge time.Duration
 
 	validationConfig ValidateConfig
 
-	// For testing, you can override the address and ID of this ingester
+	// For testing, you can override the address and ID of this ingester.
 	ingesterClientFactory func(addr string, cfg client.Config) (client.IngesterClient, error)
 }
 
@@ -104,17 +108,14 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.validationConfig.RegisterFlags(f)
 
 	f.DurationVar(&cfg.SearchPendingFor, "ingester.search-pending-for", 30*time.Second, "Time to spend searching for a pending ingester when shutting down.")
-
 	f.DurationVar(&cfg.FlushCheckPeriod, "ingester.flush-period", 1*time.Minute, "Period with which to attempt to flush chunks.")
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 1*time.Minute, "Timeout for individual flush operations.")
 	f.DurationVar(&cfg.MaxChunkIdle, "ingester.max-chunk-idle", 5*time.Minute, "Maximum chunk idle time before flushing.")
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 12*time.Hour, "Maximum chunk age before flushing.")
 	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", DefaultConcurrentFlush, "Number of concurrent goroutines flushing to dynamodb.")
 	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", "1", "Encoding version to use for chunks.")
-
 	f.BoolVar(&cfg.RejectOldSamples, "ingester.reject-old-samples", false, "Reject old samples.")
 	f.DurationVar(&cfg.RejectOldSamplesMaxAge, "ingester.reject-old-samples.max-age", 14*24*time.Hour, "Maximum accepted sample age before rejecting.")
-
 }
 
 // Ingester deals with "in flight" chunks.  Based on Prometheus 1.x
@@ -324,7 +325,7 @@ func (i *Ingester) append(ctx context.Context, sample *model.Sample) error {
 
 	if err := ValidateSample(sample, &i.cfg.validationConfig); err != nil {
 		level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "error validating sample", "err", err)
-		return nil
+		return err
 	}
 
 	for ln, lv := range sample.Metric {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -46,8 +46,6 @@ const (
 	DefaultMaxLengthLabelName = 1024
 	// DefaultMaxLengthLabelValue is the maximum length a label value can be.
 	DefaultMaxLengthLabelValue = 2048
-	// DefaultMaxLabelNamesPerSeries is the maximum number of label names in one series.
-	DefaultMaxLabelNamesPerSeries = 64
 )
 
 var (

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -44,6 +44,9 @@ func defaultIngesterTestConfig() Config {
 		FlushCheckPeriod:  99999 * time.Hour,
 		MaxChunkIdle:      99999 * time.Hour,
 		ConcurrentFlushes: 1,
+		validationConfig: ValidateConfig{
+			MaxLabelNamesPerSeries: 64,
+		},
 	}
 }
 

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -15,7 +15,7 @@ import (
 var (
 	discardedSamples = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cortex_ingester_out_of_order_samples_total",
+			Name: "cortex_ingester_discarded_samples_total",
 			Help: "The total number of samples that were discarded.",
 		},
 		[]string{discardReasonLabel},

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -16,7 +16,7 @@ var (
 	discardedSamples = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cortex_ingester_out_of_order_samples_total",
-			Help: "The total number of samples that were discarded because their timestamps were at or before the last received sample for a series.",
+			Help: "The total number of samples that were discarded.",
 		},
 		[]string{discardReasonLabel},
 	)

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -17,7 +17,7 @@ const (
 	errLabelValueTooLong = "label value too long: '%s'"
 )
 
-// Config for validation settings and options
+// ValidateConfig for validation settings and options.
 type ValidateConfig struct {
 	// maximum length a label name can be
 	MaxLabelNameLength int

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -31,7 +31,7 @@ type ValidateConfig struct {
 func (cfg *ValidateConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxLabelNameLength, "ingester.validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&cfg.MaxLabelValueLength, "ingester.validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
-	f.IntVar(&cfg.MaxLabelNamesPerSeries, "ingester.max-label-names-per-series", DefaultMaxLabelNamesPerSeries, "Maximum number of label names per series.")
+	f.IntVar(&cfg.MaxLabelNamesPerSeries, "ingester.max-label-names-per-series", 20, "Maximum number of label names per series.")
 }
 
 // ValidateSample returns an err if the sample is invalid

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"flag"
+
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/common/httpgrpc"
 )
@@ -22,13 +23,15 @@ type ValidateConfig struct {
 	MaxLabelNameLength int
 	// maximum length a label value can be. This also is the maximum length of a metric name.
 	MaxLabelValueLength int
+	// maximum number of label/value pairs timeseries.
+	MaxLabelNamesPerSeries int
 }
 
 // RegisterFlags registers a set of command line flags for setting options regarding sample validation at ingestion time.
 func (cfg *ValidateConfig) RegisterFlags(f *flag.FlagSet) {
-
 	f.IntVar(&cfg.MaxLabelNameLength, "ingester.validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&cfg.MaxLabelValueLength, "ingester.validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
+	f.IntVar(&cfg.MaxLabelNamesPerSeries, "ingester.max-label-names-per-series", DefaultMaxLabelNamesPerSeries, "Maximum number of label names per series.")
 }
 
 // ValidateSample returns an err if the sample is invalid
@@ -40,6 +43,12 @@ func ValidateSample(s *model.Sample, config *ValidateConfig) error {
 
 	if !model.IsValidMetricName(metricName) {
 		return httpgrpc.Errorf(http.StatusBadRequest, errInvalidMetricName, metricName)
+	}
+
+	numLabelNames := len(s.Metric)
+	if numLabelNames > config.MaxLabelNamesPerSeries {
+		discardedSamples.WithLabelValues(maxLabelNamesPerSeries).Inc()
+		return httpgrpc.Errorf(http.StatusBadRequest, "sample has %d label names which is greater than the accepted maximum of %d", numLabelNames, config.MaxLabelNamesPerSeries)
 	}
 
 	for k, v := range s.Metric {

--- a/pkg/ingester/validate_test.go
+++ b/pkg/ingester/validate_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-
-	cfg := ValidateConfig{MaxLabelValueLength: 25, MaxLabelNameLength: 25}
+	cfg := ValidateConfig{
+		MaxLabelValueLength:    25,
+		MaxLabelNameLength:     25,
+		MaxLabelNamesPerSeries: 64,
+	}
 	for _, c := range []struct {
 		metric model.Metric
 		err    error


### PR DESCRIPTION
We would like to limit the number of label names in a series.
`metric{l1=v1, l2=v2, ..., lN=vN}`

With the current schema, we create an `IndexEntry` for every label name in a series. A metric with 1000's of label names in one series can lead to a single chunk having 1000's of index entries associated with it.

Is this the right approach to preventing this?

cc @tomwilkie