### PR TITLE
Added querier.invariant-metricname config option.

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -125,7 +125,7 @@ func main() {
 	defer tableManager.Stop()
 
 	engine := promql.NewEngine(util.Logger, nil, querierConfig.MaxConcurrent, querierConfig.Timeout)
-	queryable := querier.NewQueryable(dist, chunkStore)
+	queryable := querier.NewQueryable(dist, chunkStore, &querierConfig)
 
 	if configStoreConfig.ConfigsAPIURL.String() != "" || configStoreConfig.DBConfig.URI != "" {
 		rulesAPI, err := ruler.NewRulesAPI(configStoreConfig)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 	defer chunkStore.Stop()
 
-	queryable := querier.NewQueryable(dist, chunkStore)
+	queryable := querier.NewQueryable(dist, chunkStore, &querierConfig)
 
 	engine := promql.NewEngine(util.Logger, nil, querierConfig.MaxConcurrent, querierConfig.Timeout)
 	api := v1.NewAPI(

--- a/cmd/ruler/main.go
+++ b/cmd/ruler/main.go
@@ -31,6 +31,7 @@ func main() {
 		}
 		ringConfig        ring.Config
 		distributorConfig distributor.Config
+		querierConfig     querier.Config
 		rulerConfig       ruler.Config
 		chunkStoreConfig  chunk.StoreConfig
 		schemaConfig      chunk.SchemaConfig
@@ -43,7 +44,7 @@ func main() {
 	trace := tracing.NewFromEnv("ruler")
 	defer trace.Close()
 
-	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig,
+	util.RegisterFlags(&serverConfig, &ringConfig, &distributorConfig, &querierConfig,
 		&rulerConfig, &chunkStoreConfig, &storageConfig, &schemaConfig, &configStoreConfig, &logLevel)
 	flag.Parse()
 
@@ -78,7 +79,7 @@ func main() {
 	prometheus.MustRegister(dist)
 
 	engine := promql.NewEngine(util.Logger, prometheus.DefaultRegisterer, rulerConfig.NumWorkers, rulerConfig.GroupTimeout)
-	queryable := querier.NewQueryable(dist, chunkStore)
+	queryable := querier.NewQueryable(dist, chunkStore, &querierConfig)
 
 	rlr, err := ruler.NewRuler(rulerConfig, engine, queryable, dist)
 	if err != nil {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -126,6 +126,24 @@ func TestMergeQuerierSortsMetricLabels(t *testing.T) {
 	}, l)
 }
 
+func TestMergeQuerierEnforcesInvariantMetricName(t *testing.T) {
+	mq := mergeQuerier{
+		cfg: &Config{InvariantMetricName: true},
+		ctx: context.Background(),
+		queriers: []Querier{
+			mockQuerier{},
+		},
+		mint: 0,
+		maxt: 0,
+	}
+
+	m, err := labels.NewMatcher(labels.MatchRegexp, labels.MetricName, "testmetric")
+	require.NoError(t, err)
+	dummyParams := storage.SelectParams{}
+	_, err = mq.Select(&dummyParams, m)
+	require.Error(t, err)
+}
+
 type mockQuerier struct {
 	matrix model.Matrix
 }

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -29,7 +29,7 @@ func newTestRuler(t *testing.T, alertmanagerURL string) *Ruler {
 	// other kinds of tests.
 
 	engine := promql.NewEngine(nil, nil, 20, 2*time.Minute)
-	queryable := querier.NewQueryable(nil, nil)
+	queryable := querier.NewQueryable(nil, nil, nil)
 	ruler, err := NewRuler(cfg, engine, queryable, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What?

Queries with metricname variants can be very slow. This PR adds a config option to querier to return an error for queries using metricname variants. This avoids doing a bunch of work for queries that will timeout anyway.

![screen shot 2018-05-30 at 3 49 59 pm](https://user-images.githubusercontent.com/121623/40749413-32430322-6421-11e8-923f-171f4de638e5.png)

## How?

Adds bool config option `querier.invariant-metricname`. When true the querier returns an error when users try to query with a metricname variant. Default value is `false` to preserve existing behavior.

## Where?

`querier.go`, `querier_test.go`.