### PR TITLE
Keep a pool of compressors to save garbage-collection

### DIFF
--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"compress/gzip"
+	"io"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
@@ -26,7 +29,7 @@ func MakeIngesterClient(addr string, timeout time.Duration, withCompression bool
 		)),
 	}
 	if withCompression {
-		opts = append(opts, grpc.WithCompressor(grpc.NewGZIPCompressor()))
+		opts = append(opts, grpc.WithCompressor(NewPooledGZIPCompressor()))
 	}
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
@@ -40,4 +43,31 @@ func MakeIngesterClient(addr string, timeout time.Duration, withCompression bool
 
 func (c *closableIngesterClient) Close() error {
 	return c.conn.Close()
+}
+
+// NewPooledGZIPCompressor creates a Compressor based on GZIP.
+// Based on the implementation in grpc library, but with a pool of
+// objects to reduce garbage
+func NewPooledGZIPCompressor() grpc.Compressor {
+	return &pooledCompressor{
+		pool: sync.Pool{New: func() interface{} { return gzip.NewWriter(nil) }},
+	}
+}
+
+type pooledCompressor struct {
+	pool sync.Pool
+}
+
+func (c *pooledCompressor) Do(w io.Writer, p []byte) error {
+	z := c.pool.Get().(*gzip.Writer)
+	defer c.pool.Put(z)
+	z.Reset(w)
+	if _, err := z.Write(p); err != nil {
+		return err
+	}
+	return z.Close()
+}
+
+func (c *pooledCompressor) Type() string {
+	return "gzip"
 }


### PR DESCRIPTION
The grpc library implementation creates and discards a compressor on every call, and the gzip buffers add up to hundreds of kilobytes, so this is quite an overhead.
