### PR TITLE
Move DynamoDB-specific test to aws directory

### DIFF
--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -41,6 +41,7 @@ func TestTableManagerAutoScaling(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			mtime.NowForce(tm)
+			defer mtime.NowReset()
 			if err := tableManager.SyncTables(ctx); err != nil {
 				t.Fatal(err)
 			}
@@ -322,6 +323,7 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			mtime.NowForce(tm)
+			defer mtime.NowReset()
 			if err := tableManager.SyncTables(ctx); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/chunk/aws/fixtures.go
+++ b/pkg/chunk/aws/fixtures.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -27,7 +28,7 @@ func (f fixture) Teardown() error {
 }
 
 // Fixtures for testing the various configuration of AWS storage.
-var Fixtures = []chunk.Fixture{
+var Fixtures = []testutils.Fixture{
 	fixture{
 		name: "S3 chunks",
 		clients: func() (chunk.StorageClient, chunk.TableClient, chunk.SchemaConfig, error) {
@@ -52,7 +53,7 @@ var Fixtures = []chunk.Fixture{
 	dynamoDBFixture(2, 10, 20),
 }
 
-func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) chunk.Fixture {
+func dynamoDBFixture(provisionedErr, gangsize, maxParallelism int) testutils.Fixture {
 	return fixture{
 		name: fmt.Sprintf("DynamoDB chunks provisionedErr=%d, ChunkGangSize=%d, ChunkGetMaxParallelism=%d",
 			provisionedErr, gangsize, maxParallelism),

--- a/pkg/chunk/aws/storage_client_test.go
+++ b/pkg/chunk/aws/storage_client_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
+)
+
+const (
+	tableName = "table"
+)
+
+func TestChunksPartialError(t *testing.T) {
+	fixture := dynamoDBFixture(0, 10, 20)
+	defer fixture.Teardown()
+	client, err := testutils.Setup(fixture, tableName)
+	require.NoError(t, err)
+
+	// We use some carefully-chosen numbers:
+	// Start with 150 chunks; DynamoDB writes batches in 25s so 6 batches.
+	// We tell the client to error after 7 operations so all writes succeed
+	// and then the 2nd read fails, so we read back only 100 chunks
+	if ep, ok := client.(*storageClient); ok {
+		ep.SetErrorParameters(22, 7)
+	} else {
+		t.Error("DynamoDB test client has unexpected type")
+		return
+	}
+	ctx := context.Background()
+	_, chunks, err := testutils.CreateChunks(0, 150)
+	require.NoError(t, err)
+	err = client.PutChunks(ctx, chunks)
+	require.NoError(t, err)
+
+	chunksWeGot, err := client.GetChunks(ctx, chunks)
+	require.Error(t, err)
+	require.Equal(t, 100, len(chunksWeGot))
+}

--- a/pkg/chunk/cassandra/fixtures.go
+++ b/pkg/chunk/cassandra/fixtures.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -35,7 +36,7 @@ func (f fixture) Teardown() error {
 }
 
 // Fixtures for unit testing Cassandra integration.
-func Fixtures() ([]chunk.Fixture, error) {
+func Fixtures() ([]testutils.Fixture, error) {
 	addresses := os.Getenv("CASSANDRA_TEST_ADDRESSES")
 	if addresses == "" {
 		return nil, nil
@@ -69,7 +70,7 @@ func Fixtures() ([]chunk.Fixture, error) {
 		return nil, err
 	}
 
-	return []chunk.Fixture{
+	return []testutils.Fixture{
 		fixture{
 			name:          "Cassandra",
 			storageClient: storageClient,

--- a/pkg/chunk/gcp/fixtures.go
+++ b/pkg/chunk/gcp/fixtures.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -75,7 +76,7 @@ func (f *fixture) Teardown() error {
 }
 
 // Fixtures for unit testing GCP storage.
-var Fixtures = []chunk.Fixture{
+var Fixtures = []testutils.Fixture{
 	&fixture{
 		name: "GCP",
 	},

--- a/pkg/chunk/storage/storage_client_test.go
+++ b/pkg/chunk/storage/storage_client_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -56,37 +55,5 @@ func TestChunksBasic(t *testing.T) {
 				require.Equal(t, chunksToGet[i].ExternalKey(), chunksWeGot[i].ExternalKey(), strconv.Itoa(i))
 			}
 		}
-	})
-}
-
-type clientWithErrorParameters interface {
-	SetErrorParameters(provisionedErr, errAfter int)
-}
-
-func TestChunksPartialError(t *testing.T) {
-	forAllFixtures(t, func(t *testing.T, client chunk.StorageClient) {
-		// This test is currently very specialised for DynamoDB
-		if !strings.Contains(t.Name(), "DynamoDB") {
-			return
-		}
-		// We use some carefully-chosen numbers:
-		// Start with 150 chunks; DynamoDB writes batches in 25s so 6 batches.
-		// We tell the client to error after 7 operations so all writes succeed
-		// and then the 2nd read fails, so we read back only 100 chunks
-		if ep, ok := client.(clientWithErrorParameters); ok {
-			ep.SetErrorParameters(22, 7)
-		} else {
-			t.Error("DynamoDB test fixture does not support SetErrorParameters() call")
-			return
-		}
-		ctx := context.Background()
-		_, chunks, err := testutils.CreateChunks(0, 150)
-		require.NoError(t, err)
-		err = client.PutChunks(ctx, chunks)
-		require.NoError(t, err)
-
-		chunksWeGot, err := client.GetChunks(ctx, chunks)
-		require.Error(t, err)
-		require.Equal(t, 100, len(chunksWeGot))
 	})
 }

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -1,17 +1,14 @@
 package storage
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/chunk/aws"
 	"github.com/weaveworks/cortex/pkg/chunk/cassandra"
 	"github.com/weaveworks/cortex/pkg/chunk/gcp"
-	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
 )
 
 const (
@@ -30,48 +27,11 @@ func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 
 	for _, fixture := range fixtures {
 		t.Run(fixture.Name(), func(t *testing.T) {
-			storageClient, tableClient, schemaConfig, err := fixture.Clients()
+			storageClient, err := testutils.Setup(fixture, tableName)
 			require.NoError(t, err)
 			defer fixture.Teardown()
-
-			tableManager, err := chunk.NewTableManager(schemaConfig, 12*time.Hour, tableClient)
-			require.NoError(t, err)
-
-			err = tableManager.SyncTables(context.Background())
-			require.NoError(t, err)
-
-			err = tableClient.CreateTable(context.Background(), chunk.TableDesc{
-				Name: tableName,
-			})
-			require.NoError(t, err)
 
 			storageClientTest(t, storageClient)
 		})
 	}
-}
-
-func dummyChunk(now model.Time) chunk.Chunk {
-	return dummyChunkFor(now, model.Metric{
-		model.MetricNameLabel: "foo",
-		"bar":  "baz",
-		"toms": "code",
-	})
-}
-
-func dummyChunkFor(now model.Time, metric model.Metric) chunk.Chunk {
-	cs, _ := promchunk.New().Add(model.SamplePair{Timestamp: now, Value: 0})
-	chunk := chunk.NewChunk(
-		userID,
-		metric.Fingerprint(),
-		metric,
-		cs[0],
-		now.Add(-time.Hour),
-		now,
-	)
-	// Force checksum calculation.
-	_, err := chunk.Encode()
-	if err != nil {
-		panic(err)
-	}
-	return chunk
 }

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -27,10 +27,3 @@ type ReadBatch interface {
 	RangeValue(index int) []byte
 	Value(index int) []byte
 }
-
-// Fixture type for per-backend testing.
-type Fixture interface {
-	Name() string
-	Clients() (StorageClient, TableClient, SchemaConfig, error)
-	Teardown() error
-}

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -79,6 +79,7 @@ func tmTest(t *testing.T, client *mockTableClient, tableManager *TableManager, n
 	t.Run(name, func(t *testing.T) {
 		ctx := context.Background()
 		mtime.NowForce(tm)
+		defer mtime.NowReset()
 		if err := tableManager.SyncTables(ctx); err != nil {
 			t.Fatal(err)
 		}
@@ -312,6 +313,7 @@ func TestTableManagerTags(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			mtime.NowForce(tm)
+			defer mtime.NowReset()
 			if err := tableManager.SyncTables(ctx); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -1,0 +1,89 @@
+package testutils
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/common/model"
+	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+const (
+	userID = "userID"
+)
+
+// Fixture type for per-backend testing.
+type Fixture interface {
+	Name() string
+	Clients() (chunk.StorageClient, chunk.TableClient, chunk.SchemaConfig, error)
+	Teardown() error
+}
+
+func Setup(fixture Fixture, tableName string) (chunk.StorageClient, error) {
+	storageClient, tableClient, schemaConfig, err := fixture.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	tableManager, err := chunk.NewTableManager(schemaConfig, 12*time.Hour, tableClient)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tableManager.SyncTables(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	err = tableClient.CreateTable(context.Background(), chunk.TableDesc{
+		Name: tableName,
+	})
+	return storageClient, err
+}
+
+func CreateChunks(startIndex, batchSize int) ([]string, []chunk.Chunk, error) {
+	keys := []string{}
+	chunks := []chunk.Chunk{}
+	for j := 0; j < batchSize; j++ {
+		chunk := dummyChunkFor(model.Now(), model.Metric{
+			model.MetricNameLabel: "foo",
+			"index":               model.LabelValue(strconv.Itoa(startIndex*batchSize + j)),
+		})
+		chunks = append(chunks, chunk)
+		_, err := chunk.Encode() // Need to encode it, side effect calculates crc
+		if err != nil {
+			return nil, nil, err
+		}
+		keys = append(keys, chunk.ExternalKey())
+	}
+	return keys, chunks, nil
+}
+
+func dummyChunk(now model.Time) chunk.Chunk {
+	return dummyChunkFor(now, model.Metric{
+		model.MetricNameLabel: "foo",
+		"bar":  "baz",
+		"toms": "code",
+	})
+}
+
+func dummyChunkFor(now model.Time, metric model.Metric) chunk.Chunk {
+	cs, _ := promchunk.New().Add(model.SamplePair{Timestamp: now, Value: 0})
+	chunk := chunk.NewChunk(
+		userID,
+		metric.Fingerprint(),
+		metric,
+		cs[0],
+		now.Add(-time.Hour),
+		now,
+	)
+	// Force checksum calculation.
+	_, err := chunk.Encode()
+	if err != nil {
+		panic(err)
+	}
+	return chunk
+}

--- a/pkg/chunk/testutils/testutils.go
+++ b/pkg/chunk/testutils/testutils.go
@@ -22,6 +22,7 @@ type Fixture interface {
 	Teardown() error
 }
 
+// Setup a fixture with initial tables
 func Setup(fixture Fixture, tableName string) (chunk.StorageClient, error) {
 	storageClient, tableClient, schemaConfig, err := fixture.Clients()
 	if err != nil {
@@ -44,6 +45,7 @@ func Setup(fixture Fixture, tableName string) (chunk.StorageClient, error) {
 	return storageClient, err
 }
 
+// CreateChunks creates some chunks for testing
 func CreateChunks(startIndex, batchSize int) ([]string, []chunk.Chunk, error) {
 	keys := []string{}
 	chunks := []chunk.Chunk{}


### PR DESCRIPTION
Clean up the test added in #791 by adding another package that both users can import.
Cuts out a check on the test name string, and an interface.

The `mtime.NowReset()` lines are needed to meet the assumption of the chunk fixture.
