### PR TITLE
More ingester events

### DIFF
--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -188,7 +188,6 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric)
 	err := i.flushChunks(ctx, fp, series.metric, chunks)
 	if err != nil {
-		util.Event().Log("msg", "flush error", "userID", userID, "err", err, "fp", fp, "series", series.metric)
 		return err
 	}
 

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -82,8 +82,9 @@ func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memo
 
 	if flush != noFlush {
 		flushQueueIndex := int(uint64(fp) % uint64(i.cfg.ConcurrentFlushes))
-		util.Event().Log("msg", "add to flush queue", "userID", userID, "reason", flush, "firstTime", firstTime, "fp", fp, "series", series.metric)
-		i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate})
+		if i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate}) {
+			util.Event().Log("msg", "add to flush queue", "userID", userID, "reason", flush, "firstTime", firstTime, "fp", fp, "series", series.metric)
+		}
 	}
 }
 

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -132,7 +132,7 @@ func (i *Ingester) flushLoop(j int) {
 		}
 		op := o.(*flushOp)
 
-		err := i.flushUserSeries(op.userID, op.fp, op.immediate)
+		err := i.flushUserSeries(j, op.userID, op.fp, op.immediate)
 		if err != nil {
 			level.Error(util.WithUserID(op.userID, util.Logger)).Log("msg", "failed to flush user", "err", err)
 		}
@@ -146,7 +146,7 @@ func (i *Ingester) flushLoop(j int) {
 	}
 }
 
-func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediate bool) error {
+func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.Fingerprint, immediate bool) error {
 	if i.preFlushUserSeries != nil {
 		i.preFlushUserSeries()
 	}
@@ -186,7 +186,7 @@ func (i *Ingester) flushUserSeries(userID string, fp model.Fingerprint, immediat
 	ctx, cancel := context.WithTimeout(ctx, i.cfg.FlushOpTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
 
-	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric)
+	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric, "queue", flushQueueIndex)
 	err := i.flushChunks(ctx, fp, series.metric, chunks)
 	if err != nil {
 		return err

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -83,7 +83,7 @@ func (i *Ingester) sweepSeries(userID string, fp model.Fingerprint, series *memo
 	if flush != noFlush {
 		flushQueueIndex := int(uint64(fp) % uint64(i.cfg.ConcurrentFlushes))
 		if i.flushQueues[flushQueueIndex].Enqueue(&flushOp{firstTime, userID, fp, immediate}) {
-			util.Event().Log("msg", "add to flush queue", "userID", userID, "reason", flush, "firstTime", firstTime, "fp", fp, "series", series.metric)
+			util.Event().Log("msg", "add to flush queue", "userID", userID, "reason", flush, "firstTime", firstTime, "fp", fp, "series", series.metric, "queue", flushQueueIndex)
 		}
 	}
 }

--- a/pkg/ingester/ingester_flush.go
+++ b/pkg/ingester/ingester_flush.go
@@ -219,8 +219,10 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 
 	// Record statistsics only when actual put request did not return error.
 	for _, chunkDesc := range chunkDescs {
-		i.chunkUtilization.Observe(chunkDesc.C.Utilization())
-		i.chunkLength.Observe(float64(chunkDesc.C.Len()))
+		utilization, length := chunkDesc.C.Utilization(), chunkDesc.C.Len()
+		util.Event().Log("msg", "chunk flushed", "userID", userID, "fp", fp, "series", metric, "utilization", utilization, "length", length, "firstTime", chunkDesc.FirstTime, "lastTime", chunkDesc.LastTime)
+		i.chunkUtilization.Observe(utilization)
+		i.chunkLength.Observe(float64(length))
 		i.chunkAge.Observe(model.Now().Sub(chunkDesc.FirstTime).Seconds())
 	}
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -214,6 +214,7 @@ func (u *userState) unlockedGet(metric model.Metric, cfg *UserStatesConfig) (mod
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-metric series limit (%d) exceeded for %s: %s", cfg.MaxSeriesPerMetric, metricName, metric)
 	}
 
+	util.Event().Log("msg", "new series", "userID", u.userID, "fp", fp, "series", metric)
 	series = newMemorySeries(metric)
 	u.fpToSeries.put(fp, series)
 	u.index.add(metric, fp)

--- a/pkg/util/priority_queue.go
+++ b/pkg/util/priority_queue.go
@@ -76,9 +76,9 @@ func (pq *PriorityQueue) DrainAndClose() {
 	pq.cond.Broadcast()
 }
 
-// Enqueue adds an operation to the queue in priority order. If the operation
-// is already on the queue, it will be ignored.
-func (pq *PriorityQueue) Enqueue(op Op) {
+// Enqueue adds an operation to the queue in priority order. Returns
+// true if added; false if the operation was already on the queue.
+func (pq *PriorityQueue) Enqueue(op Op) bool {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
@@ -88,12 +88,13 @@ func (pq *PriorityQueue) Enqueue(op Op) {
 
 	_, enqueued := pq.hit[op.Key()]
 	if enqueued {
-		return
+		return false
 	}
 
 	pq.hit[op.Key()] = struct{}{}
 	heap.Push(&pq.queue, op)
 	pq.cond.Broadcast()
+	return true
 }
 
 // Dequeue will return the op with the highest priority; block if queue is


### PR DESCRIPTION
Fleshing out the "event sampling" with more detail on chunks flushed, DynamoDB retries and series creation.

Also stop logging/eventing in the case where all retries are exhausted - this isn't useful if you sample all retries.

While I was in here I created a metric for chunks created - so you can see the rate of creation compared to the rate of flushing.  Fixes #567 