### PR TITLE
Separate the time on this server from the time in received samples

### DIFF
--- a/pkg/ingester/ingester_claim.go
+++ b/pkg/ingester/ingester_claim.go
@@ -143,8 +143,9 @@ func fromWireChunks(wireChunks []client.Chunk) ([]*desc, error) {
 	descs := make([]*desc, 0, len(wireChunks))
 	for _, c := range wireChunks {
 		desc := &desc{
-			FirstTime: model.Time(c.StartTimestampMs),
-			LastTime:  model.Time(c.EndTimestampMs),
+			FirstTime:  model.Time(c.StartTimestampMs),
+			LastTime:   model.Time(c.EndTimestampMs),
+			LastUpdate: model.Now(),
 		}
 
 		var err error

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -91,13 +91,13 @@ func (i *Ingester) shouldFlushSeries(series *memorySeries, immediate bool) bool 
 }
 
 func (i *Ingester) shouldFlushChunk(c *desc) bool {
-	// Chunks should be flushed if their oldest entry is older than MaxChunkAge
-	if model.Now().Sub(c.FirstTime) > i.cfg.MaxChunkAge {
+	// Chunks should be flushed if they span longer than MaxChunkAge
+	if c.LastTime.Sub(c.FirstTime) > i.cfg.MaxChunkAge {
 		return true
 	}
 
-	// Chunk should be flushed if their last entry is older then MaxChunkIdle
-	if model.Now().Sub(c.LastTime) > i.cfg.MaxChunkIdle {
+	// Chunk should be flushed if their last update is older then MaxChunkIdle
+	if model.Now().Sub(c.LastUpdate) > i.cfg.MaxChunkIdle {
 		return true
 	}
 

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -175,16 +175,18 @@ func (s *memorySeries) setChunks(descs []*desc) error {
 }
 
 type desc struct {
-	C         chunk.Chunk // nil if chunk is evicted.
-	FirstTime model.Time  // Populated at creation. Immutable.
-	LastTime  model.Time  // Populated at creation & on append.
+	C          chunk.Chunk // nil if chunk is evicted.
+	FirstTime  model.Time  // Timestamp of first sample. Populated at creation. Immutable.
+	LastTime   model.Time  // Timestamp of last sample. Populated at creation & on append.
+	LastUpdate model.Time  // This server's local time on last change
 }
 
 func newDesc(c chunk.Chunk, firstTime model.Time, lastTime model.Time) *desc {
 	return &desc{
-		C:         c,
-		FirstTime: firstTime,
-		LastTime:  lastTime,
+		C:          c,
+		FirstTime:  firstTime,
+		LastTime:   lastTime,
+		LastUpdate: model.Now(),
 	}
 }
 
@@ -199,6 +201,7 @@ func (d *desc) add(s model.SamplePair) ([]chunk.Chunk, error) {
 
 	if len(cs) == 1 {
 		d.LastTime = s.Timestamp // sample was added to this chunk
+		d.LastUpdate = model.Now()
 	}
 
 	return cs, nil


### PR DESCRIPTION
Use our own idea of time received to compare against `Now()` when computing age and idle time. The sender may have a clock skew, or may be in catch-up mode sending older data.

Fixes #757 
