### PR TITLE
Update Prometheus vendoring some more, adapt Cortex

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -679,6 +679,7 @@
   revision = "6ac8c5d890d415025dd5aae7595bcb2a6e7e2fad"
 
 [[projects]]
+  branch = "master"
   name = "github.com/prometheus/prometheus"
   packages = [
     "config",
@@ -721,7 +722,7 @@
     "util/yaml",
     "web/api/v1"
   ]
-  revision = "a730083cbfbb76e05244f82de0bc4146cb5f79ab"
+  revision = "4801573b64b34ea929620e948fc36da006f2f966"
 
 [[projects]]
   branch = "master"
@@ -1187,6 +1188,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1a7b72b8cd8bbdba3daf41afa0d8aa484a0fcc6fd06a579ee4588265b20e261c"
+  inputs-digest = "bb0be077b34422946e76365d4b249752738b1ca3b93b86049d9b410d2731546f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,18 +3,35 @@
 
 [[projects]]
   name = "cloud.google.com/go"
-  packages = ["bigtable","bigtable/internal/gax","bigtable/internal/option","compute/metadata","internal/version","longrunning","longrunning/autogen"]
+  packages = [
+    "bigtable",
+    "bigtable/internal/gax",
+    "bigtable/internal/option",
+    "compute/metadata",
+    "internal/version",
+    "longrunning",
+    "longrunning/autogen"
+  ]
   revision = "e11d9d1a1722e191d3d017c08077f2c15189769a"
   version = "v0.8.0"
 
 [[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
-  packages = ["arm/compute","arm/network"]
+  packages = [
+    "arm/compute",
+    "arm/network"
+  ]
   revision = "bd73d950fa4440dae889bd9917bff7cef539f86e"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/azure","autorest/date","autorest/to","autorest/validation"]
+  packages = [
+    "autorest",
+    "autorest/azure",
+    "autorest/date",
+    "autorest/to",
+    "autorest/validation"
+  ]
   revision = "a2fdd780c9a50455cecd249b00bdc3eb73a78e31"
   version = "v7.3.1"
 
@@ -45,7 +62,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse"
+  ]
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
@@ -68,7 +88,42 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/applicationautoscaling","service/applicationautoscaling/applicationautoscalingiface","service/dynamodb","service/dynamodb/dynamodbiface","service/ec2","service/s3","service/s3/s3iface","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/applicationautoscaling",
+    "service/applicationautoscaling/applicationautoscalingiface",
+    "service/dynamodb",
+    "service/dynamodb/dynamodbiface",
+    "service/ec2",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/sts"
+  ]
   revision = "b1a7b51924b90a6ecdbaeb17e96418740ff07a1e"
   version = "v1.10.8"
 
@@ -122,7 +177,10 @@
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digest","reference"]
+  packages = [
+    "digest",
+    "reference"
+  ]
   revision = "a25b9ef0c9fe242ac04bb20d3a028442b7d266b6"
   version = "v2.6.1"
 
@@ -146,7 +204,11 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log","swagger"]
+  packages = [
+    ".",
+    "log",
+    "swagger"
+  ]
   revision = "777bb3f19bcafe2575ffb2a3e46af92509ae9594"
   version = "v1.2"
 
@@ -170,7 +232,10 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["log","log/level"]
+  packages = [
+    "log",
+    "log/level"
+  ]
   revision = "a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b"
   version = "v0.5.0"
 
@@ -213,12 +278,23 @@
 [[projects]]
   branch = "master"
   name = "github.com/gocql/gocql"
-  packages = [".","internal/lru","internal/murmur","internal/streams"]
+  packages = [
+    ".",
+    "internal/lru",
+    "internal/murmur",
+    "internal/streams"
+  ]
   revision = "697e7c57f99bb127606c4d4f975c2ff4f34eca1c"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types"
+  ]
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
   version = "v0.4"
 
@@ -231,7 +307,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["jsonpb","proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/empty","ptypes/timestamp","ptypes/wrappers"]
+  packages = [
+    "jsonpb",
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/empty",
+    "ptypes/timestamp",
+    "ptypes/wrappers"
+  ]
   revision = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef"
 
 [[projects]]
@@ -255,7 +341,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/gophercloud/gophercloud"
-  packages = [".","openstack","openstack/compute/v2/extensions/floatingips","openstack/compute/v2/extensions/hypervisors","openstack/compute/v2/flavors","openstack/compute/v2/images","openstack/compute/v2/servers","openstack/identity/v2/tenants","openstack/identity/v2/tokens","openstack/identity/v3/tokens","openstack/utils","pagination"]
+  packages = [
+    ".",
+    "openstack",
+    "openstack/compute/v2/extensions/floatingips",
+    "openstack/compute/v2/extensions/hypervisors",
+    "openstack/compute/v2/flavors",
+    "openstack/compute/v2/images",
+    "openstack/compute/v2/servers",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/utils",
+    "pagination"
+  ]
   revision = "b4c2377fa77951a0e08163f52dc9b3e206355194"
 
 [[projects]]
@@ -272,7 +371,11 @@
 
 [[projects]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  packages = ["runtime","runtime/internal","utilities"]
+  packages = [
+    "runtime",
+    "runtime/internal",
+    "utilities"
+  ]
   revision = "07f5e79768022f9a3265235f0db4ac8c3f675fec"
   version = "v1.3.1"
 
@@ -363,18 +466,32 @@
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "2704adc878c21e1329f46f6e56a1c387d788ff94"
 
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "9e74fe5423dca819cf8fd940d9a5d5307ac7aa10"
 
 [[projects]]
   name = "github.com/mattes/migrate"
-  packages = ["driver","driver/postgres","file","migrate","migrate/direction","pipe"]
+  packages = [
+    "driver",
+    "driver/postgres",
+    "file",
+    "migrate",
+    "migrate/direction",
+    "pipe"
+  ]
   revision = "7dde43471463c0ee6a4183e1b5a8239ae2aa3122"
   version = "v1.3.1"
 
@@ -452,13 +569,24 @@
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [".","ext","log"]
+  packages = [
+    ".",
+    "ext",
+    "log"
+  ]
   revision = "6edb48674bd9467b8e91fda004f2bd7202d60ce4"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/openzipkin/zipkin-go-opentracing"
-  packages = [".","_thrift/gen-go/scribe","_thrift/gen-go/zipkincore","flag","types","wire"]
+  packages = [
+    ".",
+    "_thrift/gen-go/scribe",
+    "_thrift/gen-go/zipkincore",
+    "flag",
+    "types",
+    "wire"
+  ]
   revision = "6022d4d3ed39632fad842942bda1813a9b4f63c8"
   version = "v0.2.3"
 
@@ -494,7 +622,24 @@
 
 [[projects]]
   name = "github.com/prometheus/alertmanager"
-  packages = ["api","config","dispatch","inhibit","nflog","nflog/nflogpb","notify","pkg/parse","provider","provider/mem","silence","silence/silencepb","template","template/internal/deftmpl","types","ui"]
+  packages = [
+    "api",
+    "config",
+    "dispatch",
+    "inhibit",
+    "nflog",
+    "nflog/nflogpb",
+    "notify",
+    "pkg/parse",
+    "provider",
+    "provider/mem",
+    "silence",
+    "silence/silencepb",
+    "template",
+    "template/internal/deftmpl",
+    "types",
+    "ui"
+  ]
   revision = "fb713f6d8239b57c646cae30f78e8b4b8861a1aa"
 
 [[projects]]
@@ -512,25 +657,83 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["config","expfmt","internal/bitbucket.org/ww/goautoneg","log","model","promlog","route","version"]
+  packages = [
+    "config",
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "log",
+    "model",
+    "promlog",
+    "route",
+    "version"
+  ]
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "6ac8c5d890d415025dd5aae7595bcb2a6e7e2fad"
 
 [[projects]]
   name = "github.com/prometheus/prometheus"
-  packages = ["config","discovery","discovery/azure","discovery/config","discovery/consul","discovery/dns","discovery/ec2","discovery/file","discovery/gce","discovery/kubernetes","discovery/marathon","discovery/openstack","discovery/targetgroup","discovery/triton","discovery/zookeeper","notifier","pkg/labels","pkg/pool","pkg/relabel","pkg/rulefmt","pkg/textparse","pkg/timestamp","pkg/value","prompb","promql","relabel","retrieval","rules","storage","storage/remote","storage/tsdb","template","util/httputil","util/stats","util/strutil","util/testutil","util/treecache","util/yaml","web/api/v1"]
-  revision = "85f23d82a045d103ea7f3c89a91fba4a93e6367a"
-  version = "v2.1.0"
+  packages = [
+    "config",
+    "discovery",
+    "discovery/azure",
+    "discovery/config",
+    "discovery/consul",
+    "discovery/dns",
+    "discovery/ec2",
+    "discovery/file",
+    "discovery/gce",
+    "discovery/kubernetes",
+    "discovery/marathon",
+    "discovery/openstack",
+    "discovery/targetgroup",
+    "discovery/triton",
+    "discovery/zookeeper",
+    "notifier",
+    "pkg/labels",
+    "pkg/pool",
+    "pkg/relabel",
+    "pkg/rulefmt",
+    "pkg/textparse",
+    "pkg/timestamp",
+    "pkg/value",
+    "prompb",
+    "promql",
+    "relabel",
+    "rules",
+    "scrape",
+    "storage",
+    "storage/remote",
+    "storage/tsdb",
+    "template",
+    "util/httputil",
+    "util/stats",
+    "util/strutil",
+    "util/testutil",
+    "util/treecache",
+    "util/yaml",
+    "web/api/v1"
+  ]
+  revision = "a730083cbfbb76e05244f82de0bc4146cb5f79ab"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/tsdb"
-  packages = [".","chunkenc","chunks","fileutil","index","labels"]
+  packages = [
+    ".",
+    "chunkenc",
+    "chunks",
+    "fileutil",
+    "index",
+    "labels"
+  ]
   revision = "467948f3c3f2f6f4ed9881afba27dd3ae24393eb"
 
 [[projects]]
@@ -571,7 +774,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -583,7 +789,18 @@
 
 [[projects]]
   name = "github.com/uber/jaeger-client-go"
-  packages = [".","config","internal/spanlog","log","rpcmetrics","thrift-gen/agent","thrift-gen/jaeger","thrift-gen/sampling","thrift-gen/zipkincore","utils"]
+  packages = [
+    ".",
+    "config",
+    "internal/spanlog",
+    "log",
+    "rpcmetrics",
+    "thrift-gen/agent",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "utils"
+  ]
   revision = "3e3870040def0ebdaf65a003863fa64f5cb26139"
   version = "v2.9.0"
 
@@ -614,7 +831,23 @@
 [[projects]]
   branch = "master"
   name = "github.com/weaveworks/common"
-  packages = ["aws","errors","httpgrpc","httpgrpc/server","instrument","logging","mflag","mflagext","middleware","mtime","server","signals","test","tracing","user"]
+  packages = [
+    "aws",
+    "errors",
+    "httpgrpc",
+    "httpgrpc/server",
+    "instrument",
+    "logging",
+    "mflag",
+    "mflagext",
+    "middleware",
+    "mtime",
+    "server",
+    "signals",
+    "test",
+    "tracing",
+    "user"
+  ]
   revision = "bf7fd2fdfaa72bc4bf23b057af82aa3c0dbdc40c"
 
 [[projects]]
@@ -631,19 +864,41 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["curve25519","nacl/box","nacl/secretbox","poly1305","salsa20/salsa","ssh/terminal"]
+  packages = [
+    "curve25519",
+    "nacl/box",
+    "nacl/secretbox",
+    "poly1305",
+    "salsa20/salsa",
+    "ssh/terminal"
+  ]
   revision = "c7af5bf2638a1164f2eb5467c39c6cffbd13a02e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "da118f7b8e5954f39d0d2130ab35d4bf0e3cb344"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
   revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
 
 [[projects]]
@@ -655,13 +910,29 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry","windows/svc/eventlog"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry",
+    "windows/svc/eventlog"
+  ]
   revision = "9f30dcbe5be197894515a338a9bda9253567ea8f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "a9a820217f98f7c8a207ec1e45a874e1fe12c478"
 
 [[projects]]
@@ -679,24 +950,86 @@
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = ["compute/v1","gensupport","googleapi","googleapi/internal/uritemplates","googleapi/transport","internal","iterator","option","transport"]
+  packages = [
+    "compute/v1",
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "transport"
+  ]
   revision = "fbbaff1827317122a8a0e1b24de25df8417ce87b"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/socket","internal/urlfetch","socket","urlfetch"]
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/socket",
+    "internal/urlfetch",
+    "socket",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/api","googleapis/api/annotations","googleapis/api/label","googleapis/api/metric","googleapis/api/monitoredres","googleapis/api/serviceconfig","googleapis/bigtable/admin/v2","googleapis/bigtable/v2","googleapis/longrunning","googleapis/rpc/status","protobuf/api","protobuf/ptype","protobuf/source_context"]
+  packages = [
+    "googleapis/api",
+    "googleapis/api/annotations",
+    "googleapis/api/label",
+    "googleapis/api/metric",
+    "googleapis/api/monitoredres",
+    "googleapis/api/serviceconfig",
+    "googleapis/bigtable/admin/v2",
+    "googleapis/bigtable/v2",
+    "googleapis/longrunning",
+    "googleapis/rpc/status",
+    "protobuf/api",
+    "protobuf/ptype",
+    "protobuf/source_context"
+  ]
   revision = "d80a6e20e776b0b17a324d0ba1ab50a39c8e8944"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","credentials/oauth","encoding","encoding/gzip","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/oauth",
+    "encoding",
+    "encoding/gzip",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "7cea4cc846bcf00cbb27595b07da5de875ef7de9"
   version = "v1.9.1"
 
@@ -726,17 +1059,134 @@
 
 [[projects]]
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/openapi","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apimachinery",
+    "pkg/apimachinery/announced",
+    "pkg/apimachinery/registered",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/openapi",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/rand",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/apps/v1beta1","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/api","pkg/api/install","pkg/api/v1","pkg/apis/apps","pkg/apis/apps/install","pkg/apis/apps/v1beta1","pkg/apis/authentication","pkg/apis/authentication/install","pkg/apis/authentication/v1","pkg/apis/authentication/v1beta1","pkg/apis/authorization","pkg/apis/authorization/install","pkg/apis/authorization/v1","pkg/apis/authorization/v1beta1","pkg/apis/autoscaling","pkg/apis/autoscaling/install","pkg/apis/autoscaling/v1","pkg/apis/autoscaling/v2alpha1","pkg/apis/batch","pkg/apis/batch/install","pkg/apis/batch/v1","pkg/apis/batch/v2alpha1","pkg/apis/certificates","pkg/apis/certificates/install","pkg/apis/certificates/v1beta1","pkg/apis/extensions","pkg/apis/extensions/install","pkg/apis/extensions/v1beta1","pkg/apis/policy","pkg/apis/policy/install","pkg/apis/policy/v1beta1","pkg/apis/rbac","pkg/apis/rbac/install","pkg/apis/rbac/v1alpha1","pkg/apis/rbac/v1beta1","pkg/apis/settings","pkg/apis/settings/install","pkg/apis/settings/v1alpha1","pkg/apis/storage","pkg/apis/storage/install","pkg/apis/storage/v1","pkg/apis/storage/v1beta1","pkg/util","pkg/util/parsers","pkg/version","rest","rest/watch","tools/cache","tools/clientcmd/api","tools/metrics","transport","util/cert","util/clock","util/flowcontrol","util/integer"]
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2alpha1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/api",
+    "pkg/api/install",
+    "pkg/api/v1",
+    "pkg/apis/apps",
+    "pkg/apis/apps/install",
+    "pkg/apis/apps/v1beta1",
+    "pkg/apis/authentication",
+    "pkg/apis/authentication/install",
+    "pkg/apis/authentication/v1",
+    "pkg/apis/authentication/v1beta1",
+    "pkg/apis/authorization",
+    "pkg/apis/authorization/install",
+    "pkg/apis/authorization/v1",
+    "pkg/apis/authorization/v1beta1",
+    "pkg/apis/autoscaling",
+    "pkg/apis/autoscaling/install",
+    "pkg/apis/autoscaling/v1",
+    "pkg/apis/autoscaling/v2alpha1",
+    "pkg/apis/batch",
+    "pkg/apis/batch/install",
+    "pkg/apis/batch/v1",
+    "pkg/apis/batch/v2alpha1",
+    "pkg/apis/certificates",
+    "pkg/apis/certificates/install",
+    "pkg/apis/certificates/v1beta1",
+    "pkg/apis/extensions",
+    "pkg/apis/extensions/install",
+    "pkg/apis/extensions/v1beta1",
+    "pkg/apis/policy",
+    "pkg/apis/policy/install",
+    "pkg/apis/policy/v1beta1",
+    "pkg/apis/rbac",
+    "pkg/apis/rbac/install",
+    "pkg/apis/rbac/v1alpha1",
+    "pkg/apis/rbac/v1beta1",
+    "pkg/apis/settings",
+    "pkg/apis/settings/install",
+    "pkg/apis/settings/v1alpha1",
+    "pkg/apis/storage",
+    "pkg/apis/storage/install",
+    "pkg/apis/storage/v1",
+    "pkg/apis/storage/v1beta1",
+    "pkg/util",
+    "pkg/util/parsers",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "tools/cache",
+    "tools/clientcmd/api",
+    "tools/metrics",
+    "transport",
+    "util/cert",
+    "util/clock",
+    "util/flowcontrol",
+    "util/integer"
+  ]
   revision = "3627aeb7d4f6ade38f995d2c923e459146493c7e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "23b73edaa4ea0ed9b8e7c878185344e5af5c75d1b46c8a3f26acdd71048a5a66"
+  inputs-digest = "1a7b72b8cd8bbdba3daf41afa0d8aa484a0fcc6fd06a579ee4588265b20e261c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,6 +10,10 @@
   name = "github.com/weaveworks/promrus"
   version = "v1.1.0-legacy"
 
+[[constraint]]
+  name = "github.com/prometheus/prometheus"
+  revision = "a730083cbfbb76e05244f82de0bc4146cb5f79ab"
+
 [[override]]
   name = "k8s.io/client-go"
   revision = "3627aeb7d4f6ade38f995d2c923e459146493c7e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/prometheus/prometheus"
-  revision = "a730083cbfbb76e05244f82de0bc4146cb5f79ab"
+  branch = "master"
 
 [[override]]
   name = "k8s.io/client-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,6 +10,11 @@
   name = "github.com/weaveworks/promrus"
   version = "v1.1.0-legacy"
 
+# Since Cortex is heavily based on Prometheus packages, we want
+# to track upstream master quite closely, without being constrained
+# to the latest Prometheus release. This means we get various bug
+# fixes and features earlier, and makes necessary refactorings upon
+# vendor updates less huge (if updated frequently).
 [[constraint]]
   name = "github.com/prometheus/prometheus"
   branch = "master"

--- a/pkg/querier/dummy.go
+++ b/pkg/querier/dummy.go
@@ -3,14 +3,14 @@ package querier
 import (
 	"net/url"
 
-	"github.com/prometheus/prometheus/retrieval"
+	"github.com/prometheus/prometheus/scrape"
 )
 
 // DummyTargetRetriever implements TargetRetriever.
 type DummyTargetRetriever struct{}
 
 // Targets implements TargetRetriever.
-func (r DummyTargetRetriever) Targets() []*retrieval.Target { return nil }
+func (r DummyTargetRetriever) Targets() []*scrape.Target { return nil }
 
 // DummyAlertmanagerRetriever implements AlertmanagerRetriever.
 type DummyAlertmanagerRetriever struct{}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -120,12 +120,11 @@ type Ruler struct {
 	notifiers    map[string]*rulerNotifier
 }
 
-// rulerNotifier bundles a notifer.Notifier together with an associated
+// rulerNotifier bundles a notifier.Manager together with an associated
 // Alertmanager service discovery manager and handles the lifecycle
 // of both actors.
 type rulerNotifier struct {
-	notifier  *notifier.Notifier
-	sdCtx     context.Context
+	notifier  *notifier.Manager
 	sdCancel  context.CancelFunc
 	sdManager *discovery.Manager
 	wg        sync.WaitGroup
@@ -133,12 +132,11 @@ type rulerNotifier struct {
 }
 
 func newRulerNotifier(o *notifier.Options, l gklog.Logger) *rulerNotifier {
-	ctx, cancel := context.WithCancel(context.Background())
+	sdCtx, sdCancel := context.WithCancel(context.Background())
 	return &rulerNotifier{
-		notifier:  notifier.New(o, l),
-		sdCtx:     ctx,
-		sdCancel:  cancel,
-		sdManager: discovery.NewManager(l),
+		notifier:  notifier.NewManager(o, l),
+		sdCancel:  sdCancel,
+		sdManager: discovery.NewManager(sdCtx, l),
 		logger:    l,
 	}
 }
@@ -146,7 +144,7 @@ func newRulerNotifier(o *notifier.Options, l gklog.Logger) *rulerNotifier {
 func (rn *rulerNotifier) run() {
 	rn.wg.Add(2)
 	go func() {
-		if err := rn.sdManager.Run(rn.sdCtx); err != nil {
+		if err := rn.sdManager.Run(); err != nil {
 			level.Error(rn.logger).Log("msg", "error starting notifier discovery manager", "err", err)
 		}
 		rn.wg.Done()
@@ -290,7 +288,7 @@ func (r *Ruler) newGroup(ctx context.Context, rs []rules.Rule) (*rules.Group, er
 // It filters any non-firing alerts from the input.
 //
 // Copied from Prometheus's main.go.
-func sendAlerts(n *notifier.Notifier, externalURL string) rules.NotifyFunc {
+func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
 	return func(ctx native_ctx.Context, expr string, alerts ...*rules.Alert) error {
 		var res []*notifier.Alert
 
@@ -318,7 +316,7 @@ func sendAlerts(n *notifier.Notifier, externalURL string) rules.NotifyFunc {
 	}
 }
 
-func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Notifier, error) {
+func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Manager, error) {
 	r.notifiersMtx.Lock()
 	defer r.notifiersMtx.Unlock()
 

--- a/vendor/github.com/prometheus/prometheus/README.md
+++ b/vendor/github.com/prometheus/prometheus/README.md
@@ -4,6 +4,7 @@
 [![Docker Repository on Quay](https://quay.io/repository/prometheus/prometheus/status)][quay]
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/prometheus.svg?maxAge=604800)][hub]
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/prometheus)](https://goreportcard.com/report/github.com/prometheus/prometheus)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/486/badge)](https://bestpractices.coreinfrastructure.org/projects/486)
 
 Visit [prometheus.io](https://prometheus.io) for the full documentation,
 examples and guides.

--- a/vendor/github.com/prometheus/prometheus/discovery/README.md
+++ b/vendor/github.com/prometheus/prometheus/discovery/README.md
@@ -140,7 +140,9 @@ type Discoverer interface {
 }
 ```
 
-Prometheus will call the `Run()` method on a provider to initialise the discovery mechanism. The mechanism will then send *all* the `TargetGroup`s into the channel. Now the mechanism will watch for changes and then send only changed and new `TargetGroup`s down the channel.
+Prometheus will call the `Run()` method on a provider to initialise the discovery mechanism. The mechanism will then send *all* the `TargetGroup`s into the channel. 
+Now the mechanism will watch for changes. For each update it can send all `TargetGroup`s, or only changed and new `TargetGroup`s, down the channel. `Manager` will handle 
+both cases.
 
 For example if we had a discovery mechanism and it retrieves the following groups:
 

--- a/vendor/github.com/prometheus/prometheus/discovery/consul/consul.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/consul/consul.go
@@ -82,12 +82,13 @@ var (
 	DefaultSDConfig = SDConfig{
 		TagSeparator: ",",
 		Scheme:       "http",
+		Server:       "localhost:8500",
 	}
 )
 
 // SDConfig is the configuration for Consul service discovery.
 type SDConfig struct {
-	Server       string             `yaml:"server"`
+	Server       string             `yaml:"server,omitempty"`
 	Token        config_util.Secret `yaml:"token,omitempty"`
 	Datacenter   string             `yaml:"datacenter,omitempty"`
 	TagSeparator string             `yaml:"tag_separator,omitempty"`

--- a/vendor/github.com/prometheus/prometheus/discovery/file/file.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/file/file.go
@@ -96,9 +96,11 @@ func (t *TimestampCollector) Collect(ch chan<- prometheus.Metric) {
 	uniqueFiles := make(map[string]float64)
 	t.lock.RLock()
 	for fileSD := range t.discoverers {
+		fileSD.lock.RLock()
 		for filename, timestamp := range fileSD.timestamps {
 			uniqueFiles[filename] = timestamp
 		}
+		fileSD.lock.RUnlock()
 	}
 	t.lock.RUnlock()
 	for filename, timestamp := range uniqueFiles {
@@ -127,7 +129,7 @@ func (t *TimestampCollector) removeDiscoverer(disc *Discovery) {
 func NewTimestampCollector() *TimestampCollector {
 	return &TimestampCollector{
 		Description: prometheus.NewDesc(
-			"prometheus_sd_file_timestamp",
+			"prometheus_sd_file_mtime_seconds",
 			"Timestamp (mtime) of files read by FileSD. Timestamp is set at read time.",
 			[]string{"filename"},
 			nil,
@@ -387,7 +389,7 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	default:
-		panic(fmt.Errorf("retrieval.FileDiscovery.readFile: unhandled file extension %q", ext))
+		panic(fmt.Errorf("discovery.File.readFile: unhandled file extension %q", ext))
 	}
 
 	for i, tg := range targetGroups {

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpoints.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/endpoints.go
@@ -185,10 +185,6 @@ const (
 )
 
 func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
-	if len(eps.Subsets) == 0 {
-		return nil
-	}
-
 	tg := &targetgroup.Group{
 		Source: endpointsSource(eps),
 	}

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/node.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/node.go
@@ -60,6 +60,9 @@ func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 
 	// Send target groups for service updates.
 	send := func(tg *targetgroup.Group) {
+		if tg == nil {
+			return
+		}
 		select {
 		case <-ctx.Done():
 		case ch <- []*targetgroup.Group{tg}:

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
@@ -68,6 +68,9 @@ func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 
 	// Send target groups for pod updates.
 	send := func(tg *targetgroup.Group) {
+		if tg == nil {
+			return
+		}
 		level.Debug(p.logger).Log("msg", "pod update", "tg", fmt.Sprintf("%#v", tg))
 		select {
 		case <-ctx.Done():

--- a/vendor/github.com/prometheus/prometheus/discovery/manager.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/manager.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -59,13 +60,13 @@ type poolKey struct {
 }
 
 // NewManager is the Discovery Manager constructor
-func NewManager(logger log.Logger) *Manager {
+func NewManager(ctx context.Context, logger log.Logger) *Manager {
 	return &Manager{
 		logger:         logger,
 		syncCh:         make(chan map[string][]*targetgroup.Group),
 		targets:        make(map[poolKey]map[string]*targetgroup.Group),
 		discoverCancel: []context.CancelFunc{},
-		ctx:            context.Background(),
+		ctx:            ctx,
 	}
 }
 
@@ -81,16 +82,19 @@ type Manager struct {
 	targets map[poolKey]map[string]*targetgroup.Group
 	// The sync channels sends the updates in map[targetSetName] where targetSetName is the job value from the scrape config.
 	syncCh chan map[string][]*targetgroup.Group
+	// True if updates were received in the last 5 seconds.
+	recentlyUpdated bool
+	// Protects recentlyUpdated.
+	recentlyUpdatedMtx sync.Mutex
 }
 
 // Run starts the background processing
-func (m *Manager) Run(ctx context.Context) error {
-	m.ctx = ctx
+func (m *Manager) Run() error {
 	for {
 		select {
-		case <-ctx.Done():
+		case <-m.ctx.Done():
 			m.cancelDiscoverers()
-			return ctx.Err()
+			return m.ctx.Err()
 		}
 	}
 }
@@ -123,6 +127,7 @@ func (m *Manager) startProvider(ctx context.Context, poolKey poolKey, worker Dis
 
 	go worker.Run(ctx, updates)
 	go m.runProvider(ctx, poolKey, updates)
+	go m.runUpdater(ctx)
 }
 
 func (m *Manager) runProvider(ctx context.Context, poolKey poolKey, updates chan []*targetgroup.Group) {
@@ -137,7 +142,28 @@ func (m *Manager) runProvider(ctx context.Context, poolKey poolKey, updates chan
 				return
 			}
 			m.updateGroup(poolKey, tgs)
-			m.syncCh <- m.allGroups()
+			m.recentlyUpdatedMtx.Lock()
+			m.recentlyUpdated = true
+			m.recentlyUpdatedMtx.Unlock()
+		}
+	}
+}
+
+func (m *Manager) runUpdater(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.recentlyUpdatedMtx.Lock()
+			if m.recentlyUpdated {
+				m.syncCh <- m.allGroups()
+				m.recentlyUpdated = false
+			}
+			m.recentlyUpdatedMtx.Unlock()
 		}
 	}
 }

--- a/vendor/github.com/prometheus/prometheus/notifier/notifier_test.go
+++ b/vendor/github.com/prometheus/prometheus/notifier/notifier_test.go
@@ -71,7 +71,7 @@ func TestPostPath(t *testing.T) {
 }
 
 func TestHandlerNextBatch(t *testing.T) {
-	h := New(&Options{}, nil)
+	h := NewManager(&Options{}, nil)
 
 	for i := range make([]struct{}, 2*maxBatchSize+1) {
 		h.queue = append(h.queue, &Alert{
@@ -168,7 +168,7 @@ func TestHandlerSendAll(t *testing.T) {
 	defer server1.Close()
 	defer server2.Close()
 
-	h := New(&Options{}, nil)
+	h := NewManager(&Options{}, nil)
 
 	authClient, _ := httputil.NewClientFromConfig(config_util.HTTPClientConfig{
 		BasicAuth: &config_util.BasicAuth{
@@ -233,7 +233,7 @@ func TestCustomDo(t *testing.T) {
 	const testBody = "testbody"
 
 	var received bool
-	h := New(&Options{
+	h := NewManager(&Options{
 		Do: func(ctx old_ctx.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 			received = true
 			body, err := ioutil.ReadAll(req.Body)
@@ -260,7 +260,7 @@ func TestCustomDo(t *testing.T) {
 }
 
 func TestExternalLabels(t *testing.T) {
-	h := New(&Options{
+	h := NewManager(&Options{
 		QueueCapacity:  3 * maxBatchSize,
 		ExternalLabels: model.LabelSet{"a": "b"},
 		RelabelConfigs: []*config.RelabelConfig{
@@ -296,7 +296,7 @@ func TestExternalLabels(t *testing.T) {
 }
 
 func TestHandlerRelabel(t *testing.T) {
-	h := New(&Options{
+	h := NewManager(&Options{
 		QueueCapacity: 3 * maxBatchSize,
 		RelabelConfigs: []*config.RelabelConfig{
 			{
@@ -356,7 +356,7 @@ func TestHandlerQueueing(t *testing.T) {
 		}
 	}))
 
-	h := New(&Options{
+	h := NewManager(&Options{
 		QueueCapacity: 3 * maxBatchSize,
 	},
 		nil,
@@ -469,7 +469,7 @@ func TestReload(t *testing.T) {
 		},
 	}
 
-	n := New(&Options{}, nil)
+	n := NewManager(&Options{}, nil)
 
 	cfg := &config.Config{}
 	s := `

--- a/vendor/github.com/prometheus/prometheus/pkg/relabel/relabel.go
+++ b/vendor/github.com/prometheus/prometheus/pkg/relabel/relabel.go
@@ -96,7 +96,7 @@ func relabel(lset labels.Labels, cfg *config.RelabelConfig) labels.Labels {
 			}
 		}
 	default:
-		panic(fmt.Errorf("retrieval.relabel: unknown relabel action type %q", cfg.Action))
+		panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
 	}
 
 	return lb.Labels()

--- a/vendor/github.com/prometheus/prometheus/pkg/rulefmt/rulefmt.go
+++ b/vendor/github.com/prometheus/prometheus/pkg/rulefmt/rulefmt.go
@@ -174,15 +174,20 @@ func checkOverflow(m map[string]interface{}, ctx string) error {
 	return nil
 }
 
-// ParseFile parses the rule file and validates it.
+// Parse parses and validates a set of rules.
+func Parse(content []byte) (*RuleGroups, []error) {
+	var groups RuleGroups
+	if err := yaml.Unmarshal(content, &groups); err != nil {
+		return nil, []error{err}
+	}
+	return &groups, groups.Validate()
+}
+
+// ParseFile reads and parses rules from a file.
 func ParseFile(file string) (*RuleGroups, []error) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, []error{err}
 	}
-	var groups RuleGroups
-	if err := yaml.Unmarshal(b, &groups); err != nil {
-		return nil, []error{err}
-	}
-	return &groups, groups.Validate()
+	return Parse(b)
 }

--- a/vendor/github.com/prometheus/prometheus/promql/functions.go
+++ b/vendor/github.com/prometheus/prometheus/promql/functions.go
@@ -38,7 +38,7 @@ type Function struct {
 // === time() float64 ===
 func funcTime(ev *evaluator, args Expressions) Value {
 	return Scalar{
-		V: float64(ev.Timestamp / 1000),
+		V: float64(ev.Timestamp) / 1000,
 		T: ev.Timestamp,
 	}
 }

--- a/vendor/github.com/prometheus/prometheus/promql/printer.go
+++ b/vendor/github.com/prometheus/prometheus/promql/printer.go
@@ -134,43 +134,45 @@ func (es Expressions) String() (s string) {
 }
 
 func (node *AggregateExpr) String() string {
-	aggrString := fmt.Sprintf("%s(", node.Op)
+	aggrString := node.Op.String()
+
+	if node.Without {
+		aggrString += fmt.Sprintf(" without(%s) ", strings.Join(node.Grouping, ", "))
+	} else {
+		if len(node.Grouping) > 0 {
+			aggrString += fmt.Sprintf(" by(%s) ", strings.Join(node.Grouping, ", "))
+		}
+	}
+
+	aggrString += "("
 	if node.Op.isAggregatorWithParam() {
 		aggrString += fmt.Sprintf("%s, ", node.Param)
 	}
 	aggrString += fmt.Sprintf("%s)", node.Expr)
-	if len(node.Grouping) > 0 {
-		var format string
-		if node.Without {
-			format = "%s WITHOUT (%s)"
-		} else {
-			format = "%s BY (%s)"
-		}
-		aggrString = fmt.Sprintf(format, aggrString, strings.Join(node.Grouping, ", "))
-	}
+
 	return aggrString
 }
 
 func (node *BinaryExpr) String() string {
 	returnBool := ""
 	if node.ReturnBool {
-		returnBool = " BOOL"
+		returnBool = " bool"
 	}
 
 	matching := ""
 	vm := node.VectorMatching
 	if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) {
 		if vm.On {
-			matching = fmt.Sprintf(" ON(%s)", strings.Join(vm.MatchingLabels, ", "))
+			matching = fmt.Sprintf(" on(%s)", strings.Join(vm.MatchingLabels, ", "))
 		} else {
-			matching = fmt.Sprintf(" IGNORING(%s)", strings.Join(vm.MatchingLabels, ", "))
+			matching = fmt.Sprintf(" ignoring(%s)", strings.Join(vm.MatchingLabels, ", "))
 		}
 		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
-			matching += " GROUP_"
+			matching += " group_"
 			if vm.Card == CardManyToOne {
-				matching += "LEFT"
+				matching += "left"
 			} else {
-				matching += "RIGHT"
+				matching += "right"
 			}
 			matching += fmt.Sprintf("(%s)", strings.Join(vm.Include, ", "))
 		}
@@ -189,7 +191,7 @@ func (node *MatrixSelector) String() string {
 	}
 	offset := ""
 	if node.Offset != time.Duration(0) {
-		offset = fmt.Sprintf(" OFFSET %s", model.Duration(node.Offset))
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
 	}
 	return fmt.Sprintf("%s[%s]%s", vecSelector.String(), model.Duration(node.Range), offset)
 }
@@ -221,7 +223,7 @@ func (node *VectorSelector) String() string {
 	}
 	offset := ""
 	if node.Offset != time.Duration(0) {
-		offset = fmt.Sprintf(" OFFSET %s", model.Duration(node.Offset))
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
 	}
 
 	if len(labelStrings) == 0 {

--- a/vendor/github.com/prometheus/prometheus/promql/printer_test.go
+++ b/vendor/github.com/prometheus/prometheus/promql/printer_test.go
@@ -57,14 +57,17 @@ func TestExprString(t *testing.T) {
 		in, out string
 	}{
 		{
-			in:  `sum(task:errors:rate10s{job="s"}) BY ()`,
+			in:  `sum by() (task:errors:rate10s{job="s"})`,
 			out: `sum(task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum(task:errors:rate10s{job="s"}) BY (code)`,
+			in: `sum by(code) (task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `sum(task:errors:rate10s{job="s"}) WITHOUT (instance)`,
+			in: `sum without() (task:errors:rate10s{job="s"})`,
+		},
+		{
+			in: `sum without(instance) (task:errors:rate10s{job="s"})`,
 		},
 		{
 			in: `topk(5, task:errors:rate10s{job="s"})`,
@@ -73,42 +76,42 @@ func TestExprString(t *testing.T) {
 			in: `count_values("value", task:errors:rate10s{job="s"})`,
 		},
 		{
-			in: `a - ON() c`,
+			in: `a - on() c`,
 		},
 		{
-			in: `a - ON(b) c`,
+			in: `a - on(b) c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT(x) c`,
+			in: `a - on(b) group_left(x) c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT(x, y) c`,
+			in: `a - on(b) group_left(x, y) c`,
 		},
 		{
-			in:  `a - ON(b) GROUP_LEFT c`,
-			out: `a - ON(b) GROUP_LEFT() c`,
+			in:  `a - on(b) group_left c`,
+			out: `a - on(b) group_left() c`,
 		},
 		{
-			in: `a - ON(b) GROUP_LEFT() (c)`,
+			in: `a - on(b) group_left() (c)`,
 		},
 		{
-			in: `a - IGNORING(b) c`,
+			in: `a - ignoring(b) c`,
 		},
 		{
-			in:  `a - IGNORING() c`,
+			in:  `a - ignoring() c`,
 			out: `a - c`,
 		},
 		{
-			in: `up > BOOL 0`,
+			in: `up > bool 0`,
 		},
 		{
-			in: `a OFFSET 1m`,
+			in: `a offset 1m`,
 		},
 		{
-			in: `a{c="d"}[5m] OFFSET 1m`,
+			in: `a{c="d"}[5m] offset 1m`,
 		},
 		{
-			in: `a[5m] OFFSET 1m`,
+			in: `a[5m] offset 1m`,
 		},
 	}
 

--- a/vendor/github.com/prometheus/prometheus/relabel/relabel.go
+++ b/vendor/github.com/prometheus/prometheus/relabel/relabel.go
@@ -99,7 +99,7 @@ func relabel(labels model.LabelSet, cfg *config.RelabelConfig) model.LabelSet {
 			}
 		}
 	default:
-		panic(fmt.Errorf("retrieval.relabel: unknown relabel action type %q", cfg.Action))
+		panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
 	}
 	return labels
 }

--- a/vendor/github.com/prometheus/prometheus/rules/alerting.go
+++ b/vendor/github.com/prometheus/prometheus/rules/alerting.go
@@ -266,7 +266,6 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 			if a.State != StateInactive {
 				a.State = StateInactive
 				a.ResolvedAt = ts
-				a.FiredAt = time.Time{}
 			}
 			continue
 		}

--- a/vendor/github.com/prometheus/prometheus/scrape/helpers_test.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/helpers_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package scrape
 
 import (
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package scrape
 
 import (
 	"bufio"

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -301,6 +301,10 @@ func (sp *scrapePool) sync(targets []*Target) {
 			sp.loops[hash] = l
 
 			go l.run(interval, timeout, nil)
+		} else {
+			// Need to keep the most updated labels information
+			// for displaying it in the Service Discovery web page.
+			sp.targets[hash].SetDiscoveredLabels(t.DiscoveredLabels())
 		}
 	}
 

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape_test.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package scrape
 
 import (
 	"bytes"
@@ -699,7 +699,7 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	}
 	value := metric.GetCounter().GetValue()
 	if (value - beforeMetricValue) != 1 {
-		t.Fatal("Unexpected change of sample limit metric: %f", (value - beforeMetricValue))
+		t.Fatalf("Unexpected change of sample limit metric: %f", (value - beforeMetricValue))
 	}
 
 	// And verify that we got the samples that fit under the limit.

--- a/vendor/github.com/prometheus/prometheus/scrape/target.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/target.go
@@ -115,6 +115,11 @@ func (t *Target) DiscoveredLabels() labels.Labels {
 	return lset
 }
 
+// SetDiscoveredLabels sets new DiscoveredLabels
+func (t *Target) SetDiscoveredLabels(l labels.Labels) {
+	t.discoveredLabels = l
+}
+
 // URL returns a copy of the target's URL.
 func (t *Target) URL() *url.URL {
 	params := url.Values{}

--- a/vendor/github.com/prometheus/prometheus/scrape/target.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/target.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package scrape
 
 import (
 	"errors"

--- a/vendor/github.com/prometheus/prometheus/scrape/target_test.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/target_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package retrieval
+package scrape
 
 import (
 	"crypto/tls"

--- a/vendor/github.com/prometheus/prometheus/storage/buffer_test.go
+++ b/vendor/github.com/prometheus/prometheus/storage/buffer_test.go
@@ -201,6 +201,17 @@ type mockSeries struct {
 	iterator func() SeriesIterator
 }
 
+func newMockSeries(lset labels.Labels, samples []sample) Series {
+	return &mockSeries{
+		labels: func() labels.Labels {
+			return lset
+		},
+		iterator: func() SeriesIterator {
+			return newListSeriesIterator(samples)
+		},
+	}
+}
+
 func (m *mockSeries) Labels() labels.Labels    { return m.labels() }
 func (m *mockSeries) Iterator() SeriesIterator { return m.iterator() }
 

--- a/vendor/github.com/prometheus/prometheus/storage/fanout.go
+++ b/vendor/github.com/prometheus/prometheus/storage/fanout.go
@@ -303,6 +303,10 @@ type mergeSeriesSet struct {
 // NewMergeSeriesSet returns a new series set that merges (deduplicates)
 // series returned by the input series sets when iterating.
 func NewMergeSeriesSet(sets []SeriesSet) SeriesSet {
+	if len(sets) == 1 {
+		return sets[0]
+	}
+
 	// Sets need to be pre-advanced, so we can introspect the label of the
 	// series under the cursor.
 	var h seriesSetHeap
@@ -340,6 +344,9 @@ func (c *mergeSeriesSet) Next() bool {
 }
 
 func (c *mergeSeriesSet) At() Series {
+	if len(c.currentSets) == 1 {
+		return c.currentSets[0].At()
+	}
 	series := []Series{}
 	for _, seriesSet := range c.currentSets {
 		series = append(series, seriesSet.At())

--- a/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
@@ -430,6 +430,8 @@ func (s *shards) runShard(i int) {
 	// anyways.
 	pendingSamples := model.Samples{}
 
+	timer := time.NewTimer(s.qm.cfg.BatchSendDeadline)
+
 	for {
 		select {
 		case sample, ok := <-queue:
@@ -449,7 +451,11 @@ func (s *shards) runShard(i int) {
 				s.sendSamples(pendingSamples[:s.qm.cfg.MaxSamplesPerSend])
 				pendingSamples = pendingSamples[s.qm.cfg.MaxSamplesPerSend:]
 			}
-		case <-time.After(s.qm.cfg.BatchSendDeadline):
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(s.qm.cfg.BatchSendDeadline)
+		case <-timer.C:
 			if len(pendingSamples) > 0 {
 				s.sendSamples(pendingSamples)
 				pendingSamples = pendingSamples[:0]

--- a/vendor/github.com/prometheus/prometheus/storage/remote/write.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/write.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-// Appender implements retrieval.Appendable.
+// Appender implements scrape.Appendable.
 func (s *Storage) Appender() (storage.Appender, error) {
 	return s, nil
 }

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
@@ -38,7 +38,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/retrieval"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/util/httputil"
@@ -82,7 +82,7 @@ func (e *apiError) Error() string {
 }
 
 type targetRetriever interface {
-	Targets() []*retrieval.Target
+	Targets() []*scrape.Target
 }
 
 type alertmanagerRetriever interface {
@@ -428,9 +428,9 @@ type Target struct {
 
 	ScrapeURL string `json:"scrapeUrl"`
 
-	LastError  string                 `json:"lastError"`
-	LastScrape time.Time              `json:"lastScrape"`
-	Health     retrieval.TargetHealth `json:"health"`
+	LastError  string              `json:"lastError"`
+	LastScrape time.Time           `json:"lastScrape"`
+	Health     scrape.TargetHealth `json:"health"`
 }
 
 // TargetDiscovery has all the active targets.

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api_test.go
@@ -38,13 +38,13 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/retrieval"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage/remote"
 )
 
-type targetRetrieverFunc func() []*retrieval.Target
+type targetRetrieverFunc func() []*scrape.Target
 
-func (f targetRetrieverFunc) Targets() []*retrieval.Target {
+func (f targetRetrieverFunc) Targets() []*scrape.Target {
 	return f()
 }
 
@@ -81,9 +81,9 @@ func TestEndpoints(t *testing.T) {
 
 	now := time.Now()
 
-	tr := targetRetrieverFunc(func() []*retrieval.Target {
-		return []*retrieval.Target{
-			retrieval.NewTarget(
+	tr := targetRetrieverFunc(func() []*scrape.Target {
+		return []*scrape.Target{
+			scrape.NewTarget(
 				labels.FromMap(map[string]string{
 					model.SchemeLabel:      "http",
 					model.AddressLabel:     "example.com:8080",

--- a/vendor/github.com/prometheus/prometheus/web/web.go
+++ b/vendor/github.com/prometheus/prometheus/web/web.go
@@ -55,8 +55,8 @@ import (
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/retrieval"
 	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/template"
 	"github.com/prometheus/prometheus/util/httputil"
@@ -71,13 +71,13 @@ var localhostRepresentations = []string{"127.0.0.1", "localhost"}
 type Handler struct {
 	logger log.Logger
 
-	scrapeManager *retrieval.ScrapeManager
+	scrapeManager *scrape.Manager
 	ruleManager   *rules.Manager
 	queryEngine   *promql.Engine
 	context       context.Context
 	tsdb          func() *tsdb.DB
 	storage       storage.Storage
-	notifier      *notifier.Notifier
+	notifier      *notifier.Manager
 
 	apiV1 *api_v1.API
 
@@ -125,9 +125,9 @@ type Options struct {
 	TSDB          func() *tsdb.DB
 	Storage       storage.Storage
 	QueryEngine   *promql.Engine
-	ScrapeManager *retrieval.ScrapeManager
+	ScrapeManager *scrape.Manager
 	RuleManager   *rules.Manager
-	Notifier      *notifier.Notifier
+	Notifier      *notifier.Manager
 	Version       *PrometheusVersion
 	Flags         map[string]string
 
@@ -404,7 +404,7 @@ func (h *Handler) Run(ctx context.Context) error {
 		h.options.TSDB,
 		h.options.QueryEngine,
 		h.options.Storage.Querier,
-		func() []*retrieval.Target {
+		func() []*scrape.Target {
 			return h.options.ScrapeManager.Targets()
 		},
 		func() []*url.URL {
@@ -594,7 +594,7 @@ func (h *Handler) serviceDiscovery(w http.ResponseWriter, r *http.Request) {
 	sort.Strings(index)
 	scrapeConfigData := struct {
 		Index   []string
-		Targets map[string][]*retrieval.Target
+		Targets map[string][]*scrape.Target
 	}{
 		Index:   index,
 		Targets: targets,
@@ -604,7 +604,7 @@ func (h *Handler) serviceDiscovery(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) targets(w http.ResponseWriter, r *http.Request) {
 	// Bucket targets by job label
-	tps := map[string][]*retrieval.Target{}
+	tps := map[string][]*scrape.Target{}
 	for _, t := range h.scrapeManager.Targets() {
 		job := t.Labels().Get(model.JobLabel)
 		tps[job] = append(tps[job], t)
@@ -617,7 +617,7 @@ func (h *Handler) targets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.executeTemplate(w, "targets.html", struct {
-		TargetPools map[string][]*retrieval.Target
+		TargetPools map[string][]*scrape.Target
 	}{
 		TargetPools: tps,
 	})
@@ -707,21 +707,21 @@ func tmplFuncs(consolesPath string, opts *Options) template_text.FuncMap {
 			}
 			return u
 		},
-		"numHealthy": func(pool []*retrieval.Target) int {
+		"numHealthy": func(pool []*scrape.Target) int {
 			alive := len(pool)
 			for _, p := range pool {
-				if p.Health() != retrieval.HealthGood {
+				if p.Health() != scrape.HealthGood {
 					alive--
 				}
 			}
 
 			return alive
 		},
-		"healthToClass": func(th retrieval.TargetHealth) string {
+		"healthToClass": func(th scrape.TargetHealth) string {
 			switch th {
-			case retrieval.HealthUnknown:
+			case scrape.HealthUnknown:
 				return "warning"
-			case retrieval.HealthGood:
+			case scrape.HealthGood:
 				return "success"
 			default:
 				return "danger"


### PR DESCRIPTION
@jml One more little Prometheus vendoring update. Due to `dep` behavior that I didn't understand previously (it will only update to tagged releases by default), it didn't update all the way to the version I needed in the last PR. But it's good to continuously keep up with upstream anyway :)