### PR TITLE
Increase histogram buckets to cover typical scenarios

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -257,12 +257,12 @@ func New(cfg Config, chunkStore ChunkStore) (*Ingester, error) {
 		chunkLength: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_length",
 			Help:    "Distribution of stored chunk lengths (when stored).",
-			Buckets: prometheus.ExponentialBuckets(10, 2, 8), // biggest bucket is 10*2^(8-1) = 1280
+			Buckets: prometheus.ExponentialBuckets(10, 2, 10), // biggest bucket is 10*2^(10-1) = 5120
 		}),
 		chunkAge: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_chunk_age_seconds",
 			Help:    "Distribution of chunk ages (when stored).",
-			Buckets: prometheus.ExponentialBuckets(60, 2, 10), // biggest bucket is 60*2^(10-1) = 30720 = 8:32 hrs
+			Buckets: prometheus.ExponentialBuckets(60, 2, 11), // biggest bucket is 60*2^(11-1) = 61440 = 17:04 hrs
 		}),
 		memoryChunks: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_chunks",


### PR DESCRIPTION
The default max chunk age is 12 hours, so we really ought to cover that in our buckets.

If the metric repeats (all zeros, say, and with regular timestamps) then we will can easily fit 12 hours in a 1K chunk.  12 hours of 15-second samples is 2880 samples, so I extended the length buckets to cover that.

  