### PR TITLE
Enable configurable Jaeger sampling strategies (with defaults)

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	util.InitLogger(logLevel.AllowedLevel)
 
-	trace := tracing.New("distributor")
+	trace := tracing.NewFromEnv("distributor")
 	defer trace.Close()
 
 	log.AddHook(promrus.MustNewPrometheusHook())

--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -60,10 +60,6 @@ func main() {
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
 	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
 	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
-		jaegerSamplerType = "ratelimiting"
-		jaegerSamplerParam = 10.0
-	}
 	trace := tracing.New(jaegerAgentHost, "distributor", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 

--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -56,11 +55,7 @@ func main() {
 
 	util.InitLogger(logLevel.AllowedLevel)
 
-	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
-	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	trace := tracing.New(jaegerAgentHost, "distributor", jaegerSamplerType, jaegerSamplerParam)
+	trace := tracing.New("distributor")
 	defer trace.Close()
 
 	log.AddHook(promrus.MustNewPrometheusHook())

--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -57,7 +58,13 @@ func main() {
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	trace := tracing.New(jaegerAgentHost, "distributor")
+	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
+	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
+	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
+		jaegerSamplerType = "ratelimiting"
+		jaegerSamplerParam = 10.0
+	}
+	trace := tracing.New(jaegerAgentHost, "distributor", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 
 	log.AddHook(promrus.MustNewPrometheusHook())

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -59,7 +59,7 @@ func main() {
 	flag.Parse()
 	schemaConfig.MaxChunkAge = ingesterConfig.MaxChunkAge
 
-	trace := tracing.New("lite")
+	trace := tracing.NewFromEnv("lite")
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -60,11 +59,7 @@ func main() {
 	flag.Parse()
 	schemaConfig.MaxChunkAge = ingesterConfig.MaxChunkAge
 
-	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
-	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	trace := tracing.New(jaegerAgentHost, "lite", jaegerSamplerType, jaegerSamplerParam)
+	trace := tracing.New("lite")
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
@@ -61,7 +62,9 @@ func main() {
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	trace := tracing.New(jaegerAgentHost, "lite")
+	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
+	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
+	trace := tracing.New(jaegerAgentHost, "lite", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"strconv"
 
 	"google.golang.org/grpc"
 
@@ -47,7 +48,13 @@ func main() {
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	trace := tracing.New(jaegerAgentHost, "querier")
+	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
+	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
+	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
+		jaegerSamplerType = "ratelimiting"
+		jaegerSamplerParam = 10.0
+	}
+	trace := tracing.New(jaegerAgentHost, "querier", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -45,7 +45,7 @@ func main() {
 		&chunkStoreConfig, &schemaConfig, &storageConfig, &logLevel)
 	flag.Parse()
 
-	trace := tracing.New("querier")
+	trace := tracing.NewFromEnv("querier")
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"strconv"
 
 	"google.golang.org/grpc"
 
@@ -46,11 +45,7 @@ func main() {
 		&chunkStoreConfig, &schemaConfig, &storageConfig, &logLevel)
 	flag.Parse()
 
-	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
-	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	trace := tracing.New(jaegerAgentHost, "querier", jaegerSamplerType, jaegerSamplerParam)
+	trace := tracing.New("querier")
 	defer trace.Close()
 
 	util.InitLogger(logLevel.AllowedLevel)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -50,10 +50,6 @@ func main() {
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
 	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
 	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
-		jaegerSamplerType = "ratelimiting"
-		jaegerSamplerParam = 10.0
-	}
 	trace := tracing.New(jaegerAgentHost, "querier", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -37,7 +37,7 @@ func main() {
 		logLevel          util.LogLevel
 	)
 
-	trace := tracing.New("ruler")
+	trace := tracing.NewFromEnv("ruler")
 	defer trace.Close()
 
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,7 +40,13 @@ func main() {
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	trace := tracing.New(jaegerAgentHost, "ruler")
+	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
+	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
+	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
+		jaegerSamplerType = "ratelimiting"
+		jaegerSamplerParam = 10.0
+	}
+	trace := tracing.New(jaegerAgentHost, "ruler", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -42,10 +42,6 @@ func main() {
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
 	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
 	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
-		jaegerSamplerType = "ratelimiting"
-		jaegerSamplerParam = 10.0
-	}
 	trace := tracing.New(jaegerAgentHost, "ruler", jaegerSamplerType, jaegerSamplerParam)
 	defer trace.Close()
 

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strconv"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,11 +37,7 @@ func main() {
 		logLevel          util.LogLevel
 	)
 
-	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
-	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
-	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
-	trace := tracing.New(jaegerAgentHost, "ruler", jaegerSamplerType, jaegerSamplerParam)
+	trace := tracing.New("ruler")
 	defer trace.Close()
 
 	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,


### PR DESCRIPTION
This PR is a partner of https://github.com/weaveworks/common/pull/87.

This commit adds runtime configuration env vars to allow each system that's Jaeger-enabled to specify its own sampling strategy and parameters. We chose defaults of `jaeger.SamplerTypeRateLimiting` and `10.0` to yield an intuitive default behavior of "send ~10 traces per second to the collector". Other strategies are certainly usable here, however, and I'd happily entertain different default behaviors.

To test this independent of the state of the weaveworks/common PR referenced above, you can add these lines to your local Cortex repo's `Gopkg.toml`:

```
[[override]]
  name = "github.com/weaveworks/common"
  source = "github.com/Fresh-Tracks/weaveworks-common"
  revision = "e6856c7a5d16d9525051dc8daf3ce5399e5a9384"
```

With this, a `dep ensure && make` should result in a sane build.