### PR TITLE
Updating IngesterClient MaxCallRecvMsgSize to be configurable vs fixed size

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -68,8 +68,8 @@ type Distributor struct {
 // Config contains the configuration require to
 // create a Distributor
 type Config struct {
-	EnableBilling bool
-	BillingConfig billing.Config
+	EnableBilling        bool
+	BillingConfig        billing.Config
 	IngesterClientConfig ingester_client.Config
 
 	ReplicationFactor   int
@@ -80,7 +80,7 @@ type Config struct {
 	CompressToIngester  bool
 
 	// for testing
-	ingesterClientFactory func(addr string, withCompression bool,cfg ingester_client.Config) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, withCompression bool, cfg ingester_client.Config) (client.IngesterClient, error)
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -225,7 +225,7 @@ func (d *Distributor) getClientFor(ingester *ring.IngesterDesc) (client.Ingester
 		return client, nil
 	}
 
-	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.RemoteTimeout, d.cfg.CompressToIngester,d.cfg.IngesterClientConfig)
+	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.CompressToIngester, d.cfg.IngesterClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -77,10 +77,9 @@ type Config struct {
 	ClientCleanupPeriod time.Duration
 	IngestionRateLimit  float64
 	IngestionBurstSize  int
-	CompressToIngester  bool
 
 	// for testing
-	ingesterClientFactory func(addr string, withCompression bool, cfg ingester_client.Config) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, cfg ingester_client.Config) (client.IngesterClient, error)
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -93,7 +92,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
 	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
-	flag.BoolVar(&cfg.CompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters.")
 }
 
 // New constructs a new Distributor
@@ -225,7 +223,7 @@ func (d *Distributor) getClientFor(ingester *ring.IngesterDesc) (client.Ingester
 		return client, nil
 	}
 
-	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.CompressToIngester, d.cfg.IngesterClientConfig)
+	client, err := d.cfg.ingesterClientFactory(ingester.Addr, d.cfg.IngesterClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -165,7 +165,7 @@ func TestDistributorPush(t *testing.T) {
 				IngestionRateLimit:  10000,
 				IngestionBurstSize:  10000,
 
-				ingesterClientFactory: func(addr string, _ bool) (client.IngesterClient, error) {
+				ingesterClientFactory: func(addr string, _ client.Config) (client.IngesterClient, error) {
 					return ingesters[addr], nil
 				},
 			}, ring)
@@ -305,7 +305,7 @@ func TestDistributorQuery(t *testing.T) {
 				IngestionRateLimit:  10000,
 				IngestionBurstSize:  10000,
 
-				ingesterClientFactory: func(addr string, _ bool) (client.IngesterClient, error) {
+				ingesterClientFactory: func(addr string, _ client.Config) (client.IngesterClient, error) {
 					return ingesters[addr], nil
 				},
 			}, ring)

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -25,7 +25,6 @@ func MakeIngesterClient(addr string, withCompression bool, cfg Config) (Ingester
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.ClientUserHeaderInterceptor,
 		)),
-		// We have seen 20MB returns from queries - add a bit of headroom
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize)),
 	}
 	if withCompression {
@@ -50,5 +49,6 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive")
+	// We have seen 20MB returns from queries - add a bit of headroom
+	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive.")
 }

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -14,11 +14,11 @@ import (
 type closableIngesterClient struct {
 	IngesterClient
 	conn *grpc.ClientConn
-	cfg Config
+	cfg  Config
 }
 
 // MakeIngesterClient makes a new IngesterClient
-func MakeIngesterClient(addr string, withCompression bool,cfg Config) (IngesterClient, error) {
+func MakeIngesterClient(addr string, withCompression bool, cfg Config) (IngesterClient, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
@@ -26,7 +26,7 @@ func MakeIngesterClient(addr string, withCompression bool,cfg Config) (IngesterC
 			middleware.ClientUserHeaderInterceptor,
 		)),
 		// We have seen 20MB returns from queries - add a bit of headroom
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize( cfg.MaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize)),
 	}
 	if withCompression {
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
@@ -45,11 +45,10 @@ func (c *closableIngesterClient) Close() error {
 	return c.conn.Close()
 }
 
-
 type Config struct {
 	MaxRecvMsgSize int
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.IntVar(&cfg.MaxRecvMsgSize,"ingester.client.max-recv-message-size",64*1024*1024,"Maximum message size, in bytes, this client will receive")
+	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive")
 }

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -58,5 +58,5 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive.")
 	flag.BoolVar(&cfg.CompressToIngester, "ingester.client.compress-to-ingester", false, "Compress data in calls to ingesters.")
 	// moved from distributor pkg, but flag prefix left as back compat fallback for existing users.
-	flag.BoolVar(&cfg.legacyCompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters.")
+	flag.BoolVar(&cfg.legacyCompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters. (DEPRECATED: use ingester.client.compress-to-ingester instead")
 }

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // get gzip compressor registered
 
-	"github.com/weaveworks/common/middleware"
 	"flag"
+	"github.com/weaveworks/common/middleware"
 )
 
 type closableIngesterClient struct {
@@ -47,12 +47,14 @@ func (c *closableIngesterClient) Close() error {
 	return c.conn.Close()
 }
 
+// Config is the configuration struct for the ingester client
 type Config struct {
-	MaxRecvMsgSize int
-	CompressToIngester bool
+	MaxRecvMsgSize           int
+	CompressToIngester       bool
 	legacyCompressToIngester bool
 }
 
+// RegisterFlags registers configuration settings used by the ingester client config
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// We have seen 20MB returns from queries - add a bit of headroom
 	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive.")

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -8,15 +8,17 @@ import (
 	_ "google.golang.org/grpc/encoding/gzip" // get gzip compressor registered
 
 	"github.com/weaveworks/common/middleware"
+	"flag"
 )
 
 type closableIngesterClient struct {
 	IngesterClient
 	conn *grpc.ClientConn
+	cfg Config
 }
 
 // MakeIngesterClient makes a new IngesterClient
-func MakeIngesterClient(addr string, withCompression bool) (IngesterClient, error) {
+func MakeIngesterClient(addr string, withCompression bool,cfg Config) (IngesterClient, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
@@ -24,7 +26,7 @@ func MakeIngesterClient(addr string, withCompression bool) (IngesterClient, erro
 			middleware.ClientUserHeaderInterceptor,
 		)),
 		// We have seen 20MB returns from queries - add a bit of headroom
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(64 * 1024 * 1024)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize( cfg.MaxRecvMsgSize)),
 	}
 	if withCompression {
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
@@ -41,4 +43,13 @@ func MakeIngesterClient(addr string, withCompression bool) (IngesterClient, erro
 
 func (c *closableIngesterClient) Close() error {
 	return c.conn.Close()
+}
+
+
+type Config struct {
+	MaxRecvMsgSize int
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.IntVar(&cfg.MaxRecvMsgSize,"ingester.client.max-recv-message-size",64*1024*1024,"Maximum message size, in bytes, this client will receive")
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -90,7 +90,7 @@ type Config struct {
 	infName               string
 	id                    string
 	skipUnregister        bool
-	ingesterClientFactory func(addr string, withCompression bool, cfg client.Config) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, cfg client.Config) (client.IngesterClient, error)
 	KVClient              ring.KVClient
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -64,7 +64,7 @@ var (
 type Config struct {
 	RingConfig       ring.Config
 	userStatesConfig UserStatesConfig
-
+	clientConfig	client.Config
 	// Config for the ingester lifecycle control
 	ListenPort       *int
 	NumTokens        int
@@ -90,7 +90,7 @@ type Config struct {
 	infName               string
 	id                    string
 	skipUnregister        bool
-	ingesterClientFactory func(addr string, withCompression bool) (client.IngesterClient, error)
+	ingesterClientFactory func(addr string, withCompression bool, cfg client.Config) (client.IngesterClient, error)
 	KVClient              ring.KVClient
 }
 
@@ -98,7 +98,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.RingConfig.RegisterFlags(f)
 	cfg.userStatesConfig.RegisterFlags(f)
-
+	cfg.clientConfig.RegisterFlags(f)
 	f.IntVar(&cfg.NumTokens, "ingester.num-tokens", 128, "Number of tokens for each ingester.")
 	f.DurationVar(&cfg.HeartbeatPeriod, "ingester.heartbeat-period", 5*time.Second, "Period at which to heartbeat to consul.")
 	f.DurationVar(&cfg.JoinAfter, "ingester.join-after", 0*time.Second, "Period to wait for a claim from another ingester; will join automatically after this.")

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -64,7 +64,7 @@ var (
 type Config struct {
 	RingConfig       ring.Config
 	userStatesConfig UserStatesConfig
-	clientConfig	client.Config
+	clientConfig     client.Config
 	// Config for the ingester lifecycle control
 	ListenPort       *int
 	NumTokens        int

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -359,7 +359,7 @@ func (i *Ingester) transferChunks() error {
 	}
 
 	level.Info(util.Logger).Log("msg", "sending chunks to ingester", "ingester", targetIngester.Addr)
-	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, false)
+	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, false, i.cfg.clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -359,7 +359,7 @@ func (i *Ingester) transferChunks() error {
 	}
 
 	level.Info(util.Logger).Log("msg", "sending chunks to ingester", "ingester", targetIngester.Addr)
-	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, false, i.cfg.clientConfig)
+	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, i.cfg.clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/ingester_lifecycle_test.go
+++ b/pkg/ingester/ingester_lifecycle_test.go
@@ -118,7 +118,7 @@ func TestIngesterTransfer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Let ing2 send chunks to ing1
-	ing1.cfg.ingesterClientFactory = func(addr string, _ bool) (client.IngesterClient, error) {
+	ing1.cfg.ingesterClientFactory = func(addr string, _ client.Config) (client.IngesterClient, error) {
 		return ingesterClientAdapater{
 			ingester: ing2,
 		}, nil


### PR DESCRIPTION
We have some data scenarios where the amount of data exceeds the 64MB fixed size that the grpc client was set to for a max message size (added in [#660](https://github.com/weaveworks/cortex/pull/660)). This update changes that to a configurable command arg flag, with the default being set to 64MB.

