### PR TITLE
Introduce GRPC Streaming Tracing to gcp GRCP instrumentation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -271,10 +271,10 @@
   version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
-  revision = "0e7658f8ee99ee5aa683e2a032b8880091b7a055"
+  revision = "ed3ba477b4d621be4baf2a0fbff7b37ad854f3ae"
+  source = "github.com/Fresh-Tracks/grpc-opentracing"
 
 [[projects]]
   name = "github.com/hashicorp/consul"
@@ -725,6 +725,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "28012f846980a8d0923820d79f01a661f156d20b6f1f309f8822e820f0327016"
+  inputs-digest = "c07e2c79b83a2e68320ccd460b29ca95782bab36c2811860e2d66e93f54803a4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,3 +25,10 @@
 [[override]]
   name = "github.com/weaveworks/mesh"
   revision = "5015f896ab62d3e9fe757456c757521ce0c3faff"
+
+[[override]]
+  name = "github.com/grpc-ecosystem/grpc-opentracing"
+  # Merging PR https://github.com/grpc-ecosystem/grpc-opentracing/pull/25
+  # into this repo.
+  source = "github.com/Fresh-Tracks/grpc-opentracing"
+  revision = "ed3ba477b4d621be4baf2a0fbff7b37ad854f3ae"

--- a/pkg/chunk/gcp/instrumentation.go
+++ b/pkg/chunk/gcp/instrumentation.go
@@ -38,7 +38,10 @@ func instrumentation() []option.ClientOption {
 			)),
 		),
 		option.WithGRPCDialOption(
-			grpc.WithStreamInterceptor(grpcStreamInstrumentation),
+			grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(
+				otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()),
+				grpcStreamInstrumentation,
+			)),
 		),
 	}
 }

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/README.md
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/README.md
@@ -28,7 +28,9 @@ conn, err := grpc.Dial(
     address,
     ... // other options
     grpc.WithUnaryInterceptor(
-        otgrpc.OpenTracingClientInterceptor(tracer)))
+        otgrpc.OpenTracingClientInterceptor(tracer)),
+    grpc.WithStreamInterceptor(
+        otgrpc.OpenTracingStreamClientInterceptor(tracer)))
 
 // All future RPC activity involving `conn` will be automatically traced.
 ```
@@ -46,7 +48,9 @@ var tracer opentracing.Tracer = ...
 s := grpc.NewServer(
     ... // other options
     grpc.UnaryInterceptor(
-        otgrpc.OpenTracingServerInterceptor(tracer)))
+        otgrpc.OpenTracingServerInterceptor(tracer)),
+    grpc.StreamInterceptor(
+        otgrpc.OpenTracingStreamServerInterceptor(tracer)))
 
 // All future RPC activity involving `s` will be automatically traced.
 ```

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/client.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/client.go
@@ -7,6 +7,9 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"io"
+	"runtime"
+	"sync/atomic"
 )
 
 // OpenTracingClientInterceptor returns a grpc.UnaryClientInterceptor suitable
@@ -50,19 +53,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			gRPCComponentTag,
 		)
 		defer clientSpan.Finish()
-		md, ok := metadata.FromOutgoingContext(ctx)
-		if !ok {
-			md = metadata.New(nil)
-		} else {
-			md = md.Copy()
-		}
-		mdWriter := metadataReaderWriter{md}
-		err = tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, mdWriter)
-		// We have no better place to record an error than the Span itself :-/
-		if err != nil {
-			clientSpan.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
-		}
-		ctx = metadata.NewOutgoingContext(ctx, md)
+		ctx = injectSpanContext(ctx, tracer, clientSpan)
 		if otgrpcOpts.logPayloads {
 			clientSpan.LogFields(log.Object("gRPC request", req))
 		}
@@ -80,4 +71,169 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		}
 		return err
 	}
+}
+
+// OpenTracingStreamClientInterceptor returns a grpc.StreamClientInterceptor suitable
+// for use in a grpc.Dial call. The interceptor instruments streaming RPCs by creating
+// a single span to correspond to the lifetime of the RPC's stream.
+//
+// For example:
+//
+//     conn, err := grpc.Dial(
+//         address,
+//         ...,  // (existing DialOptions)
+//         grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+//
+// All gRPC client spans will inject the OpenTracing SpanContext into the gRPC
+// metadata; they will also look in the context.Context for an active
+// in-process parent Span and establish a ChildOf reference if such a parent
+// Span could be found.
+func OpenTracingStreamClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.StreamClientInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		var err error
+		var parentCtx opentracing.SpanContext
+		if parent := opentracing.SpanFromContext(ctx); parent != nil {
+			parentCtx = parent.Context()
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(parentCtx, method, nil, nil) {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
+
+		clientSpan := tracer.StartSpan(
+			method,
+			opentracing.ChildOf(parentCtx),
+			ext.SpanKindRPCClient,
+			gRPCComponentTag,
+		)
+		ctx = injectSpanContext(ctx, tracer, clientSpan)
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+			SetSpanTags(clientSpan, err, true)
+			clientSpan.Finish()
+			return cs, err
+		}
+		return newOpenTracingClientStream(cs, method, desc, clientSpan, otgrpcOpts), nil
+	}
+}
+
+func newOpenTracingClientStream(cs grpc.ClientStream, method string, desc *grpc.StreamDesc, clientSpan opentracing.Span, otgrpcOpts *options) grpc.ClientStream {
+	finishChan := make(chan struct{})
+
+	isFinished := new(int32)
+	*isFinished = 0
+	finishFunc := func(err error) {
+		// The current OpenTracing specification forbids finishing a span more than
+		// once. Since we have multiple code paths that could concurrently call
+		// `finishFunc`, we need to add some sort of synchronization to guard against
+		// multiple finishing.
+		if !atomic.CompareAndSwapInt32(isFinished, 0, 1) {
+			return
+		}
+		close(finishChan)
+		defer clientSpan.Finish()
+		if err != nil {
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+			SetSpanTags(clientSpan, err, true)
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(clientSpan, method, nil, nil, err)
+		}
+	}
+	go func() {
+		select {
+		case <-finishChan:
+			// The client span is being finished by another code path; hence, no
+			// action is necessary.
+		case <-cs.Context().Done():
+			finishFunc(cs.Context().Err())
+		}
+	}()
+	otcs := &openTracingClientStream{
+		ClientStream: cs,
+		desc:         desc,
+		finishFunc:   finishFunc,
+	}
+
+	// The `ClientStream` interface allows one to omit calling `Recv` if it's
+	// known that the result will be `io.EOF`. See
+	// http://stackoverflow.com/q/42915337
+	// In such cases, there's nothing that triggers the span to finish. We,
+	// therefore, set a finalizer so that the span and the context goroutine will
+	// at least be cleaned up when the garbage collector is run.
+	runtime.SetFinalizer(otcs, func(otcs *openTracingClientStream) {
+		otcs.finishFunc(nil)
+	})
+	return otcs
+}
+
+type openTracingClientStream struct {
+	grpc.ClientStream
+	desc       *grpc.StreamDesc
+	finishFunc func(error)
+}
+
+func (cs *openTracingClientStream) Header() (metadata.MD, error) {
+	md, err := cs.ClientStream.Header()
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return md, err
+}
+
+func (cs *openTracingClientStream) SendMsg(m interface{}) error {
+	err := cs.ClientStream.SendMsg(m)
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return err
+}
+
+func (cs *openTracingClientStream) RecvMsg(m interface{}) error {
+	err := cs.ClientStream.RecvMsg(m)
+	if err == io.EOF {
+		cs.finishFunc(nil)
+		return err
+	} else if err != nil {
+		cs.finishFunc(err)
+		return err
+	}
+	if !cs.desc.ServerStreams {
+		cs.finishFunc(nil)
+	}
+	return err
+}
+
+func (cs *openTracingClientStream) CloseSend() error {
+	err := cs.ClientStream.CloseSend()
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return err
+}
+
+func injectSpanContext(ctx context.Context, tracer opentracing.Tracer, clientSpan opentracing.Span) context.Context {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
+	}
+	mdWriter := metadataReaderWriter{md}
+	err := tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, mdWriter)
+	// We have no better place to record an error than the Span itself :-/
+	if err != nil {
+		clientSpan.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
+	}
+	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/server.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/server.go
@@ -33,11 +33,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			md = metadata.New(nil)
-		}
-		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
+		spanContext, err := extractSpanContext(ctx, tracer)
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
 			// TODO: establish some sort of error reporting mechanism here. We
 			// don't know where to put such an error and must rely on Tracer
@@ -72,4 +68,74 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		}
 		return resp, err
 	}
+}
+
+// OpenTracingStreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
+// for use in a grpc.NewServer call. The interceptor instruments streaming RPCs by
+// creating a single span to correspond to the lifetime of the RPC's stream.
+//
+// For example:
+//
+//     s := grpc.NewServer(
+//         ...,  // (existing ServerOptions)
+//         grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)))
+//
+// All gRPC server spans will look for an OpenTracing SpanContext in the gRPC
+// metadata; if found, the server span will act as the ChildOf that RPC
+// SpanContext.
+//
+// Root or not, the server Span will be embedded in the context.Context for the
+// application-specific gRPC handler(s) to access.
+func OpenTracingStreamServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.StreamServerInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		spanContext, err := extractSpanContext(ss.Context(), tracer)
+		if err != nil && err != opentracing.ErrSpanContextNotFound {
+			// TODO: establish some sort of error reporting mechanism here. We
+			// don't know where to put such an error and must rely on Tracer
+			// implementations to do something appropriate for the time being.
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(spanContext, info.FullMethod, nil, nil) {
+			return handler(srv, ss)
+		}
+
+		serverSpan := tracer.StartSpan(
+			info.FullMethod,
+			ext.RPCServerOption(spanContext),
+			gRPCComponentTag,
+		)
+		defer serverSpan.Finish()
+		ss = &openTracingServerStream{
+			ServerStream: ss,
+			ctx:          opentracing.ContextWithSpan(ss.Context(), serverSpan),
+		}
+		err = handler(srv, ss)
+		if err != nil {
+			SetSpanTags(serverSpan, err, false)
+			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(serverSpan, info.FullMethod, nil, nil, err)
+		}
+		return err
+	}
+}
+
+type openTracingServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (ss *openTracingServerStream) Context() context.Context {
+	return ss.ctx
+}
+
+func extractSpanContext(ctx context.Context, tracer opentracing.Tracer) (opentracing.SpanContext, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
+	return tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
 }


### PR DESCRIPTION
This brings in a stalled PR as a vendor-ed fork: https://github.com/grpc-ecosystem/grpc-opentracing/pull/25
and allows opentracing spans on grpc streaming calls.

The original PR seems well vetted. This matches the pattern already in use, and teasing this out seems more work that was needed.