### PR TITLE
Improve log messages on chunk transfer

### DIFF
--- a/pkg/ingester/ingester_claim.go
+++ b/pkg/ingester/ingester_claim.go
@@ -73,7 +73,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 		// round this loop.
 		if fromIngesterID == "" {
 			fromIngesterID = wireSeries.FromIngesterId
-			level.Info(util.Logger).Log("msg", "processing TransferChunks request from ingester", "ingester", fromIngesterID)
+			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
 		}
 		metric := client.FromLabelPairs(wireSeries.Labels)
 		userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)
@@ -113,10 +113,10 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 	// Close the stream last, as this is what tells the "from" ingester that
 	// it's OK to shut down.
 	if err := stream.SendAndClose(&client.TransferChunksResponse{}); err != nil {
-		level.Error(util.Logger).Log("msg", "Error closing TransferChunks stream", "ingester", fromIngesterID, "err", err)
+		level.Error(util.Logger).Log("msg", "Error closing TransferChunks stream", "from_ingester", fromIngesterID, "err", err)
 		return err
 	}
-	level.Info(util.Logger).Log("msg", "Successfully transferred chunks to ingester", "ingester", fromIngesterID)
+	level.Info(util.Logger).Log("msg", "Successfully transferred chunks", "from_ingester", fromIngesterID)
 	return nil
 }
 

--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -358,7 +358,7 @@ func (i *Ingester) transferChunks() error {
 		return fmt.Errorf("cannot find ingester to transfer chunks to: %v", err)
 	}
 
-	level.Info(util.Logger).Log("msg", "sending chunks to ingester", "ingester", targetIngester.Addr)
+	level.Info(util.Logger).Log("msg", "sending chunks", "to_ingester", targetIngester.Addr)
 	c, err := i.cfg.ingesterClientFactory(targetIngester.Addr, i.cfg.clientConfig)
 	if err != nil {
 		return err
@@ -406,7 +406,7 @@ func (i *Ingester) transferChunks() error {
 		return err
 	}
 
-	level.Info(util.Logger).Log("msg", "successfully sent chunks to ingester", "ingester", targetIngester.Addr)
+	level.Info(util.Logger).Log("msg", "successfully sent chunks", "to_ingester", targetIngester.Addr)
 	return nil
 }
 


### PR DESCRIPTION
One message said "to ingester" when it meant "from ingester", which was confusing.
I have corrected that and changed all of them to a more structured-logging style.