### PR TITLE
Retain chunks in ingester for idle time, so 'now' queries don't hit the store

### DIFF
--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -92,14 +92,15 @@ func (i *Ingester) shouldFlushSeries(series *memorySeries, immediate bool) flush
 	if immediate {
 		return reasonImmediate
 	}
-	// Series should be scheduled for flushing if they have more than one chunk
-	if len(series.chunkDescs) > 1 {
-		return reasonMultipleChunksInSeries
-	}
 
-	// Or if the only existing chunk need flushing
+	// Series should be scheduled for flushing if the oldest chunk in the series needs flushing
 	if len(series.chunkDescs) > 0 {
-		return i.shouldFlushChunk(series.chunkDescs[0])
+		reason := i.shouldFlushChunk(series.chunkDescs[0])
+		if reason != noFlush && len(series.chunkDescs) > 1 {
+			// Maintain a distinct reason for reporting purposes
+			reason = reasonMultipleChunksInSeries
+		}
+		return reason
 	}
 
 	return noFlush


### PR DESCRIPTION
Fixes #715 

I added a separate parameter to set on the ruler and querier, as this seems cleaner.  Needs to be at least a bit higher than the Prometheus "stale" time (5 minutes), and also lower than the ingester idle time.

Also a small addition to the OpenTracing data which I found useful to check whether it was working.