### PR TITLE
Fix distributor state metric showing PENDING and JOINING way too long

### DIFF
--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -291,6 +291,8 @@ func (r *Ring) Collect(ch chan<- prometheus.Metric) {
 		unhealthy:        0,
 		ACTIVE.String():  0,
 		LEAVING.String(): 0,
+		PENDING.String(): 0,
+		JOINING.String(): 0,
 	}
 	for _, ingester := range r.ringDesc.Ingesters {
 		if !r.IsHealthy(ingester) {


### PR DESCRIPTION
If we don't emit anything for a metric then Prometheus takes the last value until it is stale, i.e. for 5 minutes.
