### PR TITLE
Use our global logger for the alertmanager

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	amconfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -462,7 +461,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *amco
 	newAM, err := New(&Config{
 		UserID:      userID,
 		DataDir:     am.cfg.DataDir,
-		Logger:      log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		Logger:      util.Logger,
 		MeshRouter:  am.meshRouter,
 		Retention:   am.cfg.Retention,
 		ExternalURL: am.cfg.ExternalURL.URL,


### PR DESCRIPTION
This PR moves alertmanager's "logging to stderr" to using our global `util.Logger`.

PR #658 has switched from logrus to go-kit. Logrus' default log level is
INFO while go-kit's is DEBUG. Since the alertmanager hasn't been using
our global logger its log level wasn't set.