### PR TITLE
Remove default for database flag

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -172,10 +172,10 @@ func main() {
 		})
 	}
 
-	// Only serve the API for setting & getting rules configs if we're not
-	// serving configs from the configs API. Allows for smoother
-	// migration. See https://github.com/weaveworks/cortex/issues/619
-	if configStoreConfig.ConfigsAPIURL.URL == nil {
+	// Only serve the API for setting & getting rules configs if we have a
+	// database. Allows for smoother migration. See
+	// https://github.com/weaveworks/cortex/issues/619
+	if configStoreConfig.DBConfig.URI != "" {
 		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -103,10 +103,10 @@ func main() {
 	}
 	defer server.Shutdown()
 
-	// Only serve the API for setting & getting rules configs if we're not
-	// serving configs from the configs API. Allows for smoother
-	// migration. See https://github.com/weaveworks/cortex/issues/619
-	if configStoreConfig.ConfigsAPIURL.URL == nil {
+	// Only serve the API for setting & getting rules configs if we have a
+	// database. Allows for smoother migration. See
+	// https://github.com/weaveworks/cortex/issues/619
+	if configStoreConfig.DBConfig.URI != "" {
 		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)

--- a/pkg/configs/db/db.go
+++ b/pkg/configs/db/db.go
@@ -18,7 +18,7 @@ type Config struct {
 
 // RegisterFlags adds the flags required to configure this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&cfg.URI, "database.uri", "postgres://postgres@configs-db.weave.local/configs?sslmode=disable", "URI where the database can be found (for dev you can use memory://)")
+	flag.StringVar(&cfg.URI, "database.uri", "", "URI where the database can be found (for dev you can use memory://)")
 	flag.StringVar(&cfg.MigrationsDir, "database.migrations", "", "Path where the database migration files can be found")
 }
 

--- a/pkg/ruler/configs.go
+++ b/pkg/ruler/configs.go
@@ -43,7 +43,7 @@ func NewRulesAPI(cfg ConfigStoreConfig) (RulesAPI, error) {
 	// All of this falderal is to allow for a smooth transition away from
 	// using the configs server and toward directly connecting to the database.
 	// See https://github.com/weaveworks/cortex/issues/619
-	if cfg.ConfigsAPIURL.URL != nil {
+	if cfg.DBConfig.URI != "" {
 		return configsClient{
 			URL:     cfg.ConfigsAPIURL.URL,
 			Timeout: cfg.ClientTimeout,


### PR DESCRIPTION
Remove the default for database flags, requiring database flags to be specified in order to be used.

Why? So we can serve new ruler config endpoints only if the ruler has information about the database, which is necessary to serve the endpoints.

In #649, I submitted a PR which added new config endpoints and only served them if the ruler was *not* configured with configs API endpoints. This is a bit silly, as we want the ruler to be able to talk to the configs server during the migration process. i.e. we want the ruler (temporarily) to have both a configs API URL and a database URL.

The reason we used "absence of configs API" rather than "presence of DB" is that there was no way to detect presence of DB, because the default URL value meant it was always present.

Thus, we change the default value to be empty string, and serve new endpoints based on presence of DB.