### PR TITLE
Allow setting rule format version per user

### DIFF
--- a/cmd/configs/main.go
+++ b/cmd/configs/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
-	"github.com/weaveworks/cortex/pkg/configs"
 	"github.com/weaveworks/cortex/pkg/configs/api"
 	"github.com/weaveworks/cortex/pkg/configs/db"
 	"github.com/weaveworks/cortex/pkg/util"
@@ -25,12 +24,10 @@ func main() {
 				middleware.ServerUserHeaderInterceptor,
 			},
 		}
-		dbConfig          db.Config
-		logLevel          util.LogLevel
-		ruleFormatVersion configs.RuleFormatVersion
+		dbConfig db.Config
+		logLevel util.LogLevel
 	)
 	util.RegisterFlags(&serverConfig, &dbConfig, &logLevel)
-	flag.Var(&ruleFormatVersion, "configs.rule-format-version", "Which Prometheus rule format version to use: '1' or '2' (default '1').")
 	flag.Parse()
 
 	util.InitLogger(logLevel.AllowedLevel)
@@ -42,7 +39,7 @@ func main() {
 	}
 	defer db.Close()
 
-	a := api.New(db, ruleFormatVersion)
+	a := api.New(db)
 
 	server, err := server.New(serverConfig)
 	if err != nil {

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -175,7 +175,7 @@ func main() {
 	// serving configs from the configs API. Allows for smoother
 	// migration. See https://github.com/weaveworks/cortex/issues/619
 	if configStoreConfig.ConfigsAPIURL.URL == nil {
-		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig, rulerConfig.RuleFormatVersion)
+		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)
 			os.Exit(1)

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -106,7 +106,7 @@ func main() {
 	// serving configs from the configs API. Allows for smoother
 	// migration. See https://github.com/weaveworks/cortex/issues/619
 	if configStoreConfig.ConfigsAPIURL.URL == nil {
-		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig, rulerConfig.RuleFormatVersion)
+		a, err := ruler.NewAPIFromConfig(configStoreConfig.DBConfig)
 		if err != nil {
 			level.Error(util.Logger).Log("msg", "error initializing public rules API", "err", err)
 			os.Exit(1)

--- a/pkg/configs/api/api.go
+++ b/pkg/configs/api/api.go
@@ -20,17 +20,13 @@ import (
 
 // API implements the configs api.
 type API struct {
-	db                db.DB
-	ruleFormatVersion configs.RuleFormatVersion
+	db db.DB
 	http.Handler
 }
 
 // New creates a new API
-func New(database db.DB, rfv configs.RuleFormatVersion) *API {
-	a := &API{
-		db:                database,
-		ruleFormatVersion: rfv,
-	}
+func New(database db.DB) *API {
+	a := &API{db: database}
 	r := mux.NewRouter()
 	a.RegisterRoutes(r)
 	a.Handler = r
@@ -123,7 +119,7 @@ func (a *API) setConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid Alertmanager config: %v", err), http.StatusBadRequest)
 		return
 	}
-	if err := validateRulesFiles(cfg, a.ruleFormatVersion); err != nil {
+	if err := validateRulesFiles(cfg); err != nil {
 		level.Error(logger).Log("msg", "invalid rules", "err", err)
 		http.Error(w, fmt.Sprintf("Invalid rules: %v", err), http.StatusBadRequest)
 		return
@@ -179,8 +175,8 @@ func validateAlertmanagerConfig(cfg string) error {
 	return nil
 }
 
-func validateRulesFiles(c configs.Config, rfv configs.RuleFormatVersion) error {
-	_, err := configs.RulesConfig(c.RulesFiles).Parse(rfv)
+func validateRulesFiles(c configs.Config) error {
+	_, err := c.RulesConfig.Parse()
 	return err
 }
 

--- a/pkg/configs/api/helpers_test.go
+++ b/pkg/configs/api/helpers_test.go
@@ -27,7 +27,7 @@ var (
 // setup sets up the environment for the tests.
 func setup(t *testing.T) {
 	database = dbtest.Setup(t)
-	app = api.New(database, configs.RuleFormatV2)
+	app = api.New(database)
 	counter = 0
 }
 
@@ -77,7 +77,7 @@ func makeConfig() configs.Config {
 
             receivers:
             - name: noop`),
-		RulesFiles: nil,
+		RulesConfig: configs.RulesConfig{},
 	}
 }
 

--- a/pkg/configs/client/configs_test.go
+++ b/pkg/configs/client/configs_test.go
@@ -16,8 +16,9 @@ func TestJSONDecoding(t *testing.T) {
       "id": 1,
       "config": {
         "rules_files": {
-          "recording.rules": ":scope_authfe_request_duration_seconds:99quantile = histogram_quantile(0.99, sum(rate(scope_request_duration_seconds_bucket{ws=\"false\",job=\"authfe\",route!~\"(admin|metrics).*\"}[5m])) by (le))\n"
-        }
+          "recording.rules": "groups:\n- name: demo-service-alerts\n  interval: 15s\n  rules:\n  - alert: SomethingIsUp\n    expr: up == 1\n"
+				},
+				"rule_format_version": "2"
       }
     }
   }
@@ -28,8 +29,11 @@ func TestJSONDecoding(t *testing.T) {
 		"2": {
 			ID: 1,
 			Config: configs.Config{
-				RulesFiles: map[string]string{
-					"recording.rules": ":scope_authfe_request_duration_seconds:99quantile = histogram_quantile(0.99, sum(rate(scope_request_duration_seconds_bucket{ws=\"false\",job=\"authfe\",route!~\"(admin|metrics).*\"}[5m])) by (le))\n",
+				RulesConfig: configs.RulesConfig{
+					Files: map[string]string{
+						"recording.rules": "groups:\n- name: demo-service-alerts\n  interval: 15s\n  rules:\n  - alert: SomethingIsUp\n    expr: up == 1\n",
+					},
+					FormatVersion: configs.RuleFormatV2,
 				},
 			},
 		},

--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -41,9 +41,9 @@ func (v RuleFormatVersion) IsValid() bool {
 func (v RuleFormatVersion) MarshalJSON() ([]byte, error) {
 	switch v {
 	case RuleFormatV1:
-		return []byte(`"1"`), nil
+		return json.Marshal("1")
 	case RuleFormatV2:
-		return []byte(`"2"`), nil
+		return json.Marshal("2")
 	default:
 		return nil, fmt.Errorf("unknown rule format version %d", v)
 	}
@@ -51,10 +51,14 @@ func (v RuleFormatVersion) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (v *RuleFormatVersion) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case `"1"`:
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "1":
 		*v = RuleFormatV1
-	case `"2"`:
+	case "2":
 		*v = RuleFormatV2
 	default:
 		return fmt.Errorf("unknown rule format version %q", string(data))

--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -26,27 +27,37 @@ const (
 	RuleFormatV2 RuleFormatVersion = iota
 )
 
-// String implements flag.Value.
-func (v RuleFormatVersion) String() string {
+// IsValid returns whether the rules format version is a valid (known) version.
+func (v RuleFormatVersion) IsValid() bool {
 	switch v {
-	case RuleFormatV1:
-		return "1"
-	case RuleFormatV2:
-		return "2"
+	case RuleFormatV1, RuleFormatV2:
+		return true
 	default:
-		return "<unknown>"
+		return false
 	}
 }
 
-// Set implements flag.Value.
-func (v *RuleFormatVersion) Set(s string) error {
-	switch s {
-	case "1":
+// MarshalJSON implements json.Marshaler.
+func (v RuleFormatVersion) MarshalJSON() ([]byte, error) {
+	switch v {
+	case RuleFormatV1:
+		return []byte(`"1"`), nil
+	case RuleFormatV2:
+		return []byte(`"2"`), nil
+	default:
+		return nil, fmt.Errorf("unknown rule format version %d", v)
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (v *RuleFormatVersion) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case `"1"`:
 		*v = RuleFormatV1
-	case "2":
+	case `"2"`:
 		*v = RuleFormatV2
 	default:
-		return fmt.Errorf("invalid rule format version %q", s)
+		return fmt.Errorf("unknown rule format version %q", string(data))
 	}
 	return nil
 }
@@ -54,8 +65,44 @@ func (v *RuleFormatVersion) Set(s string) error {
 // A Config is a Cortex configuration for a single user.
 type Config struct {
 	// RulesFiles maps from a rules filename to file contents.
-	RulesFiles         RulesConfig `json:"rules_files"`
-	AlertmanagerConfig string      `json:"alertmanager_config"`
+	RulesConfig        RulesConfig
+	AlertmanagerConfig string
+}
+
+// configCompat is a compatibility struct to support old JSON config blobs
+// saved in the config DB that didn't have a rule format version yet and
+// just had a top-level field for the rule files.
+type configCompat struct {
+	RulesFiles         map[string]string `json:"rules_files"`
+	RuleFormatVersion  RuleFormatVersion `json:"rule_format_version"`
+	AlertmanagerConfig string            `json:"alertmanager_config"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (c Config) MarshalJSON() ([]byte, error) {
+	compat := &configCompat{
+		RulesFiles:         c.RulesConfig.Files,
+		RuleFormatVersion:  c.RulesConfig.FormatVersion,
+		AlertmanagerConfig: c.AlertmanagerConfig,
+	}
+
+	return json.Marshal(compat)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	compat := configCompat{}
+	if err := json.Unmarshal(data, &compat); err != nil {
+		return err
+	}
+	*c = Config{
+		RulesConfig: RulesConfig{
+			Files:         compat.RulesFiles,
+			FormatVersion: compat.RuleFormatVersion,
+		},
+		AlertmanagerConfig: compat.AlertmanagerConfig,
+	}
+	return nil
 }
 
 // View is what's returned from the Weave Cloud configs service
@@ -72,28 +119,34 @@ type View struct {
 
 // GetVersionedRulesConfig specializes the view to just the rules config.
 func (v View) GetVersionedRulesConfig() *VersionedRulesConfig {
-	if v.Config.RulesFiles == nil {
+	if v.Config.RulesConfig.Files == nil {
 		return nil
 	}
 	return &VersionedRulesConfig{
 		ID:        v.ID,
-		Config:    v.Config.RulesFiles,
+		Config:    v.Config.RulesConfig,
 		DeletedAt: v.DeletedAt,
 	}
 }
 
-// RulesConfig are the set of rules files for a particular organization.
-type RulesConfig map[string]string
+// RulesConfig is the rules configuration for a particular organization.
+type RulesConfig struct {
+	FormatVersion RuleFormatVersion `json:"format_version"`
+	Files         map[string]string `json:"files"`
+}
 
 // Equal compares two RulesConfigs for equality.
 //
 // instance Eq RulesConfig
 func (c RulesConfig) Equal(o RulesConfig) bool {
-	if len(o) != len(c) {
+	if c.FormatVersion != o.FormatVersion {
 		return false
 	}
-	for k, v1 := range c {
-		v2, ok := o[k]
+	if len(o.Files) != len(c.Files) {
+		return false
+	}
+	for k, v1 := range c.Files {
+		v2, ok := o.Files[k]
 		if !ok || v1 != v2 {
 			return false
 		}
@@ -103,18 +156,18 @@ func (c RulesConfig) Equal(o RulesConfig) bool {
 
 // Parse parses and validates the content of the rule files in a RulesConfig
 // according to the passed rule format version.
-func (c RulesConfig) Parse(v RuleFormatVersion) (map[string][]rules.Rule, error) {
-	switch v {
+func (c RulesConfig) Parse() (map[string][]rules.Rule, error) {
+	switch c.FormatVersion {
 	case RuleFormatV1:
-		return c.ParseV1()
+		return c.parseV1()
 	case RuleFormatV2:
-		return c.ParseV2()
+		return c.parseV2()
 	default:
-		panic("unknown rule format")
+		return nil, fmt.Errorf("unknown rule format version %v", c.FormatVersion)
 	}
 }
 
-// ParseV2 parses and validates the content of the rule files in a RulesConfig
+// parseV2 parses and validates the content of the rule files in a RulesConfig
 // according to the Prometheus 2.x rule format.
 //
 // NOTE: On one hand, we cannot return fully-fledged lists of rules.Group
@@ -127,10 +180,10 @@ func (c RulesConfig) Parse(v RuleFormatVersion) (map[string][]rules.Rule, error)
 // would otherwise have to ensure to convert the rulefmt.RuleGroup only exactly
 // once, not for every evaluation (or risk losing alert pending states). So
 // it's probably better to just return a set of rules.Rule here.
-func (c RulesConfig) ParseV2() (map[string][]rules.Rule, error) {
+func (c RulesConfig) parseV2() (map[string][]rules.Rule, error) {
 	groups := map[string][]rules.Rule{}
 
-	for fn, content := range c {
+	for fn, content := range c.Files {
 		rgs, errs := rulefmt.Parse([]byte(content))
 		if len(errs) > 0 {
 			return nil, fmt.Errorf("error parsing %s: %v", fn, errs[0])
@@ -170,13 +223,13 @@ func (c RulesConfig) ParseV2() (map[string][]rules.Rule, error) {
 	return groups, nil
 }
 
-// ParseV1 parses and validates the content of the rule files in a RulesConfig
+// parseV1 parses and validates the content of the rule files in a RulesConfig
 // according to the Prometheus 1.x rule format.
 //
 // The same comment about rule groups as on ParseV2() applies here.
-func (c RulesConfig) ParseV1() (map[string][]rules.Rule, error) {
+func (c RulesConfig) parseV1() (map[string][]rules.Rule, error) {
 	result := map[string][]rules.Rule{}
-	for fn, content := range c {
+	for fn, content := range c.Files {
 		stmts, err := promql.ParseStmts(content)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s: %s", fn, err)

--- a/pkg/configs/configs_test.go
+++ b/pkg/configs/configs_test.go
@@ -1,0 +1,25 @@
+package configs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalLegacyConfigWithMissingRuleFormatVersionSucceeds(t *testing.T) {
+	actual := Config{}
+	buf := []byte(`{"rules_files": {"a": "b"}}`)
+	assert.Nil(t, json.Unmarshal(buf, &actual))
+
+	expected := Config{
+		RulesConfig: RulesConfig{
+			Files: map[string]string{
+				"a": "b",
+			},
+			FormatVersion: RuleFormatV1,
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/configs/db/postgres/postgres.go
+++ b/pkg/configs/db/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -141,6 +142,9 @@ func (d DB) GetConfig(userID string) (configs.View, error) {
 
 // SetConfig sets a configuration.
 func (d DB) SetConfig(userID string, cfg configs.Config) error {
+	if !cfg.RulesConfig.FormatVersion.IsValid() {
+		return fmt.Errorf("invalid rule format version %v", cfg.RulesConfig.FormatVersion)
+	}
 	cfgBytes, err := json.Marshal(cfg)
 	if err != nil {
 		return err
@@ -189,12 +193,12 @@ func (d DB) SetRulesConfig(userID string, oldConfig, newConfig configs.RulesConf
 		// The supplied oldConfig must match the current config. If no config
 		// exists, then oldConfig must be nil. Otherwise, it must exactly
 		// equal the existing config.
-		if !((err == sql.ErrNoRows && oldConfig == nil) || oldConfig.Equal(current.Config.RulesFiles)) {
+		if !((err == sql.ErrNoRows && oldConfig.Files == nil) || oldConfig.Equal(current.Config.RulesConfig)) {
 			return nil
 		}
 		new := configs.Config{
 			AlertmanagerConfig: current.Config.AlertmanagerConfig,
-			RulesFiles:         newConfig,
+			RulesConfig:        newConfig,
 		}
 		updated = true
 		return d.SetConfig(userID, new)
@@ -205,7 +209,7 @@ func (d DB) SetRulesConfig(userID string, oldConfig, newConfig configs.RulesConf
 // findRulesConfigs helps GetAllRulesConfigs and GetRulesConfigs retrieve the
 // set of all active rules configurations across all our users.
 func (d DB) findRulesConfigs(filter squirrel.Sqlizer) (map[string]configs.VersionedRulesConfig, error) {
-	rows, err := d.Select("id", "owner_id", "config ->> 'rules_files'", "deleted_at").
+	rows, err := d.Select("id", "owner_id", "config ->> 'rules_files'", "config ->> 'rule_format_version'", "deleted_at").
 		Options("DISTINCT ON (owner_id)").
 		From("configs").
 		Where(filter).
@@ -230,12 +234,17 @@ func (d DB) findRulesConfigs(filter squirrel.Sqlizer) (map[string]configs.Versio
 		var cfg configs.VersionedRulesConfig
 		var userID string
 		var cfgBytes []byte
+		var rfvBytes []byte
 		var deletedAt pq.NullTime
-		err = rows.Scan(&cfg.ID, &userID, &cfgBytes, &deletedAt)
+		err = rows.Scan(&cfg.ID, &userID, &cfgBytes, &rfvBytes, &deletedAt)
 		if err != nil {
 			return nil, err
 		}
-		err = json.Unmarshal(cfgBytes, &cfg.Config)
+		err = json.Unmarshal(cfgBytes, &cfg.Config.Files)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(rfvBytes, &cfg.Config.FormatVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -17,26 +17,22 @@ import (
 
 // API implements the configs api.
 type API struct {
-	db                db.RulesDB
-	ruleFormatVersion configs.RuleFormatVersion
+	db db.RulesDB
 	http.Handler
 }
 
 // NewAPIFromConfig makes a new API from our database config.
-func NewAPIFromConfig(cfg db.Config, rfv configs.RuleFormatVersion) (*API, error) {
+func NewAPIFromConfig(cfg db.Config) (*API, error) {
 	db, err := db.NewRulesDB(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return NewAPI(db, rfv), nil
+	return NewAPI(db), nil
 }
 
 // NewAPI creates a new API.
-func NewAPI(db db.RulesDB, rfv configs.RuleFormatVersion) *API {
-	a := &API{
-		db:                db,
-		ruleFormatVersion: rfv,
-	}
+func NewAPI(db db.RulesDB) *API {
+	a := &API{db: db}
 	r := mux.NewRouter()
 	a.RegisterRoutes(r)
 	a.Handler = r
@@ -103,7 +99,7 @@ func (a *API) casConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err = updateReq.NewConfig.Parse(a.ruleFormatVersion); err != nil {
+	if _, err = updateReq.NewConfig.Parse(); err != nil {
 		level.Error(logger).Log("msg", "invalid rules", "err", err)
 		http.Error(w, fmt.Sprintf("Invalid rules: %v", err), http.StatusBadRequest)
 		return

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/user"
 	"github.com/weaveworks/cortex/pkg/chunk"
-	"github.com/weaveworks/cortex/pkg/configs"
 	"github.com/weaveworks/cortex/pkg/distributor"
 	"github.com/weaveworks/cortex/pkg/querier"
 	"github.com/weaveworks/cortex/pkg/util"
@@ -82,9 +81,6 @@ type Config struct {
 	// This is used for template expansion in alerts; must be a valid URL
 	ExternalURL util.URLValue
 
-	// Whether to parse rules according to the Prometheus v1 or v2 rule format.
-	RuleFormatVersion configs.RuleFormatVersion
-
 	// How frequently to evaluate rules by default.
 	EvaluationInterval time.Duration
 	NumWorkers         int
@@ -109,7 +105,6 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ExternalURL.URL, _ = url.Parse("") // Must be non-nil
 	f.Var(&cfg.ExternalURL, "ruler.external.url", "URL of alerts return path.")
-	f.Var(&cfg.RuleFormatVersion, "ruler.rule-format-version", "Which Prometheus rule format version to use: '1' or '2' (default '1').")
 	f.DurationVar(&cfg.EvaluationInterval, "ruler.evaluation-interval", 15*time.Second, "How frequently to evaluate rules")
 	f.IntVar(&cfg.NumWorkers, "ruler.num-workers", 1, "Number of rule evaluator worker routines in this process")
 	f.Var(&cfg.AlertmanagerURL, "ruler.alertmanager-url", "URL of the Alertmanager to send notifications to.")
@@ -407,7 +402,7 @@ type Server struct {
 // NewServer makes a new rule processing server.
 func NewServer(cfg Config, ruler *Ruler, rulesAPI RulesAPI) (*Server, error) {
 	// TODO: Separate configuration for polling interval.
-	s := newScheduler(rulesAPI, cfg.EvaluationInterval, cfg.EvaluationInterval, cfg.RuleFormatVersion)
+	s := newScheduler(rulesAPI, cfg.EvaluationInterval, cfg.EvaluationInterval)
 	if cfg.NumWorkers <= 0 {
 		return nil, fmt.Errorf("must have at least 1 worker, got %d", cfg.NumWorkers)
 	}

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -88,8 +88,6 @@ type scheduler struct {
 
 	pollInterval time.Duration // how often we check for new config
 
-	ruleFormatVersion configs.RuleFormatVersion // which rule format to expect
-
 	cfgs         map[string]map[string][]rules.Rule // all rules for all users
 	latestConfig configs.ID                         // # of last update received from config
 	sync.RWMutex
@@ -99,12 +97,11 @@ type scheduler struct {
 }
 
 // newScheduler makes a new scheduler.
-func newScheduler(rulesAPI RulesAPI, evaluationInterval, pollInterval time.Duration, rfv configs.RuleFormatVersion) scheduler {
+func newScheduler(rulesAPI RulesAPI, evaluationInterval, pollInterval time.Duration) scheduler {
 	return scheduler{
 		rulesAPI:           rulesAPI,
 		evaluationInterval: evaluationInterval,
 		pollInterval:       pollInterval,
-		ruleFormatVersion:  rfv,
 		q:                  NewSchedulingQueue(clockwork.NewRealClock()),
 		cfgs:               map[string]map[string][]rules.Rule{},
 
@@ -209,7 +206,7 @@ func (s *scheduler) addNewConfigs(now time.Time, cfgs map[string]configs.Version
 	hasher := fnv.New64a()
 
 	for userID, config := range cfgs {
-		rulesByGroup, err := config.Config.Parse(s.ruleFormatVersion)
+		rulesByGroup, err := config.Config.Parse()
 		if err != nil {
 			// XXX: This means that if a user has a working configuration and
 			// they submit a broken one, we'll keep processing the last known


### PR DESCRIPTION
The binary-wide rule format version flag is now removed in favor of
a per-user format version stored in the user's config JSON blob. That
JSON blob is created by the web UI and sent to the config API, so it's
now up to components outside of the Cortex backend (e.g. the Weaveworks
service UI) to set what rule format version they would like to set. If
the new JSON field for the version is omitted, it will default to 1.x
format upon unmarshaling.

This change can be rolled back safely to an older version of Cortex as
long as no 2.x rule files have been created.