### PR TITLE
Use existing Fingerprint value instead of recomputing

### DIFF
--- a/pkg/chunk/chunk.go
+++ b/pkg/chunk/chunk.go
@@ -317,13 +317,12 @@ func chunksToMatrix(chunks []Chunk) (model.Matrix, error) {
 	// Group chunks by series, sort and dedupe samples.
 	sampleStreams := map[model.Fingerprint]*model.SampleStream{}
 	for _, c := range chunks {
-		fp := c.Metric.Fingerprint()
-		ss, ok := sampleStreams[fp]
+		ss, ok := sampleStreams[c.Fingerprint]
 		if !ok {
 			ss = &model.SampleStream{
 				Metric: c.Metric,
 			}
-			sampleStreams[fp] = ss
+			sampleStreams[c.Fingerprint] = ss
 		}
 
 		samples, err := c.Samples()


### PR DESCRIPTION
Since every `Chunk` is created with a `Metric` and a `Fingerprint` at the same time, we should use the latter rather than recomputing it.

Impact of this change is fairly small, generally dwarfed by `Samples()` when we use varbit encoding.