### PR TITLE
Change backoff algorithm to "full jitter"

### DIFF
--- a/pkg/chunk/aws_storage_client.go
+++ b/pkg/chunk/aws_storage_client.go
@@ -47,7 +47,7 @@ const (
 var backoffConfig = util.BackoffConfig{
 	// Backoff for dynamoDB requests, to match AWS lib - see:
 	// https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/customizations.go
-	MinBackoff: 50 * time.Millisecond,
+	MinBackoff: 100 * time.Millisecond,
 	MaxBackoff: 50 * time.Second,
 	MaxRetries: 20,
 }


### PR DESCRIPTION
As described at https://www.awsarchitectureblog.com/2015/03/backoff.html

Fixes #638 

The bump in config is to address the point that we used to sleep 50 ms then random between 50 and 150, so if this was unchanged we would sleep rand(0-50) then rand(0-100) which is quite a bit less.

With this change it will sleep rand(0-100) then rand(0-200).
  
(Although my gut feel is this is still too low)