### PR TITLE
Rename tools/bazel to tools/bazel-build

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 Included in this repo are tools shared by weave.git and scope.git.  They include
 
-- ```bazel```: Bazel build rules used in our projects
+- ```bazel-rules```: Bazel build rules used in our projects
 - ```build```: a set of docker base-images for building weave
   projects. These should be used instead of giving each project its
   own build image.

--- a/tools/bazel-rules/BUILD.bazel
+++ b/tools/bazel-rules/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
+
+go_proto_compiler(
+    name = "gogo_proto",
+    deps = [
+        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
+    ],
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gogoslick",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_compiler(
+    name = "gogo_grpc",
+    deps = [
+        "//vendor/github.com/gogo/protobuf/gogoproto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
+        "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/golang.org/x/net/context:go_default_library",
+    ],
+    plugin = "@com_github_gogo_protobuf//protoc-gen-gogoslick",
+    options = ["plugins=grpc"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/bazel-rules/gogo.bzl
+++ b/tools/bazel-rules/gogo.bzl
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+
+
+_BUILD_FILE = """
+proto_library(
+    name = "gogoproto",
+    srcs = ["gogo.proto"],
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _go_repository_impl(ctx):
+  ctx.file("BUILD.bazel", content="")
+  ctx.file("github.com/gogo/protobuf/gogoproto/BUILD.bazel", content=_BUILD_FILE)
+  ctx.template("github.com/gogo/protobuf/gogoproto/gogo.proto", ctx.attr._proto)
+
+_gogo_proto_repository = repository_rule(
+    implementation = _go_repository_impl,
+    attrs = {
+        "_proto": attr.label(default="//vendor/github.com/gogo/protobuf/gogoproto:gogo.proto"),
+    },
+)
+
+def gogo_dependencies():
+  go_repository(
+      name = "com_github_gogo_protobuf",
+      importpath = "github.com/gogo/protobuf",
+      urls = ["https://codeload.github.com/ianthehat/protobuf/zip/2adc21fd136931e0388e278825291678e1d98309"],
+      strip_prefix = "protobuf-2adc21fd136931e0388e278825291678e1d98309",
+      type = "zip",
+      build_file_proto_mode="disable",
+  )
+  _gogo_proto_repository(name = "internal_gogo_proto_repository")


### PR DESCRIPTION
Pulls in changes from https://github.com/weaveworks/build-tools/pull/125. See that PR for justification.

Doing as standalone PR because there were conflicts (again).