### PR TITLE
WIP: Send samples to joining ingester during handover

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/user"
 	cortex_chunk "github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/ring"
@@ -163,6 +164,9 @@ type Ingester struct {
 	startTime time.Time
 	ready     bool
 
+	joiningSampleQueueLock sync.Mutex
+	joiningSampleQueue     []userSamples
+
 	// One queue per flush thread.  Fingerprint is used to
 	// pick a queue.
 	flushQueues     []*util.PriorityQueue
@@ -183,6 +187,11 @@ type Ingester struct {
 // ChunkStore is the interface we need to store chunks
 type ChunkStore interface {
 	Put(ctx context.Context, chunks []cortex_chunk.Chunk) error
+}
+
+type userSamples struct {
+	userID  string
+	samples []model.Sample
 }
 
 // New constructs a new Ingester.
@@ -249,6 +258,8 @@ func New(cfg Config, chunkStore ChunkStore) (*Ingester, error) {
 		state:     ring.PENDING,
 		startTime: time.Now(),
 
+		joiningSampleQueue: make([]userSamples, 0),
+
 		flushQueues: make([]*util.PriorityQueue, cfg.ConcurrentFlushes, cfg.ConcurrentFlushes),
 
 		ingestedSamples: prometheus.NewCounter(prometheus.CounterOpts{
@@ -304,6 +315,21 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	var lastPartialErr error
 	samples := client.FromWriteRequest(req)
 
+	if i.state == ring.JOINING {
+		userID, err := user.ExtractOrgID(ctx)
+		if err != nil {
+			// TODO not sure what to do here
+			return &client.WriteResponse{}, nil
+		}
+		i.joiningSampleQueueLock.Lock()
+		defer i.joiningSampleQueueLock.Unlock()
+		if i.state == ring.JOINING { // Confirm we are still joining, after we get the lock
+			i.joiningSampleQueue = append(
+				i.joiningSampleQueue,
+				userSamples{userID: userID, samples: samples})
+			return &client.WriteResponse{}, nil
+		}
+	}
 samples:
 	for j := range samples {
 		if err := i.append(ctx, &samples[j]); err != nil {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -318,8 +318,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	if i.state == ring.JOINING {
 		userID, err := user.ExtractOrgID(ctx)
 		if err != nil {
-			// TODO not sure what to do here
-			return &client.WriteResponse{}, nil
+			return nil, err
 		}
 		i.joiningSampleQueueLock.Lock()
 		defer i.joiningSampleQueueLock.Unlock()

--- a/pkg/ingester/ingester_claim.go
+++ b/pkg/ingester/ingester_claim.go
@@ -74,6 +74,10 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 		if fromIngesterID == "" {
 			fromIngesterID = wireSeries.FromIngesterId
 			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
+
+			if err := i.PreClaimTokensFor(fromIngesterID); err != nil {
+				return err
+			}
 		}
 		metric := client.FromLabelPairs(wireSeries.Labels)
 		userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -59,6 +59,20 @@ func (d *Desc) RemoveIngester(id string) {
 	d.Tokens = output
 }
 
+// PreClaimTokens marks all the tokens from one ingester to another,
+// returning the claimed token.
+// TODO a better name than PreClaim
+func (d *Desc) PreClaimTokens(from, to string) []uint32 {
+	var result []uint32
+	for i := 0; i < len(d.Tokens); i++ {
+		if d.Tokens[i].Ingester == from {
+			d.Tokens[i].NextIngester = to
+			result = append(result, d.Tokens[i].Token)
+		}
+	}
+	return result
+}
+
 // ClaimTokens transfers all the tokens from one ingester to another,
 // returning the claimed token.
 func (d *Desc) ClaimTokens(from, to string) []uint32 {

--- a/pkg/ring/model.go
+++ b/pkg/ring/model.go
@@ -59,9 +59,8 @@ func (d *Desc) RemoveIngester(id string) {
 	d.Tokens = output
 }
 
-// PreClaimTokens marks all the tokens from one ingester to another,
-// returning the claimed token.
-// TODO a better name than PreClaim
+// PreClaimTokens marks all the tokens from one ingester in preparation for transferring them to
+// another, returning the modified tokens.
 func (d *Desc) PreClaimTokens(from, to string) []uint32 {
 	var result []uint32
 	for i := 0; i < len(d.Tokens); i++ {
@@ -74,12 +73,13 @@ func (d *Desc) PreClaimTokens(from, to string) []uint32 {
 }
 
 // ClaimTokens transfers all the tokens from one ingester to another,
-// returning the claimed token.
+// returning the claimed tokens.
 func (d *Desc) ClaimTokens(from, to string) []uint32 {
 	var result []uint32
 	for i := 0; i < len(d.Tokens); i++ {
 		if d.Tokens[i].Ingester == from {
 			d.Tokens[i].Ingester = to
+			d.Tokens[i].NextIngester = ""
 			result = append(result, d.Tokens[i].Token)
 		}
 	}

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -48,7 +48,7 @@ func (r *Ring) replicationStrategy(ingesters []*IngesterDesc, op Operation) (
 
 // IsHealthy checks whether an ingester appears to be alive and heartbeating
 func (r *Ring) IsHealthy(ingester *IngesterDesc, op Operation) bool {
-	if op == Write && ingester.State != ACTIVE {
+	if op == Write && (ingester.State != ACTIVE && ingester.State != PREPARING_TO_LEAVE) {
 		return false
 	} else if op == Read && ingester.State == JOINING {
 		return false

--- a/pkg/ring/replication_strategy.go
+++ b/pkg/ring/replication_strategy.go
@@ -48,7 +48,7 @@ func (r *Ring) replicationStrategy(ingesters []*IngesterDesc, op Operation) (
 
 // IsHealthy checks whether an ingester appears to be alive and heartbeating
 func (r *Ring) IsHealthy(ingester *IngesterDesc, op Operation) bool {
-	if op == Write && (ingester.State != ACTIVE && ingester.State != PREPARING_TO_LEAVE) {
+	if op == Write && !(ingester.State == ACTIVE || ingester.State == PREPARING_TO_LEAVE || ingester.State == JOINING) {
 		return false
 	} else if op == Read && ingester.State == JOINING {
 		return false

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -213,6 +213,7 @@ func (r *Ring) getInternal(key uint32, op Operation) (ReplicationSet, error) {
 		distinctHosts[token.Ingester] = struct{}{}
 		ingester := r.ringDesc.Ingesters[token.Ingester]
 
+		// TODO update comment
 		// We do not want to Write to Ingesters that are not ACTIVE, but we do want
 		// to write the extra replica somewhere.  So we increase the size of the set
 		// of replicas for the key. This means we have to also increase the
@@ -220,7 +221,11 @@ func (r *Ring) getInternal(key uint32, op Operation) (ReplicationSet, error) {
 		// so don't skip it in this case.
 		// NB dead ingester will be filtered later (by replication_strategy.go).
 		if op == Write && ingester.State != ACTIVE {
-			n++
+			if nextIngester := r.ringDesc.Ingesters[token.NextIngester]; token.NextIngester != "" && ingester.State == JOINING {
+				ingester = nextIngester
+			} else {
+				n++
+			}
 		} else if op == Read && (ingester.State != ACTIVE && ingester.State != LEAVING) {
 			n++
 		}

--- a/pkg/ring/ring.proto
+++ b/pkg/ring/ring.proto
@@ -22,10 +22,32 @@ message TokenDesc {
 }
 
 enum IngesterState {
+	// ACTIVE: The ingester under normal operation
+	// Will be sent read and write requests
 	ACTIVE = 0;
+
+	// LEAVING: End state for ingesters shutting down.
+	// The ingester is shutting down and may be either:
+	// - transferring chunks to another joining ingester, or
+	// - flushing all in-memory chunks to persistent storage
+	// Will only be sent read requests.
 	LEAVING = 1;
 
+	// PENDING: Start state for a new ingester.
+	// The ingester is waiting to join the ring, it will either:
+	// - receive an incoming chunk transfer request from a leaving ingester (-> JOINING)
+	// - after a timeout, create new tokens and join the ring (-> ACTIVE)
+	// Will not be used for reads or writes.
 	PENDING = 2;
+
+	// JOINING: The injester was recently waiting to join the ring (PENDING ->) and is now
+	// handling an incoming chunk transfer request from a leaving ingester and will become active
+	// when transfer completes (-> ACTIVE).
+	// Will be sent write requests for the tokens it is receiving from the leaving ingester
 	JOINING = 3;
+
+	// PREPARING_TO_LEAVE: The ingester is about to shut down, and is looking for a replacement
+	// to receive its in-memory chunks, and will soon leave the ring (-> LEAVING).
+	// Will only be sent write requests
 	PREPARING_TO_LEAVE = 4;
 }

--- a/pkg/ring/ring.proto
+++ b/pkg/ring/ring.proto
@@ -18,6 +18,7 @@ message IngesterDesc {
 message TokenDesc {
 	uint32 token = 1;
 	string ingester = 2;
+	string nextIngester = 3;
 }
 
 enum IngesterState {

--- a/pkg/ring/ring.proto
+++ b/pkg/ring/ring.proto
@@ -27,4 +27,5 @@ enum IngesterState {
 
 	PENDING = 2;
 	JOINING = 3;
+	PREPARING_TO_LEAVE = 4;
 }


### PR DESCRIPTION
Avoids a "Mysterious Flush" (#467) after ingester handover by adding transfer destination information to the ring.

While an ingester handover is underway, the distributor will skip the leaving ingester, and pick an extra ingestor to maintain the same replication count for incoming samples.

This temporary ingestor is never involved in the handover, and will recieve samples only for the duration of the handover.
After the handover, since no more samples are being recieved, the temporary ingestor will eventually (default 5m later) mark those chunks as idle and flush them.
During a rollout this results in every ingestor flushing a shedload of chunks.

This change attempts to prevent that by marking a transfer as underway, sending new samples to the joining ingestor, and batching those new samples to be appended to the chunk store after a transfer is complete.

Fixes #467