### PR TITLE
Break out of backoff loop if Context is terminated

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -333,7 +333,7 @@ func (am *MultitenantAlertmanager) Stop() {
 // Load the full set of configurations from the server, retrying with backoff
 // until we can get them.
 func (am *MultitenantAlertmanager) loadAllConfigs() map[string]configs.View {
-	backoff := util.NewBackoff(backoffConfig, nil)
+	backoff := util.NewBackoff(nil, backoffConfig)
 	for {
 		cfgs, err := am.poll()
 		if err == nil {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -333,7 +333,7 @@ func (am *MultitenantAlertmanager) Stop() {
 // Load the full set of configurations from the server, retrying with backoff
 // until we can get them.
 func (am *MultitenantAlertmanager) loadAllConfigs() map[string]configs.View {
-	backoff := util.NewBackoff(nil, backoffConfig)
+	backoff := util.NewBackoff(context.Background(), backoffConfig)
 	for {
 		cfgs, err := am.poll()
 		if err == nil {

--- a/pkg/chunk/dynamodb_table_client.go
+++ b/pkg/chunk/dynamodb_table_client.go
@@ -66,7 +66,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 		d.limiter.Wait(ctx)
 	}
 
-	backoff := util.NewBackoff(backoffConfig, ctx.Done())
+	backoff := util.NewBackoff(ctx, backoffConfig)
 	for backoff.Ongoing() {
 		if err := fn(ctx); err != nil {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ThrottlingException" {
@@ -79,7 +79,7 @@ func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.
 		}
 		return nil
 	}
-	return fmt.Errorf("retried %d times, failing", backoff.NumRetries())
+	return backoff.Err()
 }
 
 func (d dynamoTableClient) ListTables(ctx context.Context) ([]string, error) {

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -121,7 +121,9 @@ func New(cfg Config) (*Ring, error) {
 			nil, nil,
 		),
 	}
-	go r.loop()
+	var ctx context.Context
+	ctx, r.quit = context.WithCancel(context.Background())
+	go r.loop(ctx)
 	return r, nil
 }
 
@@ -131,9 +133,7 @@ func (r *Ring) Stop() {
 	<-r.done
 }
 
-func (r *Ring) loop() {
-	var ctx context.Context
-	ctx, r.quit = context.WithCancel(context.Background())
+func (r *Ring) loop(ctx context.Context) {
 	defer close(r.done)
 	r.KVClient.WatchKey(ctx, ConsulKey, func(value interface{}) bool {
 		if value == nil {

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -138,7 +138,7 @@ func (s *scheduler) Stop() {
 // Load the full set of configurations from the server, retrying with backoff
 // until we can get them.
 func (s *scheduler) loadAllConfigs() map[string]configs.View {
-	backoff := util.NewBackoff(backoffConfig, nil)
+	backoff := util.NewBackoff(nil, backoffConfig)
 	for {
 		cfgs, err := s.poll()
 		if err == nil {

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -138,7 +138,7 @@ func (s *scheduler) Stop() {
 // Load the full set of configurations from the server, retrying with backoff
 // until we can get them.
 func (s *scheduler) loadAllConfigs() map[string]configs.View {
-	backoff := util.NewBackoff(nil, backoffConfig)
+	backoff := util.NewBackoff(context.Background(), backoffConfig)
 	for {
 		cfgs, err := s.poll()
 		if err == nil {

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"context"
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -15,17 +17,16 @@ type BackoffConfig struct {
 // Backoff implements exponential backoff with randomized wait times
 type Backoff struct {
 	cfg        BackoffConfig
-	done       <-chan struct{}
+	ctx        context.Context
 	numRetries int
-	cancelled  bool
 	duration   time.Duration
 }
 
-// NewBackoff creates a Backoff object. Pass a 'done' channel that can be closed to terminate the operation.
-func NewBackoff(cfg BackoffConfig, done <-chan struct{}) *Backoff {
+// NewBackoff creates a Backoff object. Pass a Context that can also terminate the operation.
+func NewBackoff(ctx context.Context, cfg BackoffConfig) *Backoff {
 	return &Backoff{
 		cfg:      cfg,
-		done:     done,
+		ctx:      ctx,
 		duration: cfg.MinBackoff,
 	}
 }
@@ -33,13 +34,24 @@ func NewBackoff(cfg BackoffConfig, done <-chan struct{}) *Backoff {
 // Reset the Backoff back to its initial condition
 func (b *Backoff) Reset() {
 	b.numRetries = 0
-	b.cancelled = false
 	b.duration = b.cfg.MinBackoff
 }
 
 // Ongoing returns true if caller should keep going
 func (b *Backoff) Ongoing() bool {
-	return !b.cancelled && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
+	// Stop if Context has errored or max retry count is exceeded
+	return (b.ctx == nil || b.ctx.Err() == nil) && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
+}
+
+// Err returns the reason for terminating the backoff, or nil if it didn't terminate
+func (b *Backoff) Err() error {
+	if b.ctx != nil && b.ctx.Err() != nil {
+		return b.ctx.Err()
+	}
+	if b.cfg.MaxRetries != 0 && b.numRetries >= b.cfg.MaxRetries {
+		return fmt.Errorf("terminated after %d retries", b.numRetries)
+	}
+	return nil
 }
 
 // NumRetries returns the number of retries so far
@@ -48,19 +60,18 @@ func (b *Backoff) NumRetries() int {
 }
 
 // Wait sleeps for the backoff time then increases the retry count and backoff time
-// Returns immediately if done channel is closed
+// Returns immediately if Context is terminated
 func (b *Backoff) Wait() {
 	b.numRetries++
 	b.WaitWithoutCounting()
 }
 
 // WaitWithoutCounting sleeps for the backoff time then increases backoff time
-// Returns immediately if done channel is closed
+// Returns immediately if Context is terminated
 func (b *Backoff) WaitWithoutCounting() {
 	if b.Ongoing() {
 		select {
-		case <-b.done:
-			b.cancelled = true
+		case <-b.ctx.Done():
 		case <-time.After(b.duration):
 		}
 	}

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -40,12 +40,12 @@ func (b *Backoff) Reset() {
 // Ongoing returns true if caller should keep going
 func (b *Backoff) Ongoing() bool {
 	// Stop if Context has errored or max retry count is exceeded
-	return (b.ctx == nil || b.ctx.Err() == nil) && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
+	return b.ctx.Err() == nil && (b.cfg.MaxRetries == 0 || b.numRetries < b.cfg.MaxRetries)
 }
 
 // Err returns the reason for terminating the backoff, or nil if it didn't terminate
 func (b *Backoff) Err() error {
-	if b.ctx != nil && b.ctx.Err() != nil {
+	if b.ctx.Err() != nil {
 		return b.ctx.Err()
 	}
 	if b.cfg.MaxRetries != 0 && b.numRetries >= b.cfg.MaxRetries {


### PR DESCRIPTION
Previously we would only stop if the `Context` signalled cancellation while we were in a sleep. Now, loops that check `backoff.Ongoing()` will end if the `Context` is terminated any time.

A new `backoff.Err()` function is added to report back the reason for termination.

This required reworking the Consul client to use a `Context`, but I think it ends up ok.  I took the opportunity to remove an unused function rather than fix it up.