### PR TITLE
Evaluate Ruler files in parallel

### DIFF
--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -66,14 +66,14 @@ func (c RulesConfig) Equal(o RulesConfig) bool {
 // Parse rules from the Cortex configuration.
 //
 // Strongly inspired by `loadGroups` in Prometheus.
-func (c RulesConfig) Parse() ([]rules.Rule, error) {
-	result := []rules.Rule{}
+func (c RulesConfig) Parse() (map[string][]rules.Rule, error) {
+	result := map[string][]rules.Rule{}
 	for fn, content := range c {
 		stmts, err := promql.ParseStmts(content)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s: %s", fn, err)
 		}
-
+		ra := []rules.Rule{}
 		for _, stmt := range stmts {
 			var rule rules.Rule
 
@@ -87,8 +87,9 @@ func (c RulesConfig) Parse() ([]rules.Rule, error) {
 			default:
 				return nil, fmt.Errorf("ruler.GetRules: unknown statement type")
 			}
-			result = append(result, rule)
+			ra = append(ra, rule)
 		}
+		result[fn] = ra
 	}
 	return result, nil
 }

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -266,7 +266,7 @@ func buildNotifierConfig(rulerConfig *Config) (*config.Config, error) {
 	return promConfig, nil
 }
 
-func (r *Ruler) newGroup(ctx context.Context, userID string, rs []rules.Rule) (*rules.Group, error) {
+func (r *Ruler) newGroup(ctx context.Context, userID string, item *workItem) (*rules.Group, error) {
 	appendable := &appendableAppender{pusher: r.pusher, ctx: ctx}
 	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
@@ -282,7 +282,7 @@ func (r *Ruler) newGroup(ctx context.Context, userID string, rs []rules.Rule) (*
 		Registerer:  prometheus.DefaultRegisterer,
 	}
 	delay := 0 * time.Second // Unused, so 0 value is fine.
-	return rules.NewGroup("default", "none", delay, rs, opts), nil
+	return rules.NewGroup(item.filename, "none", delay, item.rules, opts), nil
 }
 
 // sendAlerts implements a rules.NotifyFunc for a Notifier.
@@ -353,16 +353,16 @@ func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Notifier, error) {
 }
 
 // Evaluate a list of rules in the given context.
-func (r *Ruler) Evaluate(userID string, rs []rules.Rule) {
+func (r *Ruler) Evaluate(userID string, item *workItem) {
 	ctx := user.InjectOrgID(context.Background(), userID)
 	logger := util.WithContext(ctx, util.Logger)
-	level.Debug(logger).Log("msg", "evaluating rules...", "num_rules", len(rs))
+	level.Debug(logger).Log("msg", "evaluating rules...", "num_rules", len(item.rules))
 	ctx, cancelTimeout := context.WithTimeout(ctx, r.groupTimeout)
 	instrument.CollectedRequest(ctx, "Evaluate", evalDuration, nil, func(ctx native_ctx.Context) error {
 		if span := opentracing.SpanFromContext(ctx); span != nil {
 			span.SetTag("instance", userID)
 		}
-		g, err := r.newGroup(ctx, userID, rs)
+		g, err := r.newGroup(ctx, userID, item)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to create rule group", "err", err)
 			return err
@@ -376,7 +376,7 @@ func (r *Ruler) Evaluate(userID string, rs []rules.Rule) {
 		level.Warn(util.Logger).Log("msg", "context error", "error", err)
 	}
 
-	rulesProcessed.Add(float64(len(rs)))
+	rulesProcessed.Add(float64(len(item.rules)))
 }
 
 // Stop stops the Ruler.
@@ -472,7 +472,7 @@ func (w *worker) Run() {
 		}
 		evalLatency.Observe(time.Since(item.scheduled).Seconds())
 		level.Debug(util.Logger).Log("msg", "processing item", "item", item)
-		w.ruler.Evaluate(item.userID, item.rules)
+		w.ruler.Evaluate(item.userID, item)
 		w.scheduler.workItemDone(*item)
 		level.Debug(util.Logger).Log("msg", "item handed back to queue", "item", item)
 	}

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -194,9 +194,6 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 			continue
 		}
 		level.Debug(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_files", len(rulesByFilename), "is_deleted", config.IsDeleted())
-		for k, v := range rulesByFilename {
-			level.Debug(util.Logger).Log("msg", "scheduler: updating rules for user and filename", "user_id", userID, "filename", k, "num_rules", len(v))
-		}
 		s.Lock()
 		// if deleted remove from map, otherwise - update map
 		if config.IsDeleted() {
@@ -207,6 +204,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 		s.Unlock()
 		if !config.IsDeleted() {
 			for fn, rules := range rulesByFilename {
+				level.Debug(util.Logger).Log("msg", "scheduler: updating rules for user and filename", "user_id", userID, "filename", fn, "num_rules", len(rules))
 				s.addWorkItem(workItem{userID, fn, rules, now})
 			}
 		}
@@ -251,7 +249,7 @@ func (s *scheduler) workItemDone(i workItem) {
 		currentRules = ruleSet[i.filename]
 	}
 	s.Unlock()
-	if !found {
+	if !found || len(currentRules) == 0 {
 		level.Debug(util.Logger).Log("msg", "scheduler: no more work configured for user", "user_id", i.userID)
 		return
 	}

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -193,9 +193,9 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 			level.Warn(util.Logger).Log("msg", "scheduler: invalid Cortex configuration", "user_id", userID, "err", err)
 			continue
 		}
-		level.Info(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_files", len(rulesByFilename), "is_deleted", config.IsDeleted())
+		level.Debug(util.Logger).Log("msg", "scheduler: updating rules for user", "user_id", userID, "num_files", len(rulesByFilename), "is_deleted", config.IsDeleted())
 		for k, v := range rulesByFilename {
-			level.Info(util.Logger).Log("msg", "scheduler: updating rules for user and filename", "user_id", userID, "filename", k, "num_rules", len(v))
+			level.Debug(util.Logger).Log("msg", "scheduler: updating rules for user and filename", "user_id", userID, "filename", k, "num_rules", len(v))
 		}
 		s.Lock()
 		// if deleted remove from map, otherwise - update map


### PR DESCRIPTION
Instead of having to evaluate all rules sequentially for each tenant, instead evaluate the rules sequentially for each file, but allow the files to be done in parallel. This allows tenants with large numbers of rules to have their rules evaluated more efficiently. We saw a significant improvement in rule evaluation durations upon deploying this code.

Are there any concerns with this approach?

It looks like this PR will end up with a lot of merge conflicts with https://github.com/weaveworks/cortex/pull/689, if that is going in soon it may be worthwhile to wait to merge this until afterward.