### PR TITLE
Allow ingester to re-enqueue data while closing down

### DIFF
--- a/pkg/ingester/ingester_lifecycle.go
+++ b/pkg/ingester/ingester_lifecycle.go
@@ -342,7 +342,7 @@ func (i *Ingester) processShutdown() {
 
 		// Close & empty all the flush queues, to unblock waiting workers.
 		for _, flushQueue := range i.flushQueues {
-			flushQueue.DrainAndClose()
+			flushQueue.DiscardAndClose()
 		}
 	}
 

--- a/pkg/util/priority_queue.go
+++ b/pkg/util/priority_queue.go
@@ -66,8 +66,8 @@ func (pq *PriorityQueue) Close() {
 	pq.cond.Broadcast()
 }
 
-// DrainAndClose closed the queue and removes all the items from it.
-func (pq *PriorityQueue) DrainAndClose() {
+// DiscardAndClose closes the queue and removes all the items from it.
+func (pq *PriorityQueue) DiscardAndClose() {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 	pq.closed = true

--- a/pkg/util/priority_queue.go
+++ b/pkg/util/priority_queue.go
@@ -7,11 +7,12 @@ import (
 
 // PriorityQueue is a priority queue.
 type PriorityQueue struct {
-	lock   sync.Mutex
-	cond   *sync.Cond
-	closed bool
-	hit    map[string]struct{}
-	queue  queue
+	lock    sync.Mutex
+	cond    *sync.Cond
+	closing bool
+	closed  bool
+	hit     map[string]struct{}
+	queue   queue
 }
 
 // Op is an operation on the priority queue.
@@ -57,12 +58,12 @@ func (pq *PriorityQueue) Length() int {
 	return len(pq.queue)
 }
 
-// Close signals that the queue is closed. A closed queue will not accept new
-// items.
+// Close signals that the queue should be closed when it is empty.
+// A closed queue will not accept new items.
 func (pq *PriorityQueue) Close() {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
-	pq.closed = true
+	pq.closing = true
 	pq.cond.Broadcast()
 }
 
@@ -103,11 +104,12 @@ func (pq *PriorityQueue) Dequeue() Op {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	for len(pq.queue) == 0 && !pq.closed {
+	for len(pq.queue) == 0 && !(pq.closing || pq.closed) {
 		pq.cond.Wait()
 	}
 
-	if len(pq.queue) == 0 && pq.closed {
+	if len(pq.queue) == 0 && (pq.closing || pq.closed) {
+		pq.closed = true
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #427.  When the reader calls `Dequeue()` after the queue is empty we will set the `closed` flag so subsequent calls to `Enqueue()` still panic.

Also a drive-by renaming since to me "drain" implies we will read all the data from the queue, not throw it away.