### PR TITLE
Basic event logging for observability

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -32,6 +32,7 @@ func main() {
 		storageConfig    storage.Config
 		ingesterConfig   ingester.Config
 		logLevel         util.LogLevel
+		eventSampleRate  int
 		maxStreams       uint
 	)
 	// Ingester needs to know our gRPC listen port.
@@ -39,9 +40,11 @@ func main() {
 	util.RegisterFlags(&serverConfig, &chunkStoreConfig, &storageConfig,
 		&schemaConfig, &ingesterConfig, &logLevel)
 	flag.UintVar(&maxStreams, "ingester.max-concurrent-streams", 1000, "Limit on the number of concurrent streams for gRPC calls (0 = unlimited)")
+	flag.IntVar(&eventSampleRate, "event.sample-rate", 0, "How often to sample observability events (0 = never).")
 	flag.Parse()
 
 	util.InitLogger(logLevel.AllowedLevel)
+	util.InitEvents(eventSampleRate)
 
 	if maxStreams > 0 {
 		serverConfig.GRPCOptions = append(serverConfig.GRPCOptions, grpc.MaxConcurrentStreams(uint32(maxStreams)))

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -72,6 +72,7 @@ func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memo
 
 	if flush {
 		flushQueueIndex := int(uint64(fp) % uint64(i.cfg.ConcurrentFlushes))
+		util.Event().Log("msg", "add to flush queue", "userID", userID, "numChunks", len(series.chunkDescs), "firstTime", firstTime, "fp", fp, "series", series.metric)
 		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate})
 	}
 }
@@ -170,8 +171,10 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 	ctx, cancel := context.WithTimeout(ctx, i.cfg.FlushOpTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
 
+	util.Event().Log("msg", "flush chunks", "userID", userID, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric)
 	err := i.flushChunks(ctx, fp, series.metric, chunks)
 	if err != nil {
+		util.Event().Log("msg", "flush error", "userID", userID, "err", err, "fp", fp, "series", series.metric)
 		return err
 	}
 

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -1,6 +1,3 @@
-// Provide an "event" interface for observability
-
-// Temporary hack implementation to go via logger to stderr
 package util
 
 import (
@@ -9,18 +6,24 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
+// Provide an "event" interface for observability
+
+// Temporary hack implementation to go via logger to stderr
+
 var (
 	// interface{} vars to avoid allocation on every call
 	key   interface{} = "level" // masquerade as a level like debug, warn
 	event interface{} = "event"
 
-	eventLogger log.Logger = log.NewNopLogger()
+	eventLogger = log.NewNopLogger()
 )
 
+// Event is the log-like API for event sampling
 func Event() log.Logger {
 	return eventLogger
 }
 
+// InitEvents initializes event sampling, with the given frequency. Zero=off.
 func InitEvents(freq int) {
 	if freq <= 0 {
 		eventLogger = log.NewNopLogger()

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -1,0 +1,51 @@
+// Provide an "event" interface for observability
+
+// Temporary hack implementation to go via logger to stderr
+package util
+
+import (
+	"os"
+
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	// interface{} vars to avoid allocation on every call
+	key   interface{} = "level" // masquerade as a level like debug, warn
+	event interface{} = "event"
+
+	eventLogger log.Logger = log.NewNopLogger()
+)
+
+func Event() log.Logger {
+	return eventLogger
+}
+
+func InitEvents(freq int) {
+	if freq <= 0 {
+		eventLogger = log.NewNopLogger()
+	} else {
+		eventLogger = newEventLogger(freq)
+	}
+}
+
+func newEventLogger(freq int) log.Logger {
+	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	l = log.WithPrefix(l, key, event)
+	l = log.With(l, "ts", log.DefaultTimestampUTC)
+	return &samplingFilter{next: l, freq: freq}
+}
+
+type samplingFilter struct {
+	next  log.Logger
+	freq  int
+	count int
+}
+
+func (e *samplingFilter) Log(keyvals ...interface{}) error {
+	e.count++
+	if e.count%e.freq == 0 {
+		return e.next.Log(keyvals...)
+	}
+	return nil
+}


### PR DESCRIPTION
Log-like API to generate events, plus simple implementation dumping to stderr.

Only wired into ingester for now.

You would turn this on via command-line parameter `-event.sample-rate=1000`, for example, then one in every 1000 "events" will appear in your log file, and you can extract them for analysis in your favourite tool.