### PR TITLE
Unify four backoff implementations

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -196,7 +196,7 @@ func (a awsStorageClient) BatchWrite(ctx context.Context, input WriteBatch) erro
 		dynamoQueryRetryCount.WithLabelValues("BatchWrite").Observe(float64(backoff.NumRetries()))
 	}()
 
-	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.Finished() {
+	for outstanding.Len()+unprocessed.Len() > 0 && backoff.Ongoing() {
 		requests := dynamoDBWriteBatch{}
 		requests.TakeReqs(outstanding, dynamoDBMaxWriteBatchSize)
 		requests.TakeReqs(unprocessed, dynamoDBMaxWriteBatchSize)
@@ -325,7 +325,7 @@ func (a awsStorageClient) queryPage(ctx context.Context, input *dynamodb.QueryIn
 	}()
 
 	var err error
-	for !backoff.Finished() {
+	for backoff.Ongoing() {
 		err = instrument.TimeRequestHistogram(ctx, "DynamoDB.QueryPages", dynamoRequestDuration, func(_ context.Context) error {
 			return page.Send()
 		})
@@ -562,7 +562,7 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 		dynamoQueryRetryCount.WithLabelValues("getDynamoDBChunks").Observe(float64(backoff.NumRetries()))
 	}()
 
-	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.Finished() {
+	for outstanding.Len()+unprocessed.Len() > 0 && backoff.Ongoing() {
 		requests := dynamoDBReadRequest{}
 		requests.TakeReqs(outstanding, dynamoDBMaxReadBatchSize)
 		requests.TakeReqs(unprocessed, dynamoDBMaxReadBatchSize)

--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -182,12 +182,12 @@ func (a awsStorageClient) BatchWrite(ctx context.Context, input WriteBatch) erro
 	outstanding := input.(dynamoDBWriteBatch)
 	unprocessed := dynamoDBWriteBatch{}
 
-	backoff := resetBackoff()
+	backoff := util.NewBackoff(ctx.Done())
 	defer func() {
-		dynamoQueryRetryCount.WithLabelValues("BatchWrite").Observe(float64(backoff.numRetries))
+		dynamoQueryRetryCount.WithLabelValues("BatchWrite").Observe(float64(backoff.NumRetries()))
 	}()
 
-	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.finished() {
+	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.Finished() {
 		requests := dynamoDBWriteBatch{}
 		requests.TakeReqs(outstanding, dynamoDBMaxWriteBatchSize)
 		requests.TakeReqs(unprocessed, dynamoDBMaxWriteBatchSize)
@@ -216,7 +216,7 @@ func (a awsStorageClient) BatchWrite(ctx context.Context, input WriteBatch) erro
 			// so back off and retry all.
 			if awsErr, ok := err.(awserr.Error); ok && ((awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException) || request.Retryable()) {
 				unprocessed.TakeReqs(requests, -1)
-				backoff.backoff()
+				backoff.Wait()
 				continue
 			}
 
@@ -229,15 +229,15 @@ func (a awsStorageClient) BatchWrite(ctx context.Context, input WriteBatch) erro
 			unprocessed.TakeReqs(unprocessedItems, -1)
 			// I am unclear why we don't count here; perhaps the idea is
 			// that while we are making _some_ progress we should carry on.
-			backoff.backoffWithoutCounting()
+			backoff.WaitWithoutCounting()
 			continue
 		}
 
-		backoff = resetBackoff()
+		backoff.Reset()
 	}
 
 	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
-		return fmt.Errorf("failed to write chunk after %d retries, %d values remaining", backoff.numRetries, valuesLeft)
+		return fmt.Errorf("failed to write chunk after %d retries, %d values remaining", backoff.NumRetries(), valuesLeft)
 	}
 	return nil
 }
@@ -310,13 +310,13 @@ func (a awsStorageClient) QueryPages(ctx context.Context, query IndexQuery, call
 }
 
 func (a awsStorageClient) queryPage(ctx context.Context, input *dynamodb.QueryInput, page dynamoDBRequest) (dynamoDBReadResponse, error) {
-	backoff := resetBackoff()
+	backoff := util.NewBackoff(ctx.Done())
 	defer func() {
-		dynamoQueryRetryCount.WithLabelValues("queryPage").Observe(float64(backoff.numRetries))
+		dynamoQueryRetryCount.WithLabelValues("queryPage").Observe(float64(backoff.NumRetries()))
 	}()
 
 	var err error
-	for !backoff.finished() {
+	for !backoff.Finished() {
 		err = instrument.TimeRequestHistogram(ctx, "DynamoDB.QueryPages", dynamoRequestDuration, func(_ context.Context) error {
 			return page.Send()
 		})
@@ -330,9 +330,9 @@ func (a awsStorageClient) queryPage(ctx context.Context, input *dynamodb.QueryIn
 			recordDynamoError(*input.TableName, err, "DynamoDB.QueryPages")
 			if awsErr, ok := err.(awserr.Error); ok && ((awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException) || page.Retryable()) {
 				if awsErr.Code() != dynamodb.ErrCodeProvisionedThroughputExceededException {
-					level.Warn(util.Logger).Log("msg", "DynamoDB error", "retry", backoff.numRetries, "table", *input.TableName, "err", err)
+					level.Warn(util.Logger).Log("msg", "DynamoDB error", "retry", backoff.NumRetries(), "table", *input.TableName, "err", err)
 				}
-				backoff.backoff()
+				backoff.Wait()
 				continue
 			}
 			return nil, fmt.Errorf("QueryPage error: table=%v, err=%v", *input.TableName, err)
@@ -548,12 +548,12 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 
 	result := []Chunk{}
 	unprocessed := dynamoDBReadRequest{}
-	backoff := resetBackoff()
+	backoff := util.NewBackoff(ctx.Done())
 	defer func() {
-		dynamoQueryRetryCount.WithLabelValues("getDynamoDBChunks").Observe(float64(backoff.numRetries))
+		dynamoQueryRetryCount.WithLabelValues("getDynamoDBChunks").Observe(float64(backoff.NumRetries()))
 	}()
 
-	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.finished() {
+	for outstanding.Len()+unprocessed.Len() > 0 && !backoff.Finished() {
 		requests := dynamoDBReadRequest{}
 		requests.TakeReqs(outstanding, dynamoDBMaxReadBatchSize)
 		requests.TakeReqs(unprocessed, dynamoDBMaxReadBatchSize)
@@ -582,7 +582,7 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 			// so back off and retry all.
 			if awsErr, ok := err.(awserr.Error); ok && ((awsErr.Code() == dynamodb.ErrCodeProvisionedThroughputExceededException) || request.Retryable()) {
 				unprocessed.TakeReqs(requests, -1)
-				backoff.backoff()
+				backoff.Wait()
 				continue
 			}
 
@@ -601,16 +601,16 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 			unprocessed.TakeReqs(unprocessedKeys, -1)
 			// I am unclear why we don't count here; perhaps the idea is
 			// that while we are making _some_ progress we should carry on.
-			backoff.backoffWithoutCounting()
+			backoff.WaitWithoutCounting()
 			continue
 		}
 
-		backoff = resetBackoff()
+		backoff.Reset()
 	}
 
 	if valuesLeft := outstanding.Len() + unprocessed.Len(); valuesLeft > 0 {
 		// Return the chunks we did fetch, because partial results may be useful
-		return result, fmt.Errorf("failed to query chunks after %d retries, %d values remaining", backoff.numRetries, valuesLeft)
+		return result, fmt.Errorf("failed to query chunks after %d retries, %d values remaining", backoff.NumRetries(), valuesLeft)
 	}
 	return result, nil
 }

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -66,7 +66,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 		d.limiter.Wait(ctx)
 	}
 
-	backoff := util.NewBackoff(ctx.Done())
+	backoff := util.NewBackoff(backoffConfig, ctx.Done())
 	for !backoff.Finished() {
 		if err := fn(ctx); err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ThrottlingException" {

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -66,12 +66,12 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 		d.limiter.Wait(ctx)
 	}
 
-	backoff := resetBackoff()
-	for !backoff.finished() {
+	backoff := util.NewBackoff(ctx.Done())
+	for !backoff.Finished() {
 		if err := fn(ctx); err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ThrottlingException" {
-				level.Warn(util.WithContext(ctx, util.Logger)).Log("msg", "got error, backing off and retrying", "err", err, "retry", backoff.numRetries)
-				backoff.backoff()
+				level.Warn(util.WithContext(ctx, util.Logger)).Log("msg", "got error, backing off and retrying", "err", err, "retry", backoff.NumRetries())
+				backoff.Wait()
 				continue
 			} else {
 				return err
@@ -79,7 +79,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 		}
 		return nil
 	}
-	return fmt.Errorf("retried %d times, failing", backoff.numRetries)
+	return fmt.Errorf("retried %d times, failing", backoff.NumRetries())
 }
 
 func (d dynamoTableClient) ListTables(ctx context.Context) ([]string, error) {

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -67,7 +67,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 	}
 
 	backoff := util.NewBackoff(backoffConfig, ctx.Done())
-	for !backoff.Finished() {
+	for backoff.Ongoing() {
 		if err := fn(ctx); err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ThrottlingException" {
 				level.Warn(util.WithContext(ctx, util.Logger)).Log("msg", "got error, backing off and retrying", "err", err, "retry", backoff.NumRetries())

--- a/pkg/ring/consul_client.go
+++ b/pkg/ring/consul_client.go
@@ -190,10 +190,10 @@ func (c *consulClient) CAS(key string, f CASCallback) error {
 	return fmt.Errorf("failed to CAS %s", key)
 }
 
-const (
-	initialBackoff = 1 * time.Second
-	maxBackoff     = 1 * time.Minute
-)
+var backoffConfig = util.BackoffConfig{
+	MinBackoff: 1 * time.Second,
+	MaxBackoff: 1 * time.Minute,
+}
 
 func isClosed(done <-chan struct{}) bool {
 	select {
@@ -212,7 +212,7 @@ func isClosed(done <-chan struct{}) bool {
 // the done channel is closed.
 func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(string, interface{}) bool) {
 	var (
-		backoff = util.NewBackoff(done)
+		backoff = util.NewBackoff(backoffConfig, done)
 		index   = uint64(0)
 	)
 	for {
@@ -259,7 +259,7 @@ func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(s
 // the done channel is closed.
 func (c *consulClient) WatchKey(key string, done <-chan struct{}, f func(interface{}) bool) {
 	var (
-		backoff = util.NewBackoff(done)
+		backoff = util.NewBackoff(backoffConfig, done)
 		index   = uint64(0)
 	)
 	for {

--- a/pkg/ring/consul_client.go
+++ b/pkg/ring/consul_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/snappy"
 	consul "github.com/hashicorp/consul/api"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
+
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -194,33 +195,6 @@ const (
 	maxBackoff     = 1 * time.Minute
 )
 
-type backoff struct {
-	done    <-chan struct{}
-	backoff time.Duration
-}
-
-func newBackoff(done <-chan struct{}) *backoff {
-	return &backoff{
-		done:    done,
-		backoff: initialBackoff,
-	}
-}
-
-func (b *backoff) reset() {
-	b.backoff = initialBackoff
-}
-
-func (b *backoff) wait() {
-	select {
-	case <-b.done:
-	case <-time.After(b.backoff):
-		b.backoff = b.backoff * 2
-		if b.backoff > maxBackoff {
-			b.backoff = maxBackoff
-		}
-	}
-}
-
 func isClosed(done <-chan struct{}) bool {
 	select {
 	case <-done:
@@ -238,7 +212,7 @@ func isClosed(done <-chan struct{}) bool {
 // the done channel is closed.
 func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(string, interface{}) bool) {
 	var (
-		backoff = newBackoff(done)
+		backoff = util.NewBackoff(done)
 		index   = uint64(0)
 	)
 	for {
@@ -252,10 +226,10 @@ func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(s
 		})
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error getting path", "prefix", prefix, "err", err)
-			backoff.wait()
+			backoff.Wait()
 			continue
 		}
-		backoff.reset()
+		backoff.Reset()
 
 		// Skip if the index is the same as last time, because the key value is
 		// guaranteed to be the same as last time
@@ -285,7 +259,7 @@ func (c *consulClient) WatchPrefix(prefix string, done <-chan struct{}, f func(s
 // the done channel is closed.
 func (c *consulClient) WatchKey(key string, done <-chan struct{}, f func(interface{}) bool) {
 	var (
-		backoff = newBackoff(done)
+		backoff = util.NewBackoff(done)
 		index   = uint64(0)
 	)
 	for {
@@ -299,10 +273,10 @@ func (c *consulClient) WatchKey(key string, done <-chan struct{}, f func(interfa
 		})
 		if err != nil || kvp == nil {
 			level.Error(util.Logger).Log("msg", "error getting path", "key", key, "err", err)
-			backoff.wait()
+			backoff.Wait()
 			continue
 		}
-		backoff.reset()
+		backoff.Reset()
 
 		// Skip if the index is the same as last time, because the key value is
 		// guaranteed to be the same as last time

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -33,8 +33,8 @@ func (b *Backoff) Reset() {
 	b.duration = b.cfg.MinBackoff
 }
 
-func (b *Backoff) Finished() bool {
-	return b.cancelled || (b.cfg.MaxRetries > 0 && b.numRetries >= b.cfg.MaxRetries)
+func (b *Backoff) Ongoing() bool {
+	return !b.cancelled && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
 }
 
 func (b *Backoff) NumRetries() int {
@@ -47,7 +47,7 @@ func (b *Backoff) Wait() {
 }
 
 func (b *Backoff) WaitWithoutCounting() {
-	if !b.Finished() {
+	if b.Ongoing() {
 		select {
 		case <-b.done:
 			b.cancelled = true


### PR DESCRIPTION
Fixes #609 

As an added bonus the wait in `aws_storage_client` ends early if the `Context` is cancelled.