### PR TITLE
Return HTTP 429 if ingestion rate limit exceeded

### DIFF
--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -36,11 +36,7 @@ func (d *Distributor) PushHandler(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := d.Push(r.Context(), &req); err != nil {
 		level.Error(logger).Log("msg", "push error", "err", err)
-		if err == errIngestionRateLimitExceeded {
-			// Return a 4xx here to have the client discard the data and not retry. If a client
-			// is sending too much data consistently we will unlikely ever catch up otherwise.
-			http.Error(w, err.Error(), http.StatusTooManyRequests)
-		} else if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+		if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
 			http.Error(w, string(httpResp.Body), int(httpResp.Code))
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
When the distributor's push handler hits the ingestion rate limit due to
prom clients sending too much data consistently, we are unlikely to
catch up.

If we return a 429 here, the client will discard the congested data.