### PR TITLE
Add admin http page to view stats across all users

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -84,7 +84,9 @@ func main() {
 	}
 	defer server.Shutdown()
 
+	// Administrator functions
 	server.HTTP.Handle("/ring", r)
+	server.HTTP.HandleFunc("/all_user_stats", dist.AllUserStatsHandler)
 
 	operationNameFunc := nethttp.OperationNameFunc(func(r *http.Request) string {
 		return r.URL.RequestURI()

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -660,7 +660,7 @@ func (d *Distributor) UserStats(ctx context.Context) (*UserStats, error) {
 	return totalStats, nil
 }
 
-// UserStats models ingestion statistics for one user, including the user ID
+// UserIDStats models ingestion statistics for one user, including the user ID
 type UserIDStats struct {
 	UserID string `json:"userID"`
 	UserStats

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -47,6 +47,7 @@ func (r mockRing) IsHealthy(ingester *ring.IngesterDesc) bool {
 type mockIngester struct {
 	client.IngesterClient
 	happy bool
+	stats client.UsersStatsResponse
 }
 
 func (i mockIngester) Push(ctx context.Context, in *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
@@ -82,6 +83,10 @@ func (i mockIngester) Query(ctx context.Context, in *client.QueryRequest, opts .
 			},
 		},
 	}, nil
+}
+
+func (i mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
+	return &i.stats, nil
 }
 
 func TestDistributorPush(t *testing.T) {

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -1,0 +1,87 @@
+package distributor
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const tpl = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Cortex Ingester Stats</title>
+	</head>
+	<body>
+		<h1>Cortex Ingester Stats</h1>
+		<p>Current time: {{ .Now }}</p>
+		<form action="" method="POST">
+			<input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+			<table width="100%" border="1">
+				<thead>
+					<tr>
+						<th>User</th>
+						<th># Series</th>
+						<th>Ingest Rate</th>
+					</tr>
+				</thead>
+				<tbody>
+					{{ range .Stats }}
+					<tr>
+						<td>{{ .UserID }}</td>
+						<td>{{ .UserStats.NumSeries }}</td>
+						<td>{{ .UserStats.IngestionRate }}</td>
+					</tr>
+					{{ end }}
+				</tbody>
+			</table>
+		</form>
+	</body>
+</html>`
+
+var tmpl *template.Template
+
+func init() {
+	tmpl = template.Must(template.New("webpage").Parse(tpl))
+}
+
+type userStatsByTimeseries []UserIDStats
+
+func (s userStatsByTimeseries) Len() int           { return len(s) }
+func (s userStatsByTimeseries) Less(i, j int) bool { return s[i].NumSeries > s[j].NumSeries }
+func (s userStatsByTimeseries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// AllUserStatsHandler shows stats for all users.
+func (d *Distributor) AllUserStatsHandler(w http.ResponseWriter, r *http.Request) {
+	stats, err := d.AllUserStats(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	sort.Sort(userStatsByTimeseries(stats))
+
+	if encodings, found := r.Header["Accept"]; found &&
+		len(encodings) > 0 && strings.Contains(encodings[0], "json") {
+		if err := json.NewEncoder(w).Encode(stats); err != nil {
+			http.Error(w, fmt.Sprintf("Error marshalling response: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if err := tmpl.Execute(w, struct {
+		Now   time.Time
+		Stats []UserIDStats
+	}{
+		Now:   time.Now(),
+		Stats: stats,
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -22,7 +22,7 @@ const tpl = `
 		<p>Current time: {{ .Now }}</p>
 		<form action="" method="POST">
 			<input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
-			<table width="100%" border="1">
+			<table border="1">
 				<thead>
 					<tr>
 						<th>User</th>
@@ -34,8 +34,8 @@ const tpl = `
 					{{ range .Stats }}
 					<tr>
 						<td>{{ .UserID }}</td>
-						<td>{{ .UserStats.NumSeries }}</td>
-						<td>{{ .UserStats.IngestionRate }}</td>
+						<td align='right'>{{ .UserStats.NumSeries }}</td>
+						<td align='right'>{{ printf "%.2f" .UserStats.IngestionRate }}</td>
 					</tr>
 					{{ end }}
 				</tbody>

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -52,9 +52,13 @@ func init() {
 
 type userStatsByTimeseries []UserIDStats
 
-func (s userStatsByTimeseries) Len() int           { return len(s) }
-func (s userStatsByTimeseries) Less(i, j int) bool { return s[i].NumSeries > s[j].NumSeries }
-func (s userStatsByTimeseries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s userStatsByTimeseries) Len() int      { return len(s) }
+func (s userStatsByTimeseries) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s userStatsByTimeseries) Less(i, j int) bool {
+	return s[i].NumSeries > s[j].NumSeries ||
+		(s[i].NumSeries == s[j].NumSeries && s[i].UserID < s[j].UserID)
+}
 
 // AllUserStatsHandler shows stats for all users.
 func (d *Distributor) AllUserStatsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -14,6 +14,7 @@ service Ingester {
   rpc Query(QueryRequest) returns (QueryResponse) {};
   rpc LabelValues(LabelValuesRequest) returns (LabelValuesResponse) {};
   rpc UserStats(UserStatsRequest) returns (UserStatsResponse) {};
+  rpc AllUserStats(UserStatsRequest) returns (UsersStatsResponse) {};
   rpc MetricsForLabelMatchers(MetricsForLabelMatchersRequest) returns (MetricsForLabelMatchersResponse) {};
 
   // TransferChunks allows leaving ingester (client) to stream chunks directly to joining ingesters (server).
@@ -57,6 +58,15 @@ message UserStatsRequest {}
 message UserStatsResponse {
   double ingestion_rate = 1;
   uint64 num_series = 2;
+}
+
+message UserIDStatsResponse {
+  string user_id = 1;
+  UserStatsResponse data = 2;
+}
+
+message UsersStatsResponse {
+  repeated UserIDStatsResponse stats = 1;
 }
 
 message MetricsForLabelMatchersRequest {


### PR DESCRIPTION
This adds a web page a bit like the 'ring' page, but showing what different instances are using across all ingesters.

On the day when we suddenly had N million extra timeseries, I really wanted this feature.  But looking at the amount of code I'm not so sure I like it.  I'm open to suggestions.

![image](https://user-images.githubusercontent.com/8125524/37347678-4b74347c-26ca-11e8-89d5-c1c148c038d7.png)
