### PR TITLE
Reuse Snappy decoder, for performance

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -530,7 +530,8 @@ func (a awsStorageClient) getS3Chunk(ctx context.Context, chunk Chunk) (Chunk, e
 	if err != nil {
 		return Chunk{}, err
 	}
-	if err := chunk.Decode(buf); err != nil {
+	decodeContext := NewDecodeContext()
+	if err := chunk.Decode(decodeContext, buf); err != nil {
 		return Chunk{}, err
 	}
 	return chunk, nil
@@ -626,6 +627,7 @@ func (a awsStorageClient) getDynamoDBChunks(ctx context.Context, chunks []Chunk)
 
 func processChunkResponse(response *dynamodb.BatchGetItemOutput, chunksByKey map[string]Chunk) ([]Chunk, error) {
 	result := []Chunk{}
+	decodeContext := NewDecodeContext()
 	for _, items := range response.Responses {
 		for _, item := range items {
 			key, ok := item[hashKey]
@@ -643,7 +645,7 @@ func processChunkResponse(response *dynamodb.BatchGetItemOutput, chunksByKey map
 				return nil, fmt.Errorf("Got response from DynamoDB with no value: %+v", item)
 			}
 
-			if err := chunk.Decode(buf.B); err != nil {
+			if err := chunk.Decode(decodeContext, buf.B); err != nil {
 				return nil, err
 			}
 

--- a/pkg/chunk/chunk_cache.go
+++ b/pkg/chunk/chunk_cache.go
@@ -155,6 +155,7 @@ func (c *Cache) FetchChunkData(ctx context.Context, chunks []Chunk) (found []Chu
 		return nil, chunks, err
 	}
 
+	decodeContext := NewDecodeContext()
 	for i, externalKey := range keys {
 		item, ok := items[externalKey]
 		if !ok {
@@ -162,7 +163,7 @@ func (c *Cache) FetchChunkData(ctx context.Context, chunks []Chunk) (found []Chu
 			continue
 		}
 
-		if err := chunks[i].Decode(item.Value); err != nil {
+		if err := chunks[i].Decode(decodeContext, item.Value); err != nil {
 			memcacheCorrupt.Inc()
 			level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "failed to decode chunk from cache", "err", err)
 			missing = append(missing, chunks[i])

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -191,3 +191,55 @@ func TestChunksToMatrix(t *testing.T) {
 		require.Equal(t, c.expectedMatrix, matrix)
 	}
 }
+
+func benchmarkChunk() Chunk {
+	// This is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
+	return dummyChunkFor(model.Metric{
+		model.MetricNameLabel:              "container_cpu_usage_seconds_total",
+		"beta_kubernetes_io_arch":          "amd64",
+		"beta_kubernetes_io_instance_type": "c3.somesize",
+		"beta_kubernetes_io_os":            "linux",
+		"container_name":                   "some-name",
+		"cpu":                              "cpu01",
+		"failure_domain_beta_kubernetes_io_region": "somewhere-1",
+		"failure_domain_beta_kubernetes_io_zone":   "somewhere-1b",
+		"id":       "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28",
+		"image":    "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506",
+		"instance": "ip-111-11-1-11.ec2.internal",
+		"job":      "kubernetes-cadvisor",
+		"kubernetes_io_hostname": "ip-111-11-1-11",
+		"monitor":                "prod",
+		"name":                   "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
+		"namespace":              "kube-system",
+		"pod_name":               "some-other-name-5j8s8",
+	})
+}
+
+func BenchmarkEncode(b *testing.B) {
+	chunk := dummyChunk()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		chunk.Encode()
+	}
+}
+
+func BenchmarkDecode1(b *testing.B)     { benchmarkDecode(b, 1) }
+func BenchmarkDecode100(b *testing.B)   { benchmarkDecode(b, 100) }
+func BenchmarkDecode10000(b *testing.B) { benchmarkDecode(b, 10000) }
+
+func benchmarkDecode(b *testing.B, batchSize int) {
+	chunk := benchmarkChunk()
+	buf, err := chunk.Encode()
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		chunks := make([]Chunk, batchSize)
+		for j := 0; j < batchSize; j++ {
+			chunks[j].Decode(buf)
+		}
+	}
+}

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -43,6 +43,7 @@ func dummyChunkFor(metric model.Metric) Chunk {
 }
 
 func TestChunkCodec(t *testing.T) {
+	decodeContext := NewDecodeContext()
 	for i, c := range []struct {
 		chunk Chunk
 		err   error
@@ -90,7 +91,7 @@ func TestChunkCodec(t *testing.T) {
 				c.f(&have, buf)
 			}
 
-			err = have.Decode(buf)
+			err = have.Decode(decodeContext, buf)
 			require.Equal(t, c.err, errors.Cause(err))
 
 			if c.err == nil {
@@ -237,9 +238,10 @@ func benchmarkDecode(b *testing.B, batchSize int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		decodeContext := NewDecodeContext()
 		chunks := make([]Chunk, batchSize)
 		for j := 0; j < batchSize; j++ {
-			chunks[j].Decode(buf)
+			chunks[j].Decode(decodeContext, buf)
 		}
 	}
 }

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -222,6 +222,7 @@ func (s *storageClient) GetChunks(ctx context.Context, input []chunk.Chunk) ([]c
 		for i := 0; i < len(keys); i += maxRowReads {
 			page := keys[i:util.Min(i+maxRowReads, len(keys))]
 			go func(page bigtable.RowList) {
+				decodeContext := chunk.NewDecodeContext()
 				// rows are returned in key order, not order in row list
 				if err := table.ReadRows(ctx, page, func(row bigtable.Row) bool {
 					chunk, ok := chunks[row.Key()]
@@ -230,7 +231,7 @@ func (s *storageClient) GetChunks(ctx context.Context, input []chunk.Chunk) ([]c
 						return false
 					}
 
-					err := chunk.Decode(row[columnFamily][0].Value)
+					err := chunk.Decode(decodeContext, row[columnFamily][0].Value)
 					if err != nil {
 						errs <- err
 						return false

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -256,6 +256,7 @@ func (m *MockStorage) GetChunks(ctx context.Context, chunkSet []Chunk) ([]Chunk,
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
+	decodeContext := NewDecodeContext()
 	result := []Chunk{}
 	for _, chunk := range chunkSet {
 		key := chunk.ExternalKey()
@@ -263,7 +264,7 @@ func (m *MockStorage) GetChunks(ctx context.Context, chunkSet []Chunk) ([]Chunk,
 		if !ok {
 			return nil, fmt.Errorf("%v not found", key)
 		}
-		if err := chunk.Decode(buf); err != nil {
+		if err := chunk.Decode(decodeContext, buf); err != nil {
 			return nil, err
 		}
 		result = append(result, chunk)


### PR DESCRIPTION
Part of #624 

Calling `Reset()` rather than discarding and creating a new one allows buffers to be re-used, which reduces garbage-collection.

The benefit comes when you decode more than one chunk in a row - 55%-60% less time in these benchmarks:

before:
```
BenchmarkDecode1-2       	  200000	    102466 ns/op	  155771 B/op	     117 allocs/op
BenchmarkDecode100-2     	    2000	  10742609 ns/op	15577124 B/op	   11632 allocs/op
BenchmarkDecode10000-2   	      20	 829417236 ns/op	1557639768 B/op	 1163165 allocs/op
```

after:
```
BenchmarkDecode1-2       	  200000	    113408 ns/op	  155772 B/op	     117 allocs/op
BenchmarkDecode100-2     	    3000	   4202005 ns/op	  967774 B/op	   11335 allocs/op
BenchmarkDecode10000-2   	      30	 378176958 ns/op	82100856 B/op	 1133154 allocs/op
```