### PR TITLE
Ruler will add stale markers to stale series

### DIFF
--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -2,6 +2,7 @@ package ruler
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -51,7 +52,9 @@ func (a *appendableAppender) AddFast(l labels.Labels, ref uint64, t int64, v flo
 }
 
 func (a *appendableAppender) Commit() error {
-	if _, err := a.pusher.Push(a.ctx, client.ToWriteRequest(a.samples)); err != nil {
+	ctx, cancel := context.WithTimeout(a.ctx, 15*time.Second)
+	defer cancel()
+	if _, err := a.pusher.Push(ctx, client.ToWriteRequest(a.samples)); err != nil {
 		return err
 	}
 	a.samples = nil

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -54,11 +54,9 @@ func (a *appendableAppender) AddFast(l labels.Labels, ref uint64, t int64, v flo
 func (a *appendableAppender) Commit() error {
 	ctx, cancel := context.WithTimeout(a.ctx, 15*time.Second)
 	defer cancel()
-	if _, err := a.pusher.Push(ctx, client.ToWriteRequest(a.samples)); err != nil {
-		return err
-	}
+	_, err := a.pusher.Push(ctx, client.ToWriteRequest(a.samples))
 	a.samples = nil
-	return nil
+	return err
 }
 
 func (a *appendableAppender) Rollback() error {

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -2,7 +2,6 @@ package ruler
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -52,9 +51,7 @@ func (a *appendableAppender) AddFast(l labels.Labels, ref uint64, t int64, v flo
 }
 
 func (a *appendableAppender) Commit() error {
-	ctx, cancel := context.WithTimeout(a.ctx, 15*time.Second)
-	defer cancel()
-	_, err := a.pusher.Push(ctx, client.ToWriteRequest(a.samples))
+	_, err := a.pusher.Push(a.ctx, client.ToWriteRequest(a.samples))
 	a.samples = nil
 	return err
 }

--- a/pkg/ruler/group.go
+++ b/pkg/ruler/group.go
@@ -1,0 +1,29 @@
+package ruler
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/prometheus/rules"
+)
+
+// group is a wrapper around a prometheus rules.Group, with a mutable appendable
+type group struct {
+	promGroup  *rules.Group
+	appendable *appendableAppender
+}
+
+func newGroup(name string, rls []rules.Rule, appendable *appendableAppender, opts *rules.ManagerOptions) *group {
+	delay := 0 * time.Second // Unused, so 0 value is fine.
+	promGroup := rules.NewGroup(name, "none", delay, rls, opts)
+	return &group{promGroup, appendable}
+}
+
+func (g *group) Eval(ctx context.Context, ts time.Time) {
+	g.appendable.ctx = ctx
+	g.promGroup.Eval(ctx, ts)
+}
+
+func (g *group) Rules() []rules.Rule {
+	return g.promGroup.Rules()
+}

--- a/pkg/ruler/group.go
+++ b/pkg/ruler/group.go
@@ -8,6 +8,7 @@ import (
 )
 
 // group is a wrapper around a prometheus rules.Group, with a mutable appendable
+// appendable stored here will be the same appendable as in promGroup.opts.Appendable
 type group struct {
 	promGroup  *rules.Group
 	appendable *appendableAppender

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -378,7 +378,7 @@ func (r *Ruler) Evaluate(userID string, item *workItem) {
 	if err := ctx.Err(); err == nil {
 		cancelTimeout() // release resources
 	} else {
-		level.Warn(util.Logger).Log("msg", "context error", "error", err)
+		level.Warn(util.Logger).Log("msg", "context error", "user_id", userID, "error", err)
 	}
 
 	rulesProcessed.Add(float64(len(item.group.Rules())))

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -274,9 +274,8 @@ func buildNotifierConfig(rulerConfig *Config) (*config.Config, error) {
 	return promConfig, nil
 }
 
-func (r *Ruler) newGroup(userID string, groupName string, rls []rules.Rule) (*rules.Group, error) {
-	ctx := user.InjectOrgID(context.Background(), userID)
-	appendable := &appendableAppender{pusher: r.pusher, ctx: ctx}
+func (r *Ruler) newGroup(userID string, groupName string, rls []rules.Rule) (*group, error) {
+	appendable := &appendableAppender{pusher: r.pusher}
 	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
 		return nil, err
@@ -290,8 +289,7 @@ func (r *Ruler) newGroup(userID string, groupName string, rls []rules.Rule) (*ru
 		Logger:      gklog.NewNopLogger(),
 		Registerer:  prometheus.DefaultRegisterer,
 	}
-	delay := 0 * time.Second // Unused, so 0 value is fine.
-	return rules.NewGroup(groupName, "none", delay, rls, opts), nil
+	return newGroup(groupName, rls, appendable, opts), nil
 }
 
 // sendAlerts implements a rules.NotifyFunc for a Notifier.

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -376,7 +376,7 @@ func (r *Ruler) Evaluate(userID string, item *workItem) {
 	if err := ctx.Err(); err == nil {
 		cancelTimeout() // release resources
 	} else {
-		level.Warn(util.Logger).Log("msg", "context error", "user_id", userID, "error", err)
+		level.Warn(logger).Log("msg", "context error", "error", err)
 	}
 
 	rulesProcessed.Add(float64(len(item.group.Rules())))

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -274,7 +274,8 @@ func buildNotifierConfig(rulerConfig *Config) (*config.Config, error) {
 	return promConfig, nil
 }
 
-func (r *Ruler) newGroup(ctx context.Context, userID string, item *workItem) (*rules.Group, error) {
+func (r *Ruler) newGroup(userID string, groupName string, rls []rules.Rule) (*rules.Group, error) {
+	ctx := user.InjectOrgID(context.Background(), userID)
 	appendable := &appendableAppender{pusher: r.pusher, ctx: ctx}
 	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
@@ -283,14 +284,14 @@ func (r *Ruler) newGroup(ctx context.Context, userID string, item *workItem) (*r
 	opts := &rules.ManagerOptions{
 		Appendable:  appendable,
 		QueryFunc:   rules.EngineQueryFunc(r.engine, r.queryable),
-		Context:     ctx,
+		Context:     context.Background(),
 		ExternalURL: r.alertURL,
 		NotifyFunc:  sendAlerts(notifier, r.alertURL.String()),
 		Logger:      gklog.NewNopLogger(),
 		Registerer:  prometheus.DefaultRegisterer,
 	}
 	delay := 0 * time.Second // Unused, so 0 value is fine.
-	return rules.NewGroup(item.groupName, "none", delay, item.rules, opts), nil
+	return rules.NewGroup(groupName, "none", delay, rls, opts), nil
 }
 
 // sendAlerts implements a rules.NotifyFunc for a Notifier.
@@ -364,19 +365,14 @@ func (r *Ruler) getOrCreateNotifier(userID string) (*notifier.Manager, error) {
 func (r *Ruler) Evaluate(userID string, item *workItem) {
 	ctx := user.InjectOrgID(context.Background(), userID)
 	logger := util.WithContext(ctx, util.Logger)
-	level.Debug(logger).Log("msg", "evaluating rules...", "num_rules", len(item.rules))
+	level.Debug(logger).Log("msg", "evaluating rules...", "num_rules", len(item.group.Rules()))
 	ctx, cancelTimeout := context.WithTimeout(ctx, r.groupTimeout)
 	instrument.CollectedRequest(ctx, "Evaluate", evalDuration, nil, func(ctx native_ctx.Context) error {
 		if span := opentracing.SpanFromContext(ctx); span != nil {
 			span.SetTag("instance", userID)
 			span.SetTag("groupName", item.groupName)
 		}
-		g, err := r.newGroup(ctx, userID, item)
-		if err != nil {
-			level.Error(logger).Log("msg", "failed to create rule group", "err", err)
-			return err
-		}
-		g.Eval(ctx, time.Now())
+		item.group.Eval(ctx, time.Now())
 		return nil
 	})
 	if err := ctx.Err(); err == nil {
@@ -385,7 +381,7 @@ func (r *Ruler) Evaluate(userID string, item *workItem) {
 		level.Warn(util.Logger).Log("msg", "context error", "error", err)
 	}
 
-	rulesProcessed.Add(float64(len(item.rules)))
+	rulesProcessed.Add(float64(len(item.group.Rules())))
 }
 
 // Stop stops the Ruler.
@@ -407,7 +403,7 @@ type Server struct {
 // NewServer makes a new rule processing server.
 func NewServer(cfg Config, ruler *Ruler, rulesAPI RulesAPI) (*Server, error) {
 	// TODO: Separate configuration for polling interval.
-	s := newScheduler(rulesAPI, cfg.EvaluationInterval, cfg.EvaluationInterval)
+	s := newScheduler(rulesAPI, cfg.EvaluationInterval, cfg.EvaluationInterval, ruler.newGroup)
 	if cfg.NumWorkers <= 0 {
 		return nil, fmt.Errorf("must have at least 1 worker, got %d", cfg.NumWorkers)
 	}

--- a/pkg/ruler/scheduler.go
+++ b/pkg/ruler/scheduler.go
@@ -58,7 +58,7 @@ func init() {
 type workItem struct {
 	userID     string
 	groupName  string
-	group      *rules.Group
+	group      *group
 	scheduled  time.Time
 	generation configs.ID // a monotonically increasing number used to spot out of date work items
 }
@@ -87,7 +87,7 @@ type userConfig struct {
 	generation configs.ID // a monotonically increasing number used to spot out of date work items
 }
 
-type groupFactory func(userID string, groupName string, rls []rules.Rule) (*rules.Group, error)
+type groupFactory func(userID string, groupName string, rls []rules.Rule) (*group, error)
 
 type scheduler struct {
 	rulesAPI           RulesAPI

--- a/pkg/ruler/scheduler_test.go
+++ b/pkg/ruler/scheduler_test.go
@@ -69,7 +69,7 @@ func TestSchedulerComputeNextEvalTime(t *testing.T) {
 }
 
 func TestSchedulerRulesOverlap(t *testing.T) {
-	s := newScheduler(nil, 15, 15)
+	s := newScheduler(nil, 15, 15, nil)
 	userID := "bob"
 	groupName := "test"
 	next := time.Now()


### PR DESCRIPTION
Instead of storing an array of rules, store a prometheus rule group on the work item. This allows the ruler to keep a history of previous results, and mark series stale if they disappear.

I am interested in feedback about the approach/any downsides. However, it needs some more time for testing before merging.

Fixes #838 