### PR TITLE
Don't divide by zero in hash bucket histogram

### DIFF
--- a/pkg/util/hash_bucket_histogram.go
+++ b/pkg/util/hash_bucket_histogram.go
@@ -88,7 +88,9 @@ func (h *hashBucketHistogram) loop() {
 		case <-ticker.C:
 			buckets := h.swapBuckets()
 			for _, v := range buckets.buckets {
-				h.Histogram.Observe(float64(v) * float64(h.opts.HashBuckets) / float64(buckets.ops))
+				if buckets.ops > 0 {
+					h.Histogram.Observe(float64(v) * float64(h.opts.HashBuckets) / float64(buckets.ops))
+				}
 			}
 		case <-h.quit:
 			return


### PR DESCRIPTION
The observed issue is that `cortex_chunk_store_row_writes_distribution_sum` is all NaNs, although the buckets have reasonable values.

I'm not 100% sure this is the cause, but there's only so much time in the day.
