### PR TITLE
Fix panic in lite

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -57,6 +57,7 @@ func main() {
 		&ingesterConfig, &configStoreConfig, &rulerConfig, &storageConfig, &schemaConfig, &logLevel)
 	flag.BoolVar(&unauthenticated, "unauthenticated", false, "Set to true to disable multitenancy.")
 	flag.Parse()
+	ingesterConfig.SetClientConfig(distributorConfig.IngesterClientConfig)
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing
 	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -94,6 +94,11 @@ type Config struct {
 	KVClient              ring.KVClient
 }
 
+// SetClientConfig sets clientConfig in config
+func (cfg *Config) SetClientConfig(clientConfig client.Config) {
+	cfg.clientConfig = clientConfig
+}
+
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.RingConfig.RegisterFlags(f)


### PR DESCRIPTION
lite uses both ingester.Config and distributor.Config. Both of them has IngesterClientConfig, so calling RegisterFlags on them triggers panic.
This fix ignores second call to RegisterFlags on IngesterClientConfig and then populates it manually

Was broken in https://github.com/weaveworks/cortex/commit/6191d41c5a99e6f89fbd1877afc8805ab0c3ffbd