### PR TITLE
Change the value of resolver in nginx-config.yaml

### DIFF
--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -21,7 +21,7 @@ data:
       access_log   /dev/stderr  main;
       sendfile     on;
       tcp_nopush   on;
-      resolver 10.0.0.10;
+      resolver 10.96.0.10;
 
       server { # simple reverse-proxy
         listen 80;

--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -21,7 +21,7 @@ data:
       access_log   /dev/stderr  main;
       sendfile     on;
       tcp_nopush   on;
-      resolver 10.96.0.10;
+      resolver kube-dns.kube-system.svc.cluster.local;
 
       server { # simple reverse-proxy
         listen 80;


### PR DESCRIPTION
# WHAT / WHY

To change the value of resolver in nginx-config.yaml since the address of kube-dns changed.

I derived the following errors.
```
...
172.17.0.14 - - [27/Jan/2018:16:53:38 +0000]  499 "POST /api/prom/push HTTP/1.1" 0 "-" "Go-http-client/1.1" "-"
172.17.0.14 - - [27/Jan/2018:16:53:38 +0000]  499 "POST /api/prom/push HTTP/1.1" 0 "-" "Go-http-client/1.1" "-"
...
```

# Information

I followed the instruction documented in README.md to build development environment on my MAC.

`kubectl version`

```
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.0", GitCommit:"925c127ec6b946659ad0fd596fa959be43f0cc05", GitTreeState:"clean", BuildDate:"2017-12-16T03:16:50Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.0", GitCommit:"0b9efaeb34a2fc51ff8e4d34ad9bc6375459c4a4", GitTreeState:"clean", BuildDate:"2017-11-29T22:43:34Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"linux/amd64"}
```

# Result

Log from nginx container (`kubectl logs nginx`)

After I modified the config, the nginx works just fine.
```
...
172.17.0.17 - - [27/Jan/2018:16:26:21 +0000]  200 "POST /api/prom/push HTTP/1.1" 0 "-" "Go-http-client/1.1" "-"
...
```