### PR TITLE
Avoid memory allocations when comparing chunk keys

### DIFF
--- a/pkg/chunk/by_key_test.go
+++ b/pkg/chunk/by_key_test.go
@@ -1,9 +1,12 @@
 package chunk
 
 import (
+	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -95,5 +98,36 @@ func TestNWayIntersect(t *testing.T) {
 		if !reflect.DeepEqual(tc.want, have) {
 			assert.Equal(t, tc.want, have)
 		}
+	}
+}
+
+func BenchmarkByKeyLess(b *testing.B) {
+	a := ByKey{dummyChunk(), dummyChunk()}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		a.Less(0, 1)
+	}
+}
+
+func BenchmarkByKeySort100(b *testing.B)   { benchmarkByKeySort(b, 100) }
+func BenchmarkByKeySort1000(b *testing.B)  { benchmarkByKeySort(b, 1000) }
+func BenchmarkByKeySort10000(b *testing.B) { benchmarkByKeySort(b, 10000) }
+
+func benchmarkByKeySort(b *testing.B, batchSize int) {
+	chunks := []Chunk{}
+	for i := 0; i < batchSize; i++ {
+		chunk := dummyChunk()
+		// Tweak the dummy data slightly so the chunks are more likely to be different
+		// this makes the checksum wrong but we don't look at it
+		chunk.From += model.Time(rand.Intn(batchSize))
+		chunks = append(chunks, chunk)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sort.Sort(ByKey(chunks))
 	}
 }

--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -262,7 +262,7 @@ func (c *Chunk) Decode(decodeContext *DecodeContext, input []byte) error {
 	// we don't write the checksum to s3, so we have to copy the checksum in.
 	if c.ChecksumSet {
 		tempMetadata.Checksum, tempMetadata.ChecksumSet = c.Checksum, c.ChecksumSet
-		if c.ExternalKey() != tempMetadata.ExternalKey() {
+		if !equalByKey(*c, tempMetadata) {
 			return errors.WithStack(ErrWrongMetadata)
 		}
 	}

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -239,9 +239,18 @@ func benchmarkDecode(b *testing.B, batchSize int) {
 
 	for i := 0; i < b.N; i++ {
 		decodeContext := NewDecodeContext()
+		b.StopTimer()
 		chunks := make([]Chunk, batchSize)
+		// Copy across the metadata so the check works out ok
 		for j := 0; j < batchSize; j++ {
-			chunks[j].Decode(decodeContext, buf)
+			chunks[j] = chunk
+			chunks[j].Metric = nil
+			chunks[j].Data = nil
+		}
+		b.StartTimer()
+		for j := 0; j < batchSize; j++ {
+			err := chunks[j].Decode(decodeContext, buf)
+			require.NoError(b, err)
 		}
 	}
 }


### PR DESCRIPTION
Part of #624 
Chunks are sorted, merged and uniq-ified by comparing their key metadata.

Previously this went via `Sprintf()` with six memory allocations per call. 
The replacement is a bit long-winded, but very fast in operation.

Benchmarks:
before (commit 2472029f12a604967a5f17f3591d2a8e5adf2ff5)
```
BenchmarkByKeyLess-2        	 2000000	       681 ns/op	     224 B/op	      12 allocs/op
BenchmarkByKeySort100-2     	    5000	    347669 ns/op	  109587 B/op	    5869 allocs/op
BenchmarkByKeySort1000-2    	     200	   6100690 ns/op	 1931639 B/op	  103466 allocs/op
BenchmarkByKeySort10000-2   	      20	  84477998 ns/op	26671429 B/op	 1428771 allocs/op
BenchmarkEncode-2           	   50000	     22729 ns/op	   85125 B/op	      27 allocs/op
BenchmarkDecode1-2          	   30000	     52825 ns/op	  155950 B/op	     128 allocs/op
BenchmarkDecode100-2        	     500	   2619961 ns/op	  980877 B/op	   12537 allocs/op
BenchmarkDecode10000-2      	       5	 261945192 ns/op	83622628 B/op	 1313202 allocs/op
```

after this PR:
```
BenchmarkByKeyLess-2        	100000000	        10.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkByKeySort100-2     	  200000	      7919 ns/op	      32 B/op	       1 allocs/op
BenchmarkByKeySort1000-2    	   10000	    139779 ns/op	      32 B/op	       1 allocs/op
BenchmarkByKeySort10000-2   	    1000	   1841739 ns/op	      36 B/op	       1 allocs/op
BenchmarkEncode-2           	   50000	     22353 ns/op	   85129 B/op	      27 allocs/op
BenchmarkDecode1-2          	   30000	     47255 ns/op	  155691 B/op	     116 allocs/op
BenchmarkDecode100-2        	     500	   2535492 ns/op	  958269 B/op	   11334 allocs/op
BenchmarkDecode10000-2      	       5	 243836715 ns/op	81222563 B/op	 1133177 allocs/op
```
