### PR TITLE
Improve ruler tracing

### DIFF
--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -14,6 +14,7 @@ import (
 
 	gklog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -358,6 +359,9 @@ func (r *Ruler) Evaluate(userID string, rs []rules.Rule) {
 	level.Debug(logger).Log("msg", "evaluating rules...", "num_rules", len(rs))
 	ctx, cancelTimeout := context.WithTimeout(ctx, r.groupTimeout)
 	instrument.CollectedRequest(ctx, "Evaluate", evalDuration, nil, func(ctx native_ctx.Context) error {
+		if span := opentracing.SpanFromContext(ctx); span != nil {
+			span.SetTag("instance", userID)
+		}
 		g, err := r.newGroup(ctx, userID, rs)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to create rule group", "err", err)


### PR DESCRIPTION
Using `weaveworks/common/instrument` in `Evaluate()` gives us a tracing span which ties together all the sub-operations for that rule group.

It would be better to have a span per rule, but that is inside Prometheus.

I also changed the histogram buckets for eval duration to go up to 25 seconds, and drop the low end below 100ms.