### PR TITLE
Scan deletedAt (time or null) in findConfigs, findRulesConfigs and GetConfig

### DIFF
--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -194,7 +194,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 		}
 		level.Info(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_rules", len(rules))
 		s.Lock()
-		// if deleted remove from map
+		// if deleted remove from map, otherwise - update map
 		if !config.DeletedAt.IsZero() {
 			delete(s.cfgs, userID)
 		} else {


### PR DESCRIPTION
Add `deleted_at` to `GetConfig`, `findConfigs` and `findRulesConfigs` functions so they can return actual value of `deleted_at` for later use in ruler. Otherwise, ruler never discoveries deleted configs and never delete them from the map.

By default `deleted_at` column in DB set to `NULL` so we scan this into `pq.NullTime` variable (because we cannot store `nil` value into type `time.Time`).
To restore config we set `deleted_at` column in DB to `NULL`.

fixes https://github.com/weaveworks/service-conf/issues/1859