### PR TITLE
Add Jaeger to querier

### DIFF
--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaveworks/cortex/pkg/distributor"
 	"github.com/weaveworks/cortex/pkg/querier"
 	"github.com/weaveworks/cortex/pkg/ring"
+	"github.com/weaveworks/cortex/pkg/tracing"
 	"github.com/weaveworks/cortex/pkg/util"
 	"github.com/weaveworks/promrus"
 )
@@ -41,6 +42,10 @@ func main() {
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,
 		&chunkStoreConfig, &schemaConfig, &storageConfig, util.LogLevel{})
 	flag.Parse()
+
+	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
+	trace := tracing.New("querier")
+	defer trace.Close()
 
 	log.AddHook(promrus.MustNewPrometheusHook())
 


### PR DESCRIPTION
Similar to #597.  

Note it is inappropriate to route via `nethttp.Middleware` for the httpgrpc routes, since httpgrpc already sets up the opentracing context.  And I didn't need any of the http routes instrumented.