### PR TITLE
Check for empty series during ingester chunk transfer

### DIFF
--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -375,6 +375,11 @@ func (i *Ingester) transferChunks() error {
 		for pair := range state.fpToSeries.iter() {
 			state.fpLocker.Lock(pair.fp)
 
+			if len(pair.series.chunkDescs) == 0 { // Nothing to send?
+				state.fpLocker.Unlock(pair.fp)
+				continue
+			}
+
 			chunks, err := toWireChunks(pair.series.chunkDescs)
 			if err != nil {
 				state.fpLocker.Unlock(pair.fp)

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -170,7 +170,9 @@ func (s *memorySeries) setChunks(descs []*desc) error {
 	}
 
 	s.chunkDescs = descs
-	s.lastTime = descs[len(descs)-1].LastTime
+	if len(descs) > 0 {
+		s.lastTime = descs[len(descs)-1].LastTime
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #776 
Not sending an empty series is a tiny optimisation.
