### PR TITLE
Don't pass a http.Request to ParseProtoRequest; pass an io.Reader 

### DIFF
--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -16,7 +16,7 @@ import (
 func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 	compressionType := util.CompressionTypeFor(r.Header.Get("X-Prometheus-Remote-Write-Version"))
 	var req client.WriteRequest
-	buf, err := util.ParseProtoRequest(r.Context(), r, &req, compressionType)
+	buf, err := util.ParseProtoReader(r.Context(), r.Body, &req, compressionType)
 	logger := util.WithContext(r.Context(), util.Logger)
 	if err != nil {
 		level.Error(logger).Log("err", err.Error())

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -136,7 +136,7 @@ func (q MergeQueryable) RemoteReadHandler(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	var req client.ReadRequest
 	logger := util.WithContext(r.Context(), util.Logger)
-	if _, err := util.ParseProtoRequest(ctx, r, &req, compressionType); err != nil {
+	if _, err := util.ParseProtoReader(ctx, r.Body, &req, compressionType); err != nil {
 		level.Error(logger).Log("err", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -54,17 +55,17 @@ func CompressionTypeFor(version string) CompressionType {
 	return FramedSnappy
 }
 
-// ParseProtoRequest parses a proto from the body of an HTTP request.
-func ParseProtoRequest(ctx context.Context, r *http.Request, req proto.Message, compression CompressionType) ([]byte, error) {
+// ParseProtoReader parses a compressed proto from an io.Reader.
+func ParseProtoReader(ctx context.Context, reader io.Reader, req proto.Message, compression CompressionType) ([]byte, error) {
 	var body []byte
 	var err error
 	switch compression {
 	case NoCompression:
-		body, err = ioutil.ReadAll(r.Body)
+		body, err = ioutil.ReadAll(reader)
 	case FramedSnappy:
-		body, err = ioutil.ReadAll(snappy.NewReader(r.Body))
+		body, err = ioutil.ReadAll(snappy.NewReader(reader))
 	case RawSnappy:
-		body, err = ioutil.ReadAll(r.Body)
+		body, err = ioutil.ReadAll(reader)
 		if err == nil {
 			body, err = snappy.Decode(nil, body)
 		}


### PR DESCRIPTION
Makes the function more general and reusable for HTTP responses.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>