### PR TITLE
Remove backoff.WaitWithoutCounting()

### DIFF
--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -256,14 +256,10 @@ func (a storageClient) BatchWrite(ctx context.Context, input chunk.WriteBatch) e
 			return err
 		}
 
-		// If there are unprocessed items, backoff and retry those items.
+		// If there are unprocessed items, retry those items.
 		if unprocessedItems := resp.UnprocessedItems; unprocessedItems != nil && dynamoDBWriteBatch(unprocessedItems).Len() > 0 {
 			logRetry(dynamoDBWriteBatch(unprocessedItems))
 			unprocessed.TakeReqs(unprocessedItems, -1)
-			// I am unclear why we don't count here; perhaps the idea is
-			// that while we are making _some_ progress we should carry on.
-			backoff.WaitWithoutCounting()
-			continue
 		}
 
 		backoff.Reset()
@@ -640,13 +636,9 @@ func (a storageClient) getDynamoDBChunks(ctx context.Context, chunks []chunk.Chu
 		}
 		result = append(result, processedChunks...)
 
-		// If there are unprocessed items, backoff and retry those items.
+		// If there are unprocessed items, retry those items.
 		if unprocessedKeys := response.UnprocessedKeys; unprocessedKeys != nil && dynamoDBReadRequest(unprocessedKeys).Len() > 0 {
 			unprocessed.TakeReqs(unprocessedKeys, -1)
-			// I am unclear why we don't count here; perhaps the idea is
-			// that while we are making _some_ progress we should carry on.
-			backoff.WaitWithoutCounting()
-			continue
 		}
 
 		backoff.Reset()

--- a/pkg/util/backoff.go
+++ b/pkg/util/backoff.go
@@ -63,12 +63,6 @@ func (b *Backoff) NumRetries() int {
 // Returns immediately if Context is terminated
 func (b *Backoff) Wait() {
 	b.numRetries++
-	b.WaitWithoutCounting()
-}
-
-// WaitWithoutCounting sleeps for the backoff time then increases backoff time
-// Returns immediately if Context is terminated
-func (b *Backoff) WaitWithoutCounting() {
 	// Based on the "Full Jitter" approach from https://www.awsarchitectureblog.com/2015/03/backoff.html
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
 	if b.Ongoing() {


### PR DESCRIPTION
The code has a bad smell - a comment saying we don't know why it's there. 

Empirical evidence from tracing shows that we end up waiting so long that a higher-level timeout will kick in and kill the whole operation, even though DynamoDB is reporting some progress.

If it turns out waiting was necessary, DynamoDB will tell us next time round the loop and we'll crank up the backoff again, so no harm done.

Part of #792 