### PR TITLE
Add additional jaeger spans to the query path

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/go-kit/kit/log/level"
+	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -163,6 +164,9 @@ func (c *Store) calculateDynamoWrites(userID string, chunks []Chunk) (WriteBatch
 
 // Get implements ChunkStore
 func (c *Store) Get(ctx context.Context, from, through model.Time, allMatchers ...*labels.Matcher) (model.Matrix, error) {
+	sp, ctx := ot.StartSpanFromContext(ctx, "ChunkStore.Get")
+	defer sp.Finish()
+
 	if through < from {
 		return nil, fmt.Errorf("invalid query, through < from (%d < %d)", through, from)
 	}

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -198,6 +198,10 @@ func (s *storageClient) PutChunks(ctx context.Context, chunks []chunk.Chunk) err
 }
 
 func (s *storageClient) GetChunks(ctx context.Context, input []chunk.Chunk) ([]chunk.Chunk, error) {
+	sp, ctx := ot.StartSpanFromContext(ctx, "GetChunks")
+	defer sp.Finish()
+	sp.LogFields(otlog.Int("chunks requested", len(input)))
+
 	chunks := map[string]map[string]chunk.Chunk{}
 	keys := map[string]bigtable.RowList{}
 	for _, c := range input {


### PR DESCRIPTION
Adds tracing to the BigTable backend for getting chunks, and adds a higher level span to the `ChunkStore.Get` function to make jaeger traces more clear on the difference between distributor and chunk store paths.

Before:
![screen shot 2018-03-08 at 2 34 58 pm](https://user-images.githubusercontent.com/3280472/37177856-f25bf630-22dd-11e8-8d2d-7584a94aba96.png)

After:
![screen shot 2018-03-08 at 2 33 24 pm](https://user-images.githubusercontent.com/3280472/37177858-f644b232-22dd-11e8-8545-ae2854b64bfa.png)
