### PR TITLE
Parallel chunk fetching from DynamoDB

### DIFF
--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -479,9 +479,11 @@ func TestAWSStorageClientChunks(t *testing.T) {
 	tests := []struct {
 		name           string
 		provisionedErr int
+		gangSize       int
 	}{
-		{"DynamoDB chunks", 0},
-		{"DynamoDB chunks retry logic", 2},
+		{"DynamoDB chunks", 0, 10},
+		{"DynamoDB chunks with parallel fetch disabled", 0, 0},
+		{"DynamoDB chunks retry logic", 2, 10},
 	}
 
 	for _, tt := range tests {
@@ -505,6 +507,9 @@ func TestAWSStorageClientChunks(t *testing.T) {
 			require.NoError(t, err)
 
 			client := awsStorageClient{
+				cfg: AWSStorageConfig{
+					DynamoDBConfig: DynamoDBConfig{DynamoDBChunkGangSize: tt.gangSize},
+				},
 				DynamoDB:                dynamoDB,
 				schemaCfg:               schemaConfig,
 				queryRequestFn:          dynamoDB.queryRequest,


### PR DESCRIPTION
Run multiple goroutines in parallel to drive DynamoDB harder: group chunk fetches into "gangs" to allow some configuration over how hard we hit DynamoDB

This is a very simple scheme; it could be done much more intelligently but I think it's worth deploying something simple 

Example query shown below, run against dev: although the overall time is only a little shorter this includes one DynamoDB batch fetch that took 3 seconds, similar to what is described at #602.  In the presence of throttling it gets more efficient to run several queries in parallel which may hit different tables or shards.

Query is `sum(rate(container_cpu_usage_seconds_total{image!="",namespace!=""}[5m])) BY (namespace)` start=1510770800 end=1510770830

Trace before:

![image](https://user-images.githubusercontent.com/8125524/32996591-8b3e1246-cd7c-11e7-97d4-9b30088ef03d.png)

and after:

![image](https://user-images.githubusercontent.com/8125524/32996559-26a05768-cd7c-11e7-9e77-0aa56810e7cf.png)
