### PR TITLE
Save chunks to cache if GetChunks returns partial result

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -432,15 +432,13 @@ func (a awsStorageClient) GetChunks(ctx context.Context, chunks []Chunk) ([]Chun
 	var err error
 	s3Chunks, err = a.getS3Chunks(ctx, s3Chunks)
 	if err != nil {
-		return nil, err
+		return s3Chunks, err
 	}
 
 	dynamoDBChunks, err = a.getDynamoDBChunks(ctx, dynamoDBChunks)
-	if err != nil {
-		return nil, err
-	}
 
-	return append(dynamoDBChunks, s3Chunks...), nil
+	// Return any chunks we did receive: a partial result may be useful
+	return append(dynamoDBChunks, s3Chunks...), err
 }
 
 func (a awsStorageClient) getS3Chunks(ctx context.Context, chunks []Chunk) ([]Chunk, error) {
@@ -468,7 +466,8 @@ func (a awsStorageClient) getS3Chunks(ctx context.Context, chunks []Chunk) ([]Ch
 		}
 	}
 	if len(errors) > 0 {
-		return nil, errors[0]
+		// Return any chunks we did receive: a partial result may be useful
+		return result, errors[0]
 	}
 	return result, nil
 }
@@ -575,7 +574,8 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 	}
 
 	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
-		return nil, fmt.Errorf("failed to query chunks after %d retries, %d values remaining", numRetries, valuesLeft)
+		// Return the chunks we did fetch, because partial results may be useful
+		return result, fmt.Errorf("failed to query chunks after %d retries, %d values remaining", numRetries, valuesLeft)
 	}
 	return result, nil
 }


### PR DESCRIPTION
If the chunk store has, say, 1,000 chunks to fetch, it will do them in a loop in batches of 100.  Suppose it gets 900 fetched ok, then the next call hits an error: we should save the 900 to cache.

Reason is the client may be on a retry loop and come straight back with the same request.  So we should cache what we did get, and hence do better next time.

Note we do not retain any chunks obtained by a call which did error; just the ones from earlier successful calls.