### PR TITLE
Allow client time to be slightly in the future without moaning

### DIFF
--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -188,7 +188,7 @@ func (c *Store) Get(ctx context.Context, from, through model.Time, allMatchers .
 		return nil, nil
 	}
 
-	if through.After(now) {
+	if through.After(now.Add(5 * time.Minute)) {
 		// time-span end is in future ... regard as legal
 		level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "adjusting end timerange from future to now", "old_through", through, "new_through", now)
 		through = now // Avoid processing future part - otherwise some schemas could fail with eg non-existent table gripes


### PR DESCRIPTION
This is to address logs like these:

```
ts=2018-04-30T12:00:37Z caller=log.go:112 level=error org_id=123 msg="adjusting end timerange from future to now" old_through=1525089638 new_through=1525089637.71
ts=2018-04-30T12:00:38Z caller=log.go:112 level=error org_id=123 msg="adjusting end timerange from future to now" old_through=1525089639 new_through=1525089638.425
```

