### PR TITLE
Uncouple ingester/client/pool from the ingester client, so it can be used elsewhere.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -38,6 +37,7 @@ var (
 		"The current number of ingester clients.",
 		nil, nil,
 	)
+	labelNameBytes = []byte(model.MetricNameLabel)
 )
 
 // Distributor is a storage.SampleAppender and a client.Querier which
@@ -46,9 +46,7 @@ type Distributor struct {
 	cfg          Config
 	ring         ring.ReadRing
 	clientsMtx   sync.RWMutex
-	ingesterPool *ingester_client.IngesterPool
-	quit         chan struct{}
-	done         chan struct{}
+	ingesterPool *ingester_client.Pool
 
 	billingClient *billing.Client
 
@@ -71,12 +69,11 @@ type Config struct {
 	EnableBilling        bool
 	BillingConfig        billing.Config
 	IngesterClientConfig ingester_client.Config
+	PoolConfig           ingester_client.PoolConfig
 
-	RemoteTimeout        time.Duration
-	ClientCleanupPeriod  time.Duration
-	IngestionRateLimit   float64
-	IngestionBurstSize   int
-	HealthCheckIngesters bool
+	RemoteTimeout      time.Duration
+	IngestionRateLimit float64
+	IngestionBurstSize int
 
 	ShardByAllLabels bool
 
@@ -86,21 +83,23 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	flag.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	cfg.BillingConfig.RegisterFlags(f)
 	cfg.IngesterClientConfig.RegisterFlags(f)
+	cfg.PoolConfig.RegisterFlags(f)
+
+	flag.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	flag.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
-	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
 	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
-	flag.BoolVar(&cfg.HealthCheckIngesters, "distributor.health-check-ingesters", false, "Run a health check on each ingester client during periodic cleanup.")
 	flag.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
 }
 
 // New constructs a new Distributor
 func New(cfg Config, ring ring.ReadRing) (*Distributor, error) {
 	if cfg.ingesterClientFactory == nil {
-		cfg.ingesterClientFactory = ingester_client.MakeIngesterClient
+		cfg.ingesterClientFactory = func(addr string) (grpc_health_v1.HealthClient, error) {
+			return ingester_client.MakeIngesterClient(addr, cfg.IngesterClientConfig)
+		}
 	}
 
 	var billingClient *billing.Client
@@ -112,16 +111,12 @@ func New(cfg Config, ring ring.ReadRing) (*Distributor, error) {
 		}
 	}
 
-	factory := func(addr string) (grpc_health_v1.HealthClient, error) {
-		return cfg.ingesterClientFactory(addr, cfg.IngesterClientConfig)
-	}
+	cfg.PoolConfig.RemoteTimeout = cfg.RemoteTimeout
 
 	d := &Distributor{
 		cfg:            cfg,
 		ring:           ring,
-		ingesterPool:   ingester_client.NewIngesterPool(cfg.ingesterClientFactory, cfg.IngesterClientConfig, cfg.RemoteTimeout, util.Logger),
-		quit:           make(chan struct{}),
-		done:           make(chan struct{}),
+		ingesterPool:   ingester_client.NewPool(cfg.PoolConfig, ring, cfg.ingesterClientFactory, util.Logger),
 		billingClient:  billingClient,
 		ingestLimiters: map[string]*rate.Limiter{},
 		queryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -162,52 +157,12 @@ func New(cfg Config, ring ring.ReadRing) (*Distributor, error) {
 			Help:      "The total number of failed queries sent to ingesters.",
 		}, []string{"ingester"}),
 	}
-	go d.Run()
 	return d, nil
-}
-
-// Run starts the distributor's maintenance loop.
-func (d *Distributor) Run() {
-	cleanupClients := time.NewTicker(d.cfg.ClientCleanupPeriod)
-	for {
-		select {
-		case <-cleanupClients.C:
-			d.removeStaleIngesterClients()
-			if d.cfg.HealthCheckIngesters {
-				d.ingesterPool.CleanUnhealthy()
-			}
-		case <-d.quit:
-			close(d.done)
-			return
-		}
-	}
 }
 
 // Stop stops the distributor's maintenance loop.
 func (d *Distributor) Stop() {
-	close(d.quit)
-	<-d.done
-}
-
-func (d *Distributor) removeStaleIngesterClients() {
-	ingesters := map[string]struct{}{}
-	replicationSet, err := d.ring.GetAll()
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "error removing stale ingester clients", "err", err)
-		return
-	}
-
-	for _, ing := range replicationSet.Ingesters {
-		ingesters[ing.Addr] = struct{}{}
-	}
-
-	for _, addr := range d.ingesterPool.RegisteredAddresses() {
-		if _, ok := ingesters[addr]; ok {
-			continue
-		}
-		level.Info(util.Logger).Log("msg", "removing stale ingester client", "addr", addr)
-		d.ingesterPool.RemoveClientFor(addr)
-	}
+	d.ingesterPool.Stop()
 }
 
 func (d *Distributor) tokenForLabels(userID string, labels []client.LabelPair) (uint32, error) {
@@ -215,11 +170,20 @@ func (d *Distributor) tokenForLabels(userID string, labels []client.LabelPair) (
 		return shardByAllLabels(userID, labels)
 	}
 
-	metricName, err := util.ExtractMetricNameFromLabelPairs(labels)
+	metricName, err := extractMetricNameFromLabelPairs(labels)
 	if err != nil {
 		return 0, err
 	}
 	return shardByMetricName(userID, metricName), nil
+}
+
+func extractMetricNameFromLabelPairs(labels []client.LabelPair) ([]byte, error) {
+	for _, label := range labels {
+		if label.Name.Equal(labelNameBytes) {
+			return label.Value, nil
+		}
+	}
+	return nil, fmt.Errorf("No metric name label")
 }
 
 func shardByMetricName(userID string, metricName []byte) uint32 {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
@@ -232,13 +233,15 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, shardByAllLabels bo
 		replicationFactor: 3,
 	}
 
-	factory := func(addr string, _ client.Config) (client.IngesterClient, error) {
+	factory := func(addr string) (grpc_health_v1.HealthClient, error) {
 		return ingestersByAddr[addr], nil
 	}
 
 	d, err := New(Config{
-		RemoteTimeout:         1 * time.Minute,
-		ClientCleanupPeriod:   1 * time.Minute,
+		PoolConfig: client.PoolConfig{
+			RemoteTimeout:       1 * time.Minute,
+			ClientCleanupPeriod: 1 * time.Minute,
+		},
 		IngestionRateLimit:    20,
 		IngestionBurstSize:    20,
 		ingesterClientFactory: factory,

--- a/pkg/ingester/client/pool.go
+++ b/pkg/ingester/client/pool.go
@@ -72,7 +72,7 @@ func (p *Pool) loop() {
 	for {
 		select {
 		case <-cleanupClients.C:
-			p.removeStaleIngesterClients()
+			p.removeStaleClients()
 			if p.cfg.HealthCheckIngesters {
 				p.cleanUnhealthy()
 			}
@@ -152,23 +152,23 @@ func (p *Pool) Count() int {
 	return len(p.clients)
 }
 
-func (p *Pool) removeStaleIngesterClients() {
-	ingesters := map[string]struct{}{}
+func (p *Pool) removeStaleClients() {
+	clients := map[string]struct{}{}
 	replicationSet, err := p.ring.GetAll()
 	if err != nil {
-		level.Error(util.Logger).Log("msg", "error removing stale ingester clients", "err", err)
+		level.Error(util.Logger).Log("msg", "error removing stale clients", "err", err)
 		return
 	}
 
 	for _, ing := range replicationSet.Ingesters {
-		ingesters[ing.Addr] = struct{}{}
+		clients[ing.Addr] = struct{}{}
 	}
 
 	for _, addr := range p.RegisteredAddresses() {
-		if _, ok := ingesters[addr]; ok {
+		if _, ok := clients[addr]; ok {
 			continue
 		}
-		level.Info(util.Logger).Log("msg", "removing stale ingester client", "addr", addr)
+		level.Info(util.Logger).Log("msg", "removing stale client", "addr", addr)
 		p.RemoveClientFor(addr)
 	}
 }

--- a/pkg/ingester/client/pool.go
+++ b/pkg/ingester/client/pool.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"flag"
 	fmt "fmt"
 	io "io"
 	"sync"
@@ -9,108 +10,179 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/ring"
+	"github.com/weaveworks/cortex/pkg/util"
 	context "golang.org/x/net/context"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// Factory defines the signature for an ingester client factory
+// Factory defines the signature for an ingester client factory.
 type Factory func(addr string) (grpc_health_v1.HealthClient, error)
 
-// IngesterPool holds a cache of ingester clients
-type IngesterPool struct {
-	sync.RWMutex
-	clients map[string]grpc_health_v1.HealthClient
-
-	ingesterClientFactory Factory
-	ingesterClientConfig  Config
-	healthCheckTimeout    time.Duration
-	logger                log.Logger
+// PoolConfig is config for creating a Pool.
+type PoolConfig struct {
+	ClientCleanupPeriod  time.Duration
+	HealthCheckIngesters bool
+	RemoteTimeout        time.Duration
 }
 
-// NewIngesterPool creates a new cache
-func NewIngesterPool(factory Factory, config Config, healthCheckTimeout time.Duration, logger log.Logger) *IngesterPool {
-	return &IngesterPool{
-		clients:               map[string]grpc_health_v1.HealthClient{},
-		ingesterClientFactory: factory,
-		healthCheckTimeout:    healthCheckTimeout,
-		logger:                logger,
+// RegisterFlags adds the flags required to config this to the given FlagSet.
+func (cfg *PoolConfig) RegisterFlags(f *flag.FlagSet) {
+	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
+	flag.BoolVar(&cfg.HealthCheckIngesters, "distributor.health-check-ingesters", false, "Run a health check on each ingester client during periodic cleanup.")
+}
+
+// Pool holds a cache of grpc_health_v1 clients.
+type Pool struct {
+	cfg     PoolConfig
+	ring    ring.ReadRing
+	factory Factory
+	logger  log.Logger
+
+	quit chan struct{}
+	done sync.WaitGroup
+
+	sync.RWMutex
+	clients map[string]grpc_health_v1.HealthClient
+}
+
+// NewPool creates a new Pool.
+func NewPool(cfg PoolConfig, ring ring.ReadRing, factory Factory, logger log.Logger) *Pool {
+	p := &Pool{
+		cfg:     cfg,
+		ring:    ring,
+		factory: factory,
+		logger:  logger,
+		quit:    make(chan struct{}),
+
+		clients: map[string]grpc_health_v1.HealthClient{},
+	}
+
+	p.done.Add(1)
+	go p.loop()
+	return p
+}
+
+func (p *Pool) loop() {
+	defer p.done.Done()
+
+	cleanupClients := time.NewTicker(p.cfg.ClientCleanupPeriod)
+	defer cleanupClients.Stop()
+
+	for {
+		select {
+		case <-cleanupClients.C:
+			p.removeStaleIngesterClients()
+			if p.cfg.HealthCheckIngesters {
+				p.cleanUnhealthy()
+			}
+		case <-p.quit:
+			return
+		}
 	}
 }
 
-func (pool *IngesterPool) fromCache(addr string) (grpc_health_v1.HealthClient, bool) {
-	pool.RLock()
-	defer pool.RUnlock()
-	client, ok := pool.clients[addr]
+// Stop the pool's background cleanup goroutine.
+func (p *Pool) Stop() {
+	close(p.quit)
+	p.done.Wait()
+}
+
+func (p *Pool) fromCache(addr string) (grpc_health_v1.HealthClient, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	client, ok := p.clients[addr]
 	return client, ok
 }
 
 // GetClientFor gets the client for the specified address. If it does not exist it will make a new client
 // at that address
-func (pool *IngesterPool) GetClientFor(addr string) (grpc_health_v1.HealthClient, error) {
-	client, ok := pool.fromCache(addr)
+func (p *Pool) GetClientFor(addr string) (grpc_health_v1.HealthClient, error) {
+	client, ok := p.fromCache(addr)
 	if ok {
 		return client, nil
 	}
 
-	pool.Lock()
-	defer pool.Unlock()
-	client, ok = pool.clients[addr]
+	p.Lock()
+	defer p.Unlock()
+	client, ok = p.clients[addr]
 	if ok {
 		return client, nil
 	}
 
-	client, err := pool.ingesterClientFactory(addr)
+	client, err := p.factory(addr)
 	if err != nil {
 		return nil, err
 	}
-	pool.clients[addr] = client
+	p.clients[addr] = client
 	return client, nil
 }
 
 // RemoveClientFor removes the client with the specified address
-func (pool *IngesterPool) RemoveClientFor(addr string) {
-	pool.Lock()
-	defer pool.Unlock()
-	client, ok := pool.clients[addr]
+func (p *Pool) RemoveClientFor(addr string) {
+	p.Lock()
+	defer p.Unlock()
+	client, ok := p.clients[addr]
 	if ok {
-		delete(pool.clients, addr)
+		delete(p.clients, addr)
 		// Close in the background since this operation may take awhile and we have a mutex
 		go func(addr string, closer io.Closer) {
 			if err := closer.Close(); err != nil {
-				level.Error(pool.logger).Log("msg", "error closing connection to ingester", "ingester", addr, "err", err)
+				level.Error(p.logger).Log("msg", "error closing connection to ingester", "ingester", addr, "err", err)
 			}
 		}(addr, client.(io.Closer))
 	}
 }
 
 // RegisteredAddresses returns all the addresses that a client is cached for
-func (pool *IngesterPool) RegisteredAddresses() []string {
+func (p *Pool) RegisteredAddresses() []string {
 	result := []string{}
-	pool.RLock()
-	defer pool.RUnlock()
-	for addr := range pool.clients {
+	p.RLock()
+	defer p.RUnlock()
+	for addr := range p.clients {
 		result = append(result, addr)
 	}
 	return result
 }
 
 // Count returns how many clients are in the cache
-func (pool *IngesterPool) Count() int {
-	pool.RLock()
-	defer pool.RUnlock()
-	return len(pool.clients)
+func (p *Pool) Count() int {
+	p.RLock()
+	defer p.RUnlock()
+	return len(p.clients)
 }
 
-// CleanUnhealthy loops through all ingesters and deletes any that fails a healtcheck.
-func (pool *IngesterPool) CleanUnhealthy() {
-	for _, addr := range pool.RegisteredAddresses() {
-		client, ok := pool.fromCache(addr)
+func (p *Pool) removeStaleIngesterClients() {
+	ingesters := map[string]struct{}{}
+	replicationSet, err := p.ring.GetAll()
+	if err != nil {
+		level.Error(util.Logger).Log("msg", "error removing stale ingester clients", "err", err)
+		return
+	}
+
+	for _, ing := range replicationSet.Ingesters {
+		ingesters[ing.Addr] = struct{}{}
+	}
+
+	for _, addr := range p.RegisteredAddresses() {
+		if _, ok := ingesters[addr]; ok {
+			continue
+		}
+		level.Info(util.Logger).Log("msg", "removing stale ingester client", "addr", addr)
+		p.RemoveClientFor(addr)
+	}
+}
+
+// cleanUnhealthy loops through all ingesters and deletes any that fails a healtcheck.
+func (p *Pool) cleanUnhealthy() {
+	for _, addr := range p.RegisteredAddresses() {
+		client, ok := p.fromCache(addr)
 		// not ok means someone removed a client between the start of this loop and now
 		if ok {
-			err := healthCheck(client, pool.healthCheckTimeout)
+			err := healthCheck(client, p.cfg.RemoteTimeout)
 			if err != nil {
-				level.Warn(pool.logger).Log("msg", "removing ingester failing healtcheck", "addr", addr, "reason", err)
-				pool.RemoveClientFor(addr)
+				level.Warn(util.Logger).Log("msg", "removing ingester failing healtcheck", "addr", addr, "reason", err)
+				p.RemoveClientFor(addr)
 			}
 		}
 	}

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -51,7 +51,7 @@ func TestHealthCheck(t *testing.T) {
 
 func TestIngesterCache(t *testing.T) {
 	buildCount := 0
-	factory := func(addr string, _ Config) (IngesterClient, error) {
+	factory := func(addr string) (grpc_health_v1.HealthClient, error) {
 		if addr == "bad" {
 			return nil, fmt.Errorf("Fail")
 		}
@@ -102,7 +102,7 @@ func TestIngesterCache(t *testing.T) {
 func TestCleanUnhealthy(t *testing.T) {
 	goodAddrs := []string{"good1", "good2"}
 	badAddrs := []string{"bad1", "bad2"}
-	clients := map[string]IngesterClient{}
+	clients := map[string]grpc_health_v1.HealthClient{}
 	for _, addr := range goodAddrs {
 		clients[addr] = mockIngester{happy: true, status: grpc_health_v1.HealthCheckResponse_SERVING}
 	}

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/weaveworks/cortex/pkg/ring"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -26,6 +27,14 @@ func (i mockIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheckR
 
 func (i mockIngester) Close() error {
 	return nil
+}
+
+type mockReadRing struct {
+	ring.ReadRing
+}
+
+func (mockReadRing) GetAll() (ring.ReplicationSet, error) {
+	return ring.ReplicationSet{}, nil
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -58,7 +67,12 @@ func TestIngesterCache(t *testing.T) {
 		buildCount++
 		return mockIngester{happy: true, status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 	}
-	pool := NewIngesterPool(factory, Config{}, 50*time.Millisecond, log.NewNopLogger())
+
+	pool := NewPool(PoolConfig{
+		RemoteTimeout:       50 * time.Millisecond,
+		ClientCleanupPeriod: 10 * time.Second,
+	}, mockReadRing{}, factory, log.NewNopLogger())
+	defer pool.Stop()
 
 	pool.GetClientFor("1")
 	if buildCount != 1 {
@@ -109,11 +123,11 @@ func TestCleanUnhealthy(t *testing.T) {
 	for _, addr := range badAddrs {
 		clients[addr] = mockIngester{happy: false, status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}
 	}
-	pool := &IngesterPool{
+	pool := &Pool{
 		clients: clients,
 		logger:  log.NewNopLogger(),
 	}
-	pool.CleanUnhealthy()
+	pool.cleanUnhealthy()
 	for _, addr := range badAddrs {
 		if _, ok := pool.clients[addr]; ok {
 			t.Errorf("Found bad ingester after clean: %s\n", addr)

--- a/pkg/util/matchers.go
+++ b/pkg/util/matchers.go
@@ -5,11 +5,6 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/weaveworks/cortex/pkg/ingester/client"
-)
-
-var (
-	labelNameBytes = []byte(model.MetricNameLabel)
 )
 
 // SplitFiltersAndMatchers splits empty matchers off, which are treated as filters, see #220
@@ -28,16 +23,6 @@ func SplitFiltersAndMatchers(allMatchers []*labels.Matcher) (filters, matchers [
 		}
 	}
 	return
-}
-
-// ExtractMetricNameFromLabelPairs extracts the metric name for a slice of LabelPairs.
-func ExtractMetricNameFromLabelPairs(labels []client.LabelPair) ([]byte, error) {
-	for _, label := range labels {
-		if label.Name.Equal(labelNameBytes) {
-			return label.Value, nil
-		}
-	}
-	return nil, fmt.Errorf("No metric name label")
 }
 
 // ExtractMetricNameFromMetric extract the metric name from a model.Metric


### PR DESCRIPTION
Makes the ingester client pool only rely on grpc_health_v1 interface; I've found this code useful in other projects after reducing this coupling.

Also move the cleanup loop into `pool.go`, and do some tidy ups: rename pool method target to p, remove to stuttering.