### PR TITLE
Teach storage_client.QueryPages to use a RowRange that filters on the server.

### DIFF
--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -114,17 +114,12 @@ func (s *storageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, 
 	if len(query.RangeValuePrefix) > 0 {
 		rowRange = bigtable.PrefixRange(query.HashValue + separator + string(query.RangeValuePrefix))
 	} else if len(query.RangeValueStart) > 0 {
-		rowRange = bigtable.InfiniteRange(query.HashValue + separator + string(query.RangeValueStart))
+		rowRange = bigtable.NewRange(query.HashValue+separator+string(query.RangeValueStart), query.HashValue+separator+string('\xff'))
 	} else {
 		rowRange = bigtable.PrefixRange(query.HashValue + separator)
 	}
 
 	err := table.ReadRows(ctx, rowRange, func(r bigtable.Row) bool {
-		// Bigtable doesn't know when to stop, as we're reading "until the end of the
-		// row" in DynamoDB.  So we need to check the prefix of the row is still correct.
-		if !strings.HasPrefix(r.Key(), query.HashValue+separator) {
-			return false
-		}
 		return callback(bigtableReadBatch(r), false)
 	}, bigtable.RowFilter(bigtable.FamilyFilter(columnFamily)))
 	if err != nil {


### PR DESCRIPTION
Send in a lexicographically greater-than string to ReadRows and let the bigtable server
stop sending rows when's its finished.

We measured a 25-30% reduction in response time on the p90.

Some code for testing the queries outside of cortex: https://gist.github.com/bcotton/c76a9efc394d442b7d3689f8a8b7e2ca