### PR TITLE
Limit parallelism when fetching chunks from DynamoDB

### DIFF
--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -480,10 +480,11 @@ func TestAWSStorageClientChunks(t *testing.T) {
 		name           string
 		provisionedErr int
 		gangSize       int
+		maxParallelism int
 	}{
-		{"DynamoDB chunks", 0, 10},
-		{"DynamoDB chunks with parallel fetch disabled", 0, 0},
-		{"DynamoDB chunks retry logic", 2, 10},
+		{"DynamoDB chunks", 0, 10, 20},
+		{"DynamoDB chunks with parallel fetch disabled", 0, 0, 20},
+		{"DynamoDB chunks retry logic", 2, 10, 20},
 	}
 
 	for _, tt := range tests {
@@ -508,7 +509,7 @@ func TestAWSStorageClientChunks(t *testing.T) {
 
 			client := awsStorageClient{
 				cfg: AWSStorageConfig{
-					DynamoDBConfig: DynamoDBConfig{DynamoDBChunkGangSize: tt.gangSize},
+					DynamoDBConfig: DynamoDBConfig{ChunkGangSize: tt.gangSize, ChunkGetMaxParallelism: tt.maxParallelism},
 				},
 				DynamoDB:                dynamoDB,
 				schemaCfg:               schemaConfig,


### PR DESCRIPTION
I think I went too far in #603 - if someone sends a query that requires 260,000 chunks we don't want to hit DynamoDB from 260 goroutines in parallel.

(Ideally there would be a global pool of workers for each table)