### PR TITLE
Deprecate v7 and v8 schema versions

### DIFF
--- a/k8s/ingester-dep.yaml
+++ b/k8s/ingester-dep.yaml
@@ -49,7 +49,7 @@ spec:
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
-        - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.v6-schema-from=2017-03-19
         - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms

--- a/k8s/querier-dep.yaml
+++ b/k8s/querier-dep.yaml
@@ -26,8 +26,7 @@ spec:
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
-        - -dynamodb.v7-schema-from=2017-03-19
-        - -dynamodb.v8-schema-from=2017-06-05
+        - -dynamodb.v6-schema-from=2017-03-19
         - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms

--- a/k8s/ruler-dep.yaml
+++ b/k8s/ruler-dep.yaml
@@ -29,8 +29,7 @@ spec:
         - -dynamodb.base64-buckets-from=2017-01-17
         - -dynamodb.v4-schema-from=2017-02-05
         - -dynamodb.v5-schema-from=2017-02-22
-        - -dynamodb.v7-schema-from=2017-03-19
-        - -dynamodb.v8-schema-from=2017-06-05
+        - -dynamodb.v6-schema-from=2017-03-19
         - -dynamodb.chunk-table.from=2017-04-17
         - -memcached.hostname=memcached.default.svc.cluster.local
         - -memcached.timeout=100ms

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -126,7 +126,7 @@ func v6Schema(cfg SchemaConfig) Schema {
 	}
 }
 
-// DEPRECATED: v7 schema is an extension of v6, with support for queries with no metric names
+// DEPRECATED: v7 schema is an extension of v6, with support for queries with no metric names, but is broken
 func v7Schema(cfg SchemaConfig) Schema {
 	return schema{
 		cfg.dailyBuckets,
@@ -134,7 +134,7 @@ func v7Schema(cfg SchemaConfig) Schema {
 	}
 }
 
-// DEPRECATED: v8 schema is an extension of v6, with support for a labelset/series index
+// DEPRECATED: v8 schema is an extension of v6, with support for a labelset/series index, but is too slow in practice
 func v8Schema(cfg SchemaConfig) Schema {
 	return schema{
 		cfg.dailyBuckets,

--- a/pkg/chunk/schema.go
+++ b/pkg/chunk/schema.go
@@ -126,7 +126,7 @@ func v6Schema(cfg SchemaConfig) Schema {
 	}
 }
 
-// v7 schema is an extension of v6, with support for queries with no metric names
+// DEPRECATED: v7 schema is an extension of v6, with support for queries with no metric names
 func v7Schema(cfg SchemaConfig) Schema {
 	return schema{
 		cfg.dailyBuckets,
@@ -134,7 +134,7 @@ func v7Schema(cfg SchemaConfig) Schema {
 	}
 }
 
-// v8 schema is an extension of v6, with support for a labelset/series index
+// DEPRECATED: v8 schema is an extension of v6, with support for a labelset/series index
 func v8Schema(cfg SchemaConfig) Schema {
 	return schema{
 		cfg.dailyBuckets,

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -58,8 +58,8 @@ func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.V4SchemaFrom, "dynamodb.v4-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v4 schema.")
 	f.Var(&cfg.V5SchemaFrom, "dynamodb.v5-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v5 schema.")
 	f.Var(&cfg.V6SchemaFrom, "dynamodb.v6-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v6 schema.")
-	f.Var(&cfg.V7SchemaFrom, "dynamodb.v7-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v7 schema.")
-	f.Var(&cfg.V8SchemaFrom, "dynamodb.v8-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v8 schema.")
+	f.Var(&cfg.V7SchemaFrom, "dynamodb.v7-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v7 schema (Deprecated).")
+	f.Var(&cfg.V8SchemaFrom, "dynamodb.v8-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v8 schema (Deprecated).")
 
 	f.BoolVar(&cfg.ThroughputUpdatesDisabled, "table-manager.throughput-updates-disabled", false, "If true, disable all changes to DB capacity")
 	f.DurationVar(&cfg.DynamoDBPollInterval, "dynamodb.poll-interval", 2*time.Minute, "How frequently to poll DynamoDB to learn our capacity.")


### PR DESCRIPTION
Deprecate v7 and v8 schema versions since they don't really work. Make it more obvious in the example k8s configuration that v6 should be used.