### PR TITLE
Update to go 1.9.3

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1-stretch
+FROM golang:1.9.3-stretch
 RUN apt-get update && apt-get install -y python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \


### PR DESCRIPTION
I was getting some weird corruptions with the 1.9.1 image, so I thought I might just update:

```
Removing intermediate container 7ee024e3390e
 ---> 346736e42efd
Step 3/7 : RUN go clean -i net && 	go install -tags netgo std && 	go install -race -tags netgo std
 ---> Running in 2f7709b6c1c9
# crypto/x509
/usr/local/go/src/crypto/x509/verify.go:8:2: import /usr/local/go/pkg/linux_amd64/bytes.a: not a go object file: 5��c�um�uZ�5�s����g|	��r�	]����V�6��;"Jk�%o�$���
                                                                                                                                                                      ���1mq�	(����~n)D����������u�4ѕ���ז**ί���g�5��t+�
             ��G��nأ_u%?��D4�)�1
                                �T�rq�������#��c?���6�*	�[kv�a2�Z'r��,s���ެ��Ii�����gQr2���LF�/
                                                                                              Jfj.����7������J��y�s#�0Ԁ�����X>7������wCTqSR\�܉�څ�_���I����r@
# net/textproto
/usr/local/go/src/net/textproto/reader.go:8:2: import /usr/local/go/pkg/linux_amd64/bufio.a: not a go object file: ������v�*0h�n@�h
                                                                                                                                  0�[��܆��kdr�Z���%|#ߊ�?�����@�1�d9�Fz����-���:�|Z�y��Za.�x��d��XΟ���z�knz�A��k:F�>�ɀ;%�a]Lⷁ�]|�o���»#l�)��6�#/�L���/��h����'dF���>������WQ_�����
�Pj��.�.�Ю[�&��]�����!�`
��r�8�^�s]ҩ���g�K����_�[NGUq�wء_����X�8���{Õk���d�-,s-pų�>ɍ{���F[�[���(ԧ��ȼ�E�7=A�D��'k�<�:g���]T�8������Ȥ��M�E�������W�RĕT��d]���A"XK��"�e٬!{�Z���5�z�v�*#
�6i�o�����                                               ��1 �(����b.@M��Ǭ�r���ͺyH_�
          �5��"�>���
                    �5��4�x���Çi�1h�ojk���&�C���I��M�	iDKV�[��s��n��c���yx���������#��SU�ǝ@u��Zv��}W�@���L���M�*���=�=S�(����ĥ�����3�
                                                                                                                                       g���x����� �3+�F����=��}"i4Hk������#t1���x�~
# vendor/golang_org/x/net/nettest
/usr/local/go/src/vendor/golang_org/x/net/nettest/conntest.go:9:2: import /usr/local/go/pkg/linux_amd64/bytes.a: not a go object file: 5��c�um�uZ�5�s����g|	��r�	]����V�6��;"Jk�%o�$���
                                                                                                                                                                                              ���1mq�	(����~n)D����������u�4ѕ���ז**ί���g�5��t+�
                                     ��G��nأ_u%?��D4�)�1
                                                        �T�rq�������#��c?���6�*	�[kv�a2�Z'r��,s���ެ��Ii�����gQr2���LF�/
                                                                                                                      Jfj.����7������J��y�s#�0Ԁ�����X>7������wCTqSR\�܉�څ�_���I����r@
The command '/bin/sh -c go clean -i net && 	go install -tags netgo std && 	go install -race -tags netgo std' returned a non-zero code: 2
make: *** [build-image/.uptodate] Error 2
```