### PR TITLE
Fix typos in error logging

### DIFF
--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	storageClient, err := storage.NewStorageClient(storageConfig, schemaConfig)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing storage client: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing storage client", "err", err)
 		os.Exit(1)
 	}
 
@@ -56,14 +56,14 @@ func main() {
 
 	r, err := ring.New(ringConfig)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing ring: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing ring", "err", err)
 		os.Exit(1)
 	}
 	defer r.Stop()
 
 	dist, err := distributor.New(distributorConfig, r)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing distributor: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing distributor", "err", err)
 		os.Exit(1)
 	}
 	defer dist.Stop()
@@ -71,7 +71,7 @@ func main() {
 
 	rlr, err := ruler.NewRuler(rulerConfig, dist, chunkStore)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing ruler: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing ruler", "err", err)
 		os.Exit(1)
 	}
 	defer rlr.Stop()
@@ -84,14 +84,14 @@ func main() {
 
 	rulerServer, err := ruler.NewServer(rulerConfig, rlr, rulesAPI)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing ruler server: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing ruler server", "err", err)
 		os.Exit(1)
 	}
 	defer rulerServer.Stop()
 
 	server, err := server.New(serverConfig)
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error initializing server: %v", err)
+		level.Error(util.Logger).Log("msg", "error initializing server", "err", err)
 		os.Exit(1)
 	}
 	defer server.Shutdown()

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -325,7 +325,7 @@ func (i *Ingester) processShutdown() {
 	flushRequired := true
 	if i.cfg.ClaimOnRollout {
 		if err := i.transferChunks(); err != nil {
-			level.Error(util.Logger).Log("msg", "Failed to transfer chunks to another ingester: %v", err)
+			level.Error(util.Logger).Log("msg", "Failed to transfer chunks to another ingester", "err", err)
 		} else {
 			flushRequired = false
 		}


### PR DESCRIPTION
Current code gives you this kind of thing:

```
ts=2018-01-15T15:01:20.02110214Z caller=log.go:108 level=error msg="Error looking for pending ingester: %v"
ts=2018-01-15T15:01:20.021162734Z caller=log.go:108 level=error msg="Failed to transfer chunks to another ingester: %v"
```
