### PR TITLE
Move SchemaConfig.MaxChunkAge to NewTableManager()

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -40,7 +40,6 @@ func main() {
 		&schemaConfig, &ingesterConfig, &logLevel)
 	flag.UintVar(&maxStreams, "ingester.max-concurrent-streams", 1000, "Limit on the number of concurrent streams for gRPC calls (0 = unlimited)")
 	flag.Parse()
-	schemaConfig.MaxChunkAge = ingesterConfig.MaxChunkAge
 
 	util.InitLogger(logLevel.AllowedLevel)
 

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -57,7 +57,6 @@ func main() {
 		&ingesterConfig, &configStoreConfig, &rulerConfig, &storageConfig, &schemaConfig, &logLevel)
 	flag.BoolVar(&unauthenticated, "unauthenticated", false, "Set to true to disable multitenancy.")
 	flag.Parse()
-	schemaConfig.MaxChunkAge = ingesterConfig.MaxChunkAge
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
@@ -116,7 +115,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tableManager, err := chunk.NewTableManager(schemaConfig, tableClient)
+	tableManager, err := chunk.NewTableManager(schemaConfig, ingesterConfig.MaxChunkAge, tableClient)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing DynamoDB table manager", "err", err)
 		os.Exit(1)

--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/chunk/storage"
+	"github.com/weaveworks/cortex/pkg/ingester"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -23,11 +24,12 @@ func main() {
 			},
 		}
 
-		storageConfig storage.Config
-		schemaConfig  chunk.SchemaConfig
-		logLevel      util.LogLevel
+		ingesterConfig ingester.Config
+		storageConfig  storage.Config
+		schemaConfig   chunk.SchemaConfig
+		logLevel       util.LogLevel
 	)
-	util.RegisterFlags(&serverConfig, &storageConfig, &schemaConfig, &logLevel)
+	util.RegisterFlags(&ingesterConfig, &serverConfig, &storageConfig, &schemaConfig, &logLevel)
 	flag.Parse()
 
 	util.InitLogger(logLevel.AllowedLevel)
@@ -47,7 +49,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tableManager, err := chunk.NewTableManager(schemaConfig, tableClient)
+	tableManager, err := chunk.NewTableManager(schemaConfig, ingesterConfig.MaxChunkAge, tableClient)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error initializing DynamoDB table manager", "err", err)
 		os.Exit(1)

--- a/pkg/chunk/aws_storage_client_test.go
+++ b/pkg/chunk/aws_storage_client_test.go
@@ -499,6 +499,7 @@ func TestAWSStorageClientChunks(t *testing.T) {
 			}
 			tableManager, err := NewTableManager(
 				schemaConfig,
+				maxChunkAge,
 				&dynamoTableClient{
 					DynamoDB: dynamoDB,
 				},

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -25,7 +25,7 @@ import (
 func newTestChunkStore(t *testing.T, cfg StoreConfig) *Store {
 	storage := NewMockStorage()
 	schemaCfg := SchemaConfig{}
-	tableManager, err := NewTableManager(schemaCfg, storage)
+	tableManager, err := NewTableManager(schemaCfg, maxChunkAge, storage)
 	require.NoError(t, err)
 	err = tableManager.syncTables(context.Background())
 	require.NoError(t, err)

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -37,7 +37,6 @@ type SchemaConfig struct {
 
 	// duration a table will be created before it is needed.
 	CreationGracePeriod time.Duration
-	MaxChunkAge         time.Duration
 
 	// Config for the index & chunk tables.
 	OriginalTableName string

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -101,18 +101,20 @@ func (ts Tags) AWSTags() []*dynamodb.Tag {
 
 // TableManager creates and manages the provisioned throughput on DynamoDB tables
 type TableManager struct {
-	client TableClient
-	cfg    SchemaConfig
-	done   chan struct{}
-	wait   sync.WaitGroup
+	client      TableClient
+	cfg         SchemaConfig
+	maxChunkAge time.Duration
+	done        chan struct{}
+	wait        sync.WaitGroup
 }
 
 // NewTableManager makes a new TableManager
-func NewTableManager(cfg SchemaConfig, tableClient TableClient) (*TableManager, error) {
+func NewTableManager(cfg SchemaConfig, maxChunkAge time.Duration, tableClient TableClient) (*TableManager, error) {
 	return &TableManager{
-		cfg:    cfg,
-		client: tableClient,
-		done:   make(chan struct{}),
+		cfg:         cfg,
+		maxChunkAge: maxChunkAge,
+		client:      tableClient,
+		done:        make(chan struct{}),
 	}, nil
 }
 
@@ -187,7 +189,7 @@ func (m *TableManager) calculateExpectedTables() []TableDesc {
 		var (
 			tablePeriodSecs = int64(m.cfg.IndexTables.Period / time.Second)
 			gracePeriodSecs = int64(m.cfg.CreationGracePeriod / time.Second)
-			maxChunkAgeSecs = int64(m.cfg.MaxChunkAge / time.Second)
+			maxChunkAgeSecs = int64(m.maxChunkAge / time.Second)
 			firstTable      = m.cfg.IndexTables.From.Unix() / tablePeriodSecs
 			now             = mtime.Now().Unix()
 		)
@@ -205,13 +207,13 @@ func (m *TableManager) calculateExpectedTables() []TableDesc {
 
 	if m.cfg.UsePeriodicTables {
 		result = append(result, m.cfg.IndexTables.periodicTables(
-			m.cfg.CreationGracePeriod, m.cfg.MaxChunkAge,
+			m.cfg.CreationGracePeriod, m.maxChunkAge,
 		)...)
 	}
 
 	if m.cfg.ChunkTables.From.IsSet() {
 		result = append(result, m.cfg.ChunkTables.periodicTables(
-			m.cfg.CreationGracePeriod, m.cfg.MaxChunkAge,
+			m.cfg.CreationGracePeriod, m.maxChunkAge,
 		)...)
 	}
 

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -57,9 +57,8 @@ func TestTableManager(t *testing.T) {
 		},
 
 		CreationGracePeriod: gracePeriod,
-		MaxChunkAge:         maxChunkAge,
 	}
-	tableManager, err := NewTableManager(cfg, client)
+	tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +190,7 @@ func TestTableManagerTags(t *testing.T) {
 
 	// Check at time zero, we have the base table with no tags.
 	{
-		tableManager, err := NewTableManager(SchemaConfig{}, client)
+		tableManager, err := NewTableManager(SchemaConfig{}, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -210,7 +209,7 @@ func TestTableManagerTags(t *testing.T) {
 	{
 		cfg := SchemaConfig{}
 		cfg.IndexTables.Tags.Set("foo=bar")
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -372,12 +371,11 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		},
 
 		CreationGracePeriod: gracePeriod,
-		MaxChunkAge:         maxChunkAge,
 	}
 
 	// Check tables are created with autoscale
 	{
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -427,7 +425,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		cfg.IndexTables.WriteScale.OutCooldown = 200
 		cfg.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -477,7 +475,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		cfg.IndexTables.WriteScale.OutCooldown = 200
 		cfg.ChunkTables.WriteScale.TargetValue = 90.0
 
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -543,7 +541,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		cfg.IndexTables.WriteScale.Enabled = false
 		cfg.ChunkTables.WriteScale.Enabled = false
 
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -655,12 +653,11 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 		},
 
 		CreationGracePeriod: gracePeriod,
-		MaxChunkAge:         maxChunkAge,
 	}
 
 	// Check legacy and latest tables do not autoscale with inactive autoscale enabled.
 	{
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -691,7 +688,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables are autoscaled even if there are less than the limit.
 	{
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -748,7 +745,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 
 	// Check inactive tables past the limit do not autoscale but the latest N do.
 	{
-		tableManager, err := NewTableManager(cfg, client)
+		tableManager, err := NewTableManager(cfg, maxChunkAge, client)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Fixes #621 

`TableManager` uses `MaxChunkAge` to hold off scaling back the previous table, and in #583 this was moved to `ingester.Config` but not removed from the previous place.  Moving the value to a parameter means you can't forget to copy it from `ingester.Config` to `chunk.SchemaConfig`.

(We can't just pass `ingester.Config` in, because package `ingester` imports package `chunk`, so there would be a cycle)
