### PR TITLE
Fix intermittently failing TestIngesterTransfer

### DIFF
--- a/pkg/ingester/ingester_claim.go
+++ b/pkg/ingester/ingester_claim.go
@@ -98,7 +98,6 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 		sentChunks.Add(float64(len(descs)))
 	}
 
-
 	if err := i.ClaimTokensFor(fromIngesterID); err != nil {
 		return err
 	}

--- a/pkg/ingester/ingester_claim.go
+++ b/pkg/ingester/ingester_claim.go
@@ -112,7 +112,12 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 
 	// Close the stream last, as this is what tells the "from" ingester that
 	// it's OK to shut down.
-	return stream.SendAndClose(&client.TransferChunksResponse{})
+	if err := stream.SendAndClose(&client.TransferChunksResponse{}); err != nil {
+		level.Error(util.Logger).Log("msg", "Error closing TransferChunks stream", "ingester", fromIngesterID, "err", err)
+		return err
+	}
+	level.Info(util.Logger).Log("msg", "Successfully transferred chunks to ingester", "ingester", fromIngesterID)
+	return nil
 }
 
 func toWireChunks(descs []*desc) ([]client.Chunk, error) {

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -425,11 +425,12 @@ func (i *Ingester) findTargetIngester() (*ring.IngesterDesc, error) {
 	for {
 		ingester, err := findIngester()
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "Error looking for pending ingester: %v", err)
+			level.Debug(util.Logger).Log("msg", "Error looking for pending ingester", "err", err)
 			if time.Now().Before(deadline) {
 				time.Sleep(i.cfg.SearchPendingFor / pendingSearchIterations)
 				continue
 			} else {
+				level.Warn(util.Logger).Log("msg", "Could not find pending ingester before deadline", "err", err)
 				return nil, err
 			}
 		}

--- a/pkg/ring/consul_client.go
+++ b/pkg/ring/consul_client.go
@@ -178,11 +178,11 @@ func (c *consulClient) CAS(key string, f CASCallback) error {
 			ModifyIndex: index,
 		}, writeOptions)
 		if err != nil {
-			level.Error(util.Logger).Log("msg", "error CASing", "ley", key, "err", err)
+			level.Error(util.Logger).Log("msg", "error CASing", "key", key, "err", err)
 			continue
 		}
 		if !ok {
-			level.Error(util.Logger).Log("msg", "error CASing, trying again", "key", key, "index", index)
+			level.Debug(util.Logger).Log("msg", "error CASing, trying again", "key", key, "index", index)
 			continue
 		}
 		return nil


### PR DESCRIPTION
This fixes the intermittently failing `TestIngesterTransfer`.

The issue was that the `TransferChunks` method (called as an RPC by the departing ingester) would signal that it was complete (`SendAndClose`) *before* it claimed the ring and updated its state to active.

The test, however, runs a query immediately after the departing ingester has shut down.

Thus, there's a very small window after `Shutdown` has terminated but before `ClaimTokensFor` and `ChangeState` have run. When we run the query in this window, we get no results, because there are no ingesters that have the chunks we need.

I've fixed this by moving the call to `SendAndClose` to the end of `TransferChunks`. I *think* this is the right approach, but am not 100% sure.

An alternative would be to prevent the race in the test without changing the production code. To do this, we'd add the following snippet just after the call to `Shutdown()`:

```go
// ing2 might not have claimed the ring before it's told ing1 it's OK to
// shut down.
poll(t, 10*time.Millisecond, ring.ACTIVE, func() interface{} {
    return ing2.state
})
```

It was writing the comment that convinced me this was a less good approach.

The PR includes a commit that fixes some general, minor logging bugs I noticed while trying to debug the test failure.

I should point out that my snarky comment on #369 was wrong-headed: the test failure is _not_ due to relying on the system clock, but rather to a more vanilla race condition.

Fixes #369 