### PR TITLE
Perform ingester pushes in a background context rather than the request context

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -347,12 +347,10 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 		done:           make(chan struct{}),
 		err:            make(chan error),
 	}
-	ctx, cancel := context.WithTimeout(ctx, d.cfg.RemoteTimeout)
-	defer cancel() // cancel the timeout to release resources
 	for ingester, samples := range samplesByIngester {
 		go func(ingester *ring.IngesterDesc, samples []*sampleTracker) {
 			// Use a background context to make sure all ingesters get samples even if we return early
-			localCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			localCtx, cancel := context.WithTimeout(context.Background(), d.cfg.RemoteTimeout)
 			defer cancel()
 			localCtx = user.InjectOrgID(localCtx, userID)
 			if sp := opentracing.SpanFromContext(ctx); sp != nil {


### PR DESCRIPTION
Use a background context for the pushes to the ingester. This allows the context to continue after the request is returned in order to finish writing to `replicas` ingesters, rather than stopping after a quorum. 

Solution to: https://github.com/weaveworks/cortex/issues/730
Alternative to: https://github.com/weaveworks/cortex/pull/732

Jaeger trace showing the third push finishing after the request is done:
![screen shot 2018-03-07 at 1 03 12 pm](https://user-images.githubusercontent.com/3280472/37115773-535452f0-2209-11e8-86d5-b2abbbdcb27e.png)
