### PR TITLE
Don't run deleted rules

### DIFF
--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -100,3 +100,8 @@ type VersionedRulesConfig struct {
 	Config    RulesConfig `json:"config"`
 	DeletedAt time.Time   `json:"deleted_at"`
 }
+
+// IsDeleted tells you if the config is deleted.
+func (vr VersionedRulesConfig) IsDeleted() bool {
+	return !vr.DeletedAt.IsZero()
+}

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -195,7 +195,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 		level.Info(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_rules", len(rules))
 		s.Lock()
 		// if deleted remove from map, otherwise - update map
-		if !config.DeletedAt.IsZero() {
+		if config.IsDeleted() {
 			delete(s.cfgs, userID)
 		} else {
 			s.cfgs[userID] = rules

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -201,7 +201,9 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 			s.cfgs[userID] = rules
 		}
 		s.Unlock()
-		s.addWorkItem(workItem{userID, rules, now})
+		if !config.IsDeleted() {
+			s.addWorkItem(workItem{userID, rules, now})
+		}
 	}
 	configUpdates.Add(float64(len(cfgs)))
 	s.Lock()

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -192,7 +192,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 			level.Warn(util.Logger).Log("msg", "scheduler: invalid Cortex configuration", "user_id", userID, "err", err)
 			continue
 		}
-		level.Info(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_rules", len(rules))
+		level.Info(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_rules", len(rules), "is_deleted", config.IsDeleted())
 		s.Lock()
 		// if deleted remove from map, otherwise - update map
 		if config.IsDeleted() {


### PR DESCRIPTION
I was puzzled why we are still getting errors in the logs from deleted instances - they will run once then stop, but the notifier created for them will carry on.
