### PR TITLE
Various minor improvements to the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cmd/table-manager/table-manager
 cmd/lite/lite
 .uptodate
 .pkg
+.cache
 pkg/ingester/client/cortex.pb.go
 pkg/ring/ring.pb.go
 bazel-*

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,4 +20,5 @@ RUN go get -tags netgo \
 		github.com/gogo/protobuf/gogoproto && \
 	rm -rf /go/pkg /go/src
 COPY build.sh /
+ENV GOCACHE=/go/cache
 ENTRYPOINT ["/build.sh"]

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.3-stretch
+FROM golang:1.10.1-stretch
 RUN apt-get update && apt-get install -y python-requests python-yaml file jq unzip protobuf-compiler libprotobuf-dev && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go clean -i net && \


### PR DESCRIPTION
- We use various `find` commands to figure out what to build; stop these traversing various large directories they shouldn't.
- Update to go 1.10 and start using its build caching.

Before these changes:
```
$ make clean
$ time make cmd/distributor/distributor
...
real	1m26.436s
user	0m0.848s
sys	0m0.699s
```

After:
```
$ make clean
$ time make cmd/distributor/distributor
...
real	0m35.185s
user	0m0.813s
sys	0m0.379s
```