### PR TITLE
Revert "Remove default for database flag"

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -172,10 +172,10 @@ func main() {
 		})
 	}
 
-	// Only serve the API for setting & getting rules configs if we have a
-	// database. Allows for smoother migration. See
-	// https://github.com/weaveworks/cortex/issues/619
-	if configStoreConfig.DBConfig.URI != "" {
+	// Only serve the API for setting & getting rules configs if we're not
+	// serving configs from the configs API. Allows for smoother
+	// migration. See https://github.com/weaveworks/cortex/issues/619
+	if configStoreConfig.ConfigsAPIURL.URL == nil {
 		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -103,10 +103,10 @@ func main() {
 	}
 	defer server.Shutdown()
 
-	// Only serve the API for setting & getting rules configs if we have a
-	// database. Allows for smoother migration. See
-	// https://github.com/weaveworks/cortex/issues/619
-	if configStoreConfig.DBConfig.URI != "" {
+	// Only serve the API for setting & getting rules configs if we're not
+	// serving configs from the configs API. Allows for smoother
+	// migration. See https://github.com/weaveworks/cortex/issues/619
+	if configStoreConfig.ConfigsAPIURL.URL == nil {
 		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)

--- a/pkg/configs/db/db.go
+++ b/pkg/configs/db/db.go
@@ -18,7 +18,7 @@ type Config struct {
 
 // RegisterFlags adds the flags required to configure this to the given FlagSet.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&cfg.URI, "database.uri", "", "URI where the database can be found (for dev you can use memory://)")
+	flag.StringVar(&cfg.URI, "database.uri", "postgres://postgres@configs-db.weave.local/configs?sslmode=disable", "URI where the database can be found (for dev you can use memory://)")
 	flag.StringVar(&cfg.MigrationsDir, "database.migrations", "", "Path where the database migration files can be found")
 }
 

--- a/pkg/ruler/configs.go
+++ b/pkg/ruler/configs.go
@@ -43,7 +43,7 @@ func NewRulesAPI(cfg ConfigStoreConfig) (RulesAPI, error) {
 	// All of this falderal is to allow for a smooth transition away from
 	// using the configs server and toward directly connecting to the database.
 	// See https://github.com/weaveworks/cortex/issues/619
-	if cfg.DBConfig.URI != "" {
+	if cfg.ConfigsAPIURL.URL != nil {
 		return configsClient{
 			URL:     cfg.ConfigsAPIURL.URL,
 			Timeout: cfg.ClientTimeout,


### PR DESCRIPTION
Reverts weaveworks/cortex#708

```console
$ kubectl get po --namespace=cortex
...
ruler-85f79bb777-l2nmt           0/1       CrashLoopBackOff   6          6m
...
$ kubectl logs --namespace=cortex ruler-85f79bb777-l2nmt
ts=2018-02-15T14:40:02.482696195Z caller=log.go:108 level=error msg="error initializing rules API" err="Unknown database type: "