### PR TITLE
Enable Jaeger tracing in the ruler

### DIFF
--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
+	"github.com/weaveworks/common/tracing"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/chunk/storage"
 	"github.com/weaveworks/cortex/pkg/distributor"
@@ -35,6 +36,12 @@ func main() {
 		configStoreConfig ruler.ConfigStoreConfig
 		logLevel          util.LogLevel
 	)
+
+	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
+	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
+	trace := tracing.New(jaegerAgentHost, "ruler")
+	defer trace.Close()
+
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,
 		&rulerConfig, &chunkStoreConfig, &storageConfig, &schemaConfig, &configStoreConfig, &logLevel)
 	flag.Parse()


### PR DESCRIPTION
Given that the ruler pulls triple (quadruple?) duty as a querier, distributor, alerter, etc., it seems helpful to have Jaeger traces enabled. Particularly as we're investigating some sneaky query slow-downs that seem to be isolated to the ruler.