### PR TITLE
Fix auto scaling - don't set inactive write scaling on active tables

### DIFF
--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -241,11 +241,6 @@ func (cfg *PeriodicTableConfig) periodicTables(beginGrace, endGrace time.Duratio
 			Tags:             cfg.GetTags(),
 		}
 
-		// Autoscale last N tables (excluding lastTable which is active).
-		if cfg.InactiveWriteScale.Enabled && i >= (lastTable-cfg.InactiveWriteScaleLastN) && i < lastTable {
-			table.WriteScale = cfg.InactiveWriteScale
-		}
-
 		// if now is within table [start - grace, end + grace), then we need some write throughput
 		if (i*periodSecs)-beginGraceSecs <= now && now < (i*periodSecs)+periodSecs+endGraceSecs {
 			table.ProvisionedRead = cfg.ProvisionedReadThroughput
@@ -254,7 +249,11 @@ func (cfg *PeriodicTableConfig) periodicTables(beginGrace, endGrace time.Duratio
 			if cfg.WriteScale.Enabled {
 				table.WriteScale = cfg.WriteScale
 			}
+		} else if cfg.InactiveWriteScale.Enabled && i >= (lastTable-cfg.InactiveWriteScaleLastN) {
+			// Autoscale last N tables
+			table.WriteScale = cfg.InactiveWriteScale
 		}
+
 		result = append(result, table)
 	}
 	return result

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -292,7 +292,7 @@ func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDes
 			continue
 		}
 
-		level.Info(util.Logger).Log("msg", "updating provisioned throughput on table", "table", expected.Name, "old_read", current.ProvisionedRead, "old_write", current.ProvisionedWrite, "new_read", expected.ProvisionedRead, "old_read", expected.ProvisionedWrite)
+		level.Info(util.Logger).Log("msg", "updating provisioned throughput on table", "table", expected.Name, "old_read", current.ProvisionedRead, "old_write", current.ProvisionedWrite, "new_read", expected.ProvisionedRead, "new_write", expected.ProvisionedWrite)
 		err = m.client.UpdateTable(ctx, current, expected)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #749 

Most of this PR is setting up the unit test.