### PR TITLE
Optionally compress gRPC calls from distributor to ingester

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -601,7 +601,7 @@
   branch = "master"
   name = "github.com/weaveworks/common"
   packages = ["aws","errors","httpgrpc","httpgrpc/server","instrument","logging","mflag","mflagext","middleware","mtime","server","signals","test","tracing","user"]
-  revision = "92029dbfb76a2b715629d9f7e68e62574028df22"
+  revision = "d85bab03a1b1327e94db89d64a84dfd1e79f193f"
 
 [[projects]]
   name = "github.com/weaveworks/mesh"
@@ -723,6 +723,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "964891df04ed2e61f4a7b2c31717a5ef815ac247a8e7a05fe811b0fdfb704f73"
+  inputs-digest = "a0dbd4f4bd702793e995197f195de8ec82b3340f351e223eab2d766c0f71c0df"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -76,9 +76,10 @@ type Config struct {
 	ClientCleanupPeriod time.Duration
 	IngestionRateLimit  float64
 	IngestionBurstSize  int
+	CompressPushes      bool
 
 	// for testing
-	ingesterClientFactory func(addr string, timeout time.Duration) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, timeout time.Duration, withCompression bool) (client.IngesterClient, error)
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -91,6 +92,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
 	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
+	flag.BoolVar(&cfg.CompressPushes, "distributor.compress-pushes", false, "Compress sample data pushed to ingesters.")
 }
 
 // New constructs a new Distributor
@@ -222,7 +224,7 @@ func (d *Distributor) getClientFor(ingester *ring.IngesterDesc) (client.Ingester
 		return client, nil
 	}
 
-	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.RemoteTimeout)
+	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.RemoteTimeout, d.cfg.CompressPushes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -76,7 +76,7 @@ type Config struct {
 	ClientCleanupPeriod time.Duration
 	IngestionRateLimit  float64
 	IngestionBurstSize  int
-	CompressPushes      bool
+	CompressToIngester  bool
 
 	// for testing
 	ingesterClientFactory func(addr string, timeout time.Duration, withCompression bool) (client.IngesterClient, error)
@@ -92,7 +92,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
 	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
-	flag.BoolVar(&cfg.CompressPushes, "distributor.compress-pushes", false, "Compress sample data pushed to ingesters.")
+	flag.BoolVar(&cfg.CompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters.")
 }
 
 // New constructs a new Distributor
@@ -224,7 +224,7 @@ func (d *Distributor) getClientFor(ingester *ring.IngesterDesc) (client.Ingester
 		return client, nil
 	}
 
-	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.RemoteTimeout, d.cfg.CompressPushes)
+	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.RemoteTimeout, d.cfg.CompressToIngester)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -165,7 +165,7 @@ func TestDistributorPush(t *testing.T) {
 				IngestionRateLimit:  10000,
 				IngestionBurstSize:  10000,
 
-				ingesterClientFactory: func(addr string, _ time.Duration) (client.IngesterClient, error) {
+				ingesterClientFactory: func(addr string, _ time.Duration, _ bool) (client.IngesterClient, error) {
 					return ingesters[addr], nil
 				},
 			}, ring)
@@ -305,7 +305,7 @@ func TestDistributorQuery(t *testing.T) {
 				IngestionRateLimit:  10000,
 				IngestionBurstSize:  10000,
 
-				ingesterClientFactory: func(addr string, _ time.Duration) (client.IngesterClient, error) {
+				ingesterClientFactory: func(addr string, _ time.Duration, _ bool) (client.IngesterClient, error) {
 					return ingesters[addr], nil
 				},
 			}, ring)

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -17,13 +17,16 @@ type closableIngesterClient struct {
 }
 
 // MakeIngesterClient makes a new IngesterClient
-func MakeIngesterClient(addr string, timeout time.Duration) (IngesterClient, error) {
+func MakeIngesterClient(addr string, timeout time.Duration, withCompression bool) (IngesterClient, error) {
 	opts := []grpc.DialOption{grpc.WithTimeout(timeout),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.ClientUserHeaderInterceptor,
 		)),
+	}
+	if withCompression {
+		opts = append(opts, grpc.WithCompressor(grpc.NewGZIPCompressor()))
 	}
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -18,15 +18,14 @@ type closableIngesterClient struct {
 
 // MakeIngesterClient makes a new IngesterClient
 func MakeIngesterClient(addr string, timeout time.Duration) (IngesterClient, error) {
-	conn, err := grpc.Dial(
-		addr,
-		grpc.WithTimeout(timeout),
+	opts := []grpc.DialOption{grpc.WithTimeout(timeout),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.ClientUserHeaderInterceptor,
 		)),
-	)
+	}
+	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -90,7 +90,7 @@ type Config struct {
 	infName               string
 	id                    string
 	skipUnregister        bool
-	ingesterClientFactory func(addr string, timeout time.Duration) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, timeout time.Duration, withCompression bool) (client.IngesterClient, error)
 	KVClient              ring.KVClient
 }
 

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -358,7 +358,7 @@ func (i *Ingester) transferChunks() error {
 	}
 
 	level.Info(util.Logger).Log("msg", "sending chunks to ingester", "ingester", targetIngester.Addr)
-	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, i.cfg.SearchPendingFor)
+	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, i.cfg.SearchPendingFor, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/ingester_lifecycle_test.go
+++ b/pkg/ingester/ingester_lifecycle_test.go
@@ -118,7 +118,7 @@ func TestIngesterTransfer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
-	ing1.cfg.ingesterClientFactory = func(addr string, timeout time.Duration) (client.IngesterClient, error) {
+	ing1.cfg.ingesterClientFactory = func(addr string, timeout time.Duration, _ bool) (client.IngesterClient, error) {
 		return ingesterClientAdapater{
 			ingester: ing2,
 		}, nil

--- a/vendor/github.com/weaveworks/common/instrument/instrument.go
+++ b/vendor/github.com/weaveworks/common/instrument/instrument.go
@@ -11,6 +11,10 @@ import (
 	oldcontext "golang.org/x/net/context"
 )
 
+// DefBuckets are histogram buckets for the response time (in seconds)
+// of a network service, including one that is responding very slowly.
+var DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100}
+
 // Collector describes something that collects data before and/or after a task.
 type Collector interface {
 	Register()

--- a/vendor/github.com/weaveworks/common/server/server.go
+++ b/vendor/github.com/weaveworks/common/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks-experiments/loki/pkg/client"
 	"github.com/weaveworks/common/httpgrpc"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
+	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/signals"
 )
@@ -95,7 +96,7 @@ func New(cfg Config) (*Server, error) {
 		Namespace: cfg.MetricsNamespace,
 		Name:      "request_duration_seconds",
 		Help:      "Time (in seconds) spent serving HTTP requests.",
-		Buckets:   prometheus.DefBuckets,
+		Buckets:   instrument.DefBuckets,
 	}, []string{"method", "route", "status_code", "ws"})
 	prometheus.MustRegister(requestDuration)
 
@@ -110,6 +111,7 @@ func New(cfg Config) (*Server, error) {
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpcMiddleware...,
 		)),
+		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
 	)
 
 	// Setup HTTP server


### PR DESCRIPTION
We see about a 85% reduction in network traffic from distributor to ingester when we try this in our dev environment.

This is good if your network traffic costs more than the CPU it takes to compress it.
