### PR TITLE
Set gRPC compression and max message options

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -601,7 +601,7 @@
   branch = "master"
   name = "github.com/weaveworks/common"
   packages = ["aws","errors","httpgrpc","httpgrpc/server","instrument","logging","mflag","mflagext","middleware","mtime","server","signals","test","tracing","user"]
-  revision = "d85bab03a1b1327e94db89d64a84dfd1e79f193f"
+  revision = "bf7fd2fdfaa72bc4bf23b057af82aa3c0dbdc40c"
 
 [[projects]]
   name = "github.com/weaveworks/mesh"
@@ -682,7 +682,7 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","credentials/oauth","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","credentials/oauth","encoding","encoding/gzip","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
   revision = "7cea4cc846bcf00cbb27595b07da5de875ef7de9"
   version = "v1.9.1"
 
@@ -723,6 +723,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "50b77b2122959f3f753d90e0d4a8f344f7374848371c3956e51c4d965ecc0cfc"
+  inputs-digest = "580b7d294648ad7793e7cac316258d28563ccc8de3cca6dcab2c78fe33851db2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip" // get gzip compressor registered
 
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"

--- a/vendor/github.com/weaveworks/common/server/server.go
+++ b/vendor/github.com/weaveworks/common/server/server.go
@@ -48,6 +48,7 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration
 	HTTPServerIdleTimeout         time.Duration
 
+	GRPCOptions    []grpc.ServerOption
 	GRPCMiddleware []grpc.UnaryServerInterceptor
 	HTTPMiddleware []middleware.Interface
 }
@@ -107,12 +108,13 @@ func New(cfg Config) (*Server, error) {
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
-	grpcServer := grpc.NewServer(
+	grpcOptions := []grpc.ServerOption{
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpcMiddleware...,
 		)),
-		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
-	)
+	}
+	grpcOptions = append(grpcOptions, cfg.GRPCOptions...)
+	grpcServer := grpc.NewServer(grpcOptions...)
 
 	// Setup HTTP server
 	router := mux.NewRouter()

--- a/vendor/google.golang.org/grpc/encoding/gzip/gzip.go
+++ b/vendor/google.golang.org/grpc/encoding/gzip/gzip.go
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package gzip implements and registers the gzip compressor
+// during the initialization.
+// This package is EXPERIMENTAL.
+package gzip
+
+import (
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"sync"
+
+	"google.golang.org/grpc/encoding"
+)
+
+func init() {
+	c := &compressor{}
+	c.poolCompressor.New = func() interface{} {
+		return &writer{Writer: gzip.NewWriter(ioutil.Discard), pool: &c.poolCompressor}
+	}
+	encoding.RegisterCompressor(c)
+}
+
+type writer struct {
+	*gzip.Writer
+	pool *sync.Pool
+}
+
+func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	z := c.poolCompressor.Get().(*writer)
+	z.Writer.Reset(w)
+	return z, nil
+}
+
+func (z *writer) Close() error {
+	defer z.pool.Put(z)
+	return z.Writer.Close()
+}
+
+type reader struct {
+	*gzip.Reader
+	pool *sync.Pool
+}
+
+func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
+	z, inPool := c.poolDecompressor.Get().(*reader)
+	if !inPool {
+		newZ, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return &reader{Reader: newZ, pool: &c.poolDecompressor}, nil
+	}
+	if err := z.Reset(r); err != nil {
+		c.poolDecompressor.Put(z)
+		return nil, err
+	}
+	return z, nil
+}
+
+func (z *reader) Read(p []byte) (n int, err error) {
+	n, err = z.Reader.Read(p)
+	if err == io.EOF {
+		z.pool.Put(z)
+	}
+	return n, err
+}
+
+func (c *compressor) Name() string {
+	return "gzip"
+}
+
+type compressor struct {
+	poolCompressor   sync.Pool
+	poolDecompressor sync.Pool
+}


### PR DESCRIPTION
Depends on https://github.com/weaveworks/common/pull/83; I will fix up when that is merged.

The limit on message size came with the new gRPC.
New-style compression options because the old ones are now deprecated.
