### PR TITLE
Don't add promrus hook in distributor main

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"google.golang.org/grpc"
 
 	"github.com/weaveworks/common/middleware"
@@ -18,7 +17,6 @@ import (
 	"github.com/weaveworks/cortex/pkg/distributor"
 	"github.com/weaveworks/cortex/pkg/ring"
 	"github.com/weaveworks/cortex/pkg/util"
-	"github.com/weaveworks/promrus"
 )
 
 func main() {
@@ -59,8 +57,6 @@ func main() {
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
 	trace := tracing.New(jaegerAgentHost, "distributor")
 	defer trace.Close()
-
-	log.AddHook(promrus.MustNewPrometheusHook())
 
 	r, err := ring.New(ringConfig)
 	if err != nil {


### PR DESCRIPTION
Related to #666 
Looks like this was left over when the overlapping functionality was added in `cortex/pkg/util/log.go`

I'm not 100% sure what this would have done, but in any case, it doesn't make sense to do this in one server and not the others.