### PR TITLE
Restrict to time interval when pulling samples from a chunk

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -183,7 +183,7 @@ func (c *Store) getMetricNameMatrix(ctx context.Context, from, through model.Tim
 	if err != nil {
 		return nil, err
 	}
-	return chunksToMatrix(ctx, chunks)
+	return chunksToMatrix(ctx, chunks, from, through)
 }
 
 func (c *Store) getMetricNameChunks(ctx context.Context, from, through model.Time, allMatchers []*labels.Matcher, metricName string) ([]Chunk, error) {
@@ -301,7 +301,7 @@ outer:
 			}
 		}
 	}
-	return chunksToMatrix(ctx, chunks)
+	return chunksToMatrix(ctx, chunks, from, through)
 }
 
 func (c *Store) lookupChunksByMetricName(ctx context.Context, from, through model.Time, matchers []*labels.Matcher, metricName string) ([]Chunk, error) {

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -35,7 +35,7 @@ func newTestChunkStore(t *testing.T, cfg StoreConfig) *Store {
 }
 
 func createSampleStreamFrom(chunk Chunk) (*model.SampleStream, error) {
-	samples, err := chunk.Samples()
+	samples, err := chunk.Samples(chunk.From, chunk.Through)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func TestChunkStoreRandom(t *testing.T) {
 			for _, chunk := range chunks {
 				assert.False(t, chunk.From.After(endTime))
 				assert.False(t, chunk.Through.Before(startTime))
-				samples, err := chunk.Samples()
+				samples, err := chunk.Samples(chunk.From, chunk.Through)
 				assert.NoError(t, err)
 				assert.Equal(t, 1, len(samples))
 				// TODO verify chunk contents
@@ -496,7 +496,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 		for _, chunk := range chunks {
 			assert.False(t, chunk.From.After(endTime))
 			assert.False(t, chunk.Through.Before(startTime))
-			samples, err := chunk.Samples()
+			samples, err := chunk.Samples(chunk.From, chunk.Through)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(samples))
 		}

--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -140,10 +140,10 @@ func TestChunksToMatrix(t *testing.T) {
 		"toms": "code",
 	}
 	chunk1 := dummyChunkFor(metric)
-	chunk1Samples, err := chunk1.Samples()
+	chunk1Samples, err := chunk1.Samples(chunk1.From, chunk1.Through)
 	require.NoError(t, err)
 	chunk2 := dummyChunkFor(metric)
-	chunk2Samples, err := chunk2.Samples()
+	chunk2Samples, err := chunk2.Samples(chunk2.From, chunk2.Through)
 	require.NoError(t, err)
 
 	ss1 := &model.SampleStream{
@@ -158,7 +158,7 @@ func TestChunksToMatrix(t *testing.T) {
 		"toms": "code",
 	}
 	chunk3 := dummyChunkFor(otherMetric)
-	chunk3Samples, err := chunk3.Samples()
+	chunk3Samples, err := chunk3.Samples(chunk3.From, chunk3.Through)
 	require.NoError(t, err)
 
 	ss2 := &model.SampleStream{
@@ -185,7 +185,7 @@ func TestChunksToMatrix(t *testing.T) {
 			},
 		},
 	} {
-		matrix, err := chunksToMatrix(context.Background(), c.chunks)
+		matrix, err := chunksToMatrix(context.Background(), c.chunks, chunk1.From, chunk3.Through)
 		require.NoError(t, err)
 
 		sort.Sort(matrix)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -97,7 +97,7 @@ func chunksToMatrix(chunks []chunk.Chunk) (model.Matrix, error) {
 			sampleStreams[fp] = ss
 		}
 
-		samples, err := c.Samples()
+		samples, err := c.Samples(c.From, c.Through)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
It's good to discard data we don't need as soon as possible.

This speeds things up when the query time interval does not cover the whole of a chunk.
It will be slightly slower than before when the interval does cover the whole chunk - we could have both variants if that shows up as a problem.

Since `RangeValues()` already does what we need, we save code too.

Part of #624 - if you look closely you will see my sample query covers just 30 seconds; it dates from a time when I was trying to shrink the task to make it easier to see what was happening.  
