### PR TITLE
 Auto-scale DynamoDB provision based on Prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -603,6 +603,8 @@
   branch = "master"
   name = "github.com/prometheus/client_golang"
   packages = [
+    "api",
+    "api/prometheus/v1",
     "prometheus",
     "prometheus/promauto"
   ]
@@ -1127,6 +1129,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7407372f211e217b883afbe8ef20b73dc81cf37461eed40bc2cbd4b33872fb5a"
+  inputs-digest = "799238d885f842e01364af1e2c58d3d81f498fcbef2568ed2d0176187b54f13d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -37,8 +37,8 @@ func main() {
 		schemaConfig.IndexTables.WriteScale.Enabled ||
 		schemaConfig.ChunkTables.InactiveWriteScale.Enabled ||
 		schemaConfig.IndexTables.InactiveWriteScale.Enabled) &&
-		storageConfig.AWSStorageConfig.ApplicationAutoScaling.URL == nil {
-		level.Error(util.Logger).Log("msg", "WriteScale is enabled but no ApplicationAutoScaling URL has been provided")
+		(storageConfig.AWSStorageConfig.ApplicationAutoScaling.URL == nil && storageConfig.AWSStorageConfig.MetricsURL == "") {
+		level.Error(util.Logger).Log("msg", "WriteScale is enabled but no ApplicationAutoScaling or Metrics URL has been provided")
 		os.Exit(1)
 	}
 

--- a/cmd/table-manager/main.go
+++ b/cmd/table-manager/main.go
@@ -37,7 +37,7 @@ func main() {
 		schemaConfig.IndexTables.WriteScale.Enabled ||
 		schemaConfig.ChunkTables.InactiveWriteScale.Enabled ||
 		schemaConfig.IndexTables.InactiveWriteScale.Enabled) &&
-		(storageConfig.AWSStorageConfig.ApplicationAutoScaling.URL == nil && storageConfig.AWSStorageConfig.MetricsURL == "") {
+		(storageConfig.AWSStorageConfig.ApplicationAutoScaling.URL == nil && storageConfig.AWSStorageConfig.Metrics.URL == "") {
 		level.Error(util.Logger).Log("msg", "WriteScale is enabled but no ApplicationAutoScaling or Metrics URL has been provided")
 		os.Exit(1)
 	}

--- a/pkg/chunk/aws/aws_autoscaling.go
+++ b/pkg/chunk/aws/aws_autoscaling.go
@@ -49,7 +49,7 @@ func newAWSAutoscale(cfg DynamoDBConfig, callManager callManager) (*awsAutoscale
 	}, nil
 }
 
-func (a *awsAutoscale) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
+func (a *awsAutoscale) PostCreateTable(ctx context.Context, desc chunk.TableDesc) error {
 	if desc.WriteScale.Enabled {
 		return a.enableAutoScaling(ctx, desc)
 	}

--- a/pkg/chunk/aws/aws_autoscaling.go
+++ b/pkg/chunk/aws/aws_autoscaling.go
@@ -1,0 +1,226 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/common/instrument"
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+const (
+	autoScalingPolicyNamePrefix = "DynamoScalingPolicy_cortex_"
+)
+
+var applicationAutoScalingRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "cortex",
+	Name:      "application_autoscaling_request_duration_seconds",
+	Help:      "Time spent doing ApplicationAutoScaling requests.",
+
+	// AWS latency seems to range from a few ms to a few sec. So use 8 buckets
+	// from 128us to 2s. TODO: Confirm that this is the case for ApplicationAutoScaling.
+	Buckets: prometheus.ExponentialBuckets(0.000128, 4, 8),
+}, []string{"operation", "status_code"})
+
+func init() {
+	prometheus.MustRegister(applicationAutoScalingRequestDuration)
+}
+
+type awsAutoscale struct {
+	call                   callManager
+	ApplicationAutoScaling applicationautoscalingiface.ApplicationAutoScalingAPI
+}
+
+func newAWSAutoscale(cfg DynamoDBConfig, callManager callManager) (*awsAutoscale, error) {
+	session, err := awsSessionFromURL(cfg.ApplicationAutoScaling.URL)
+	if err != nil {
+		return nil, err
+	}
+	return &awsAutoscale{
+		call: callManager,
+		ApplicationAutoScaling: applicationautoscaling.New(session),
+	}, nil
+}
+
+func (a *awsAutoscale) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
+	if desc.WriteScale.Enabled {
+		return a.enableAutoScaling(ctx, desc)
+	}
+	return nil
+}
+
+func (a *awsAutoscale) DescribeTable(ctx context.Context, desc *chunk.TableDesc) error {
+	err := a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DescribeScalableTargetsWithContext", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			out, err := a.ApplicationAutoScaling.DescribeScalableTargetsWithContext(ctx, &applicationautoscaling.DescribeScalableTargetsInput{
+				ResourceIds:       []*string{aws.String("table/" + desc.Name)},
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+			})
+			if err != nil {
+				return err
+			}
+			switch l := len(out.ScalableTargets); l {
+			case 0:
+				return err
+			case 1:
+				desc.WriteScale.Enabled = true
+				if target := out.ScalableTargets[0]; target != nil {
+					if target.RoleARN != nil {
+						desc.WriteScale.RoleARN = *target.RoleARN
+					}
+					if target.MinCapacity != nil {
+						desc.WriteScale.MinCapacity = *target.MinCapacity
+					}
+					if target.MaxCapacity != nil {
+						desc.WriteScale.MaxCapacity = *target.MaxCapacity
+					}
+				}
+				return err
+			default:
+				return fmt.Errorf("more than one scalable target found for DynamoDB table")
+			}
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	err = a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DescribeScalingPoliciesWithContext", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			out, err := a.ApplicationAutoScaling.DescribeScalingPoliciesWithContext(ctx, &applicationautoscaling.DescribeScalingPoliciesInput{
+				PolicyNames:       []*string{aws.String(autoScalingPolicyNamePrefix + desc.Name)},
+				ResourceId:        aws.String("table/" + desc.Name),
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+			})
+			if err != nil {
+				return err
+			}
+			switch l := len(out.ScalingPolicies); l {
+			case 0:
+				return err
+			case 1:
+				config := out.ScalingPolicies[0].TargetTrackingScalingPolicyConfiguration
+				if config != nil {
+					if config.ScaleInCooldown != nil {
+						desc.WriteScale.InCooldown = *config.ScaleInCooldown
+					}
+					if config.ScaleOutCooldown != nil {
+						desc.WriteScale.OutCooldown = *config.ScaleOutCooldown
+					}
+					if config.TargetValue != nil {
+						desc.WriteScale.TargetValue = *config.TargetValue
+					}
+				}
+				return err
+			default:
+				return fmt.Errorf("more than one scaling policy found for DynamoDB table")
+			}
+		})
+	})
+	return err
+}
+
+func (a *awsAutoscale) UpdateTable(ctx context.Context, current chunk.TableDesc, expected *chunk.TableDesc) error {
+	var err error
+	if !current.WriteScale.Enabled {
+		if expected.WriteScale.Enabled {
+			level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
+			err = a.enableAutoScaling(ctx, *expected)
+		}
+	} else {
+		if !expected.WriteScale.Enabled {
+			level.Info(util.Logger).Log("msg", "disabling autoscaling on table", "table")
+			err = a.disableAutoScaling(ctx, *expected)
+		} else if current.WriteScale != expected.WriteScale {
+			level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
+			err = a.enableAutoScaling(ctx, *expected)
+		}
+	}
+	return err
+}
+
+func (a *awsAutoscale) enableAutoScaling(ctx context.Context, desc chunk.TableDesc) error {
+	// Registers or updates a scalable target
+	if err := a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.RegisterScalableTarget", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			input := &applicationautoscaling.RegisterScalableTargetInput{
+				MinCapacity:       aws.Int64(desc.WriteScale.MinCapacity),
+				MaxCapacity:       aws.Int64(desc.WriteScale.MaxCapacity),
+				ResourceId:        aws.String("table/" + desc.Name),
+				RoleARN:           aws.String(desc.WriteScale.RoleARN),
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+			}
+			_, err := a.ApplicationAutoScaling.RegisterScalableTarget(input)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Puts or updates a scaling policy
+	return a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.PutScalingPolicy", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			input := &applicationautoscaling.PutScalingPolicyInput{
+				PolicyName:        aws.String(autoScalingPolicyNamePrefix + desc.Name),
+				PolicyType:        aws.String("TargetTrackingScaling"),
+				ResourceId:        aws.String("table/" + desc.Name),
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+				TargetTrackingScalingPolicyConfiguration: &applicationautoscaling.TargetTrackingScalingPolicyConfiguration{
+					PredefinedMetricSpecification: &applicationautoscaling.PredefinedMetricSpecification{
+						PredefinedMetricType: aws.String("DynamoDBWriteCapacityUtilization"),
+					},
+					ScaleInCooldown:  aws.Int64(desc.WriteScale.InCooldown),
+					ScaleOutCooldown: aws.Int64(desc.WriteScale.OutCooldown),
+					TargetValue:      aws.Float64(desc.WriteScale.TargetValue),
+				},
+			}
+			_, err := a.ApplicationAutoScaling.PutScalingPolicy(input)
+			return err
+		})
+	})
+}
+
+func (a *awsAutoscale) disableAutoScaling(ctx context.Context, desc chunk.TableDesc) error {
+	// Deregister scalable target
+	if err := a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DeregisterScalableTarget", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			input := &applicationautoscaling.DeregisterScalableTargetInput{
+				ResourceId:        aws.String("table/" + desc.Name),
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+			}
+			_, err := a.ApplicationAutoScaling.DeregisterScalableTarget(input)
+			return err
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Delete scaling policy
+	return a.call.backoffAndRetry(ctx, func(ctx context.Context) error {
+		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DeleteScalingPolicy", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
+			input := &applicationautoscaling.DeleteScalingPolicyInput{
+				PolicyName:        aws.String(autoScalingPolicyNamePrefix + desc.Name),
+				ResourceId:        aws.String("table/" + desc.Name),
+				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
+				ServiceNamespace:  aws.String("dynamodb"),
+			}
+			_, err := a.ApplicationAutoScaling.DeleteScalingPolicy(input)
+			return err
+		})
+	})
+}

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -2,16 +2,12 @@ package aws
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
-	"github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/time/rate"
 
 	"github.com/weaveworks/common/instrument"
@@ -19,30 +15,24 @@ import (
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
-const (
-	autoScalingPolicyNamePrefix = "DynamoScalingPolicy_cortex_"
-)
+// Pluggable auto-scaler implementation
+type autoscale interface {
+	CreateTable(ctx context.Context, desc chunk.TableDesc) error
+	// This whole interface is very similar to chunk.TableClient, but
+	// DescribeTable needs to mutate desc
+	DescribeTable(ctx context.Context, desc *chunk.TableDesc) error
+	UpdateTable(ctx context.Context, current chunk.TableDesc, expected *chunk.TableDesc) error
+}
 
-var applicationAutoScalingRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "cortex",
-	Name:      "application_autoscaling_request_duration_seconds",
-	Help:      "Time spent doing ApplicationAutoScaling requests.",
-
-	// AWS latency seems to range from a few ms to a few sec. So use 8 buckets
-	// from 128us to 2s. TODO: Confirm that this is the case for ApplicationAutoScaling.
-	Buckets: prometheus.ExponentialBuckets(0.000128, 4, 8),
-}, []string{"operation", "status_code"})
-
-func init() {
-	prometheus.MustRegister(applicationAutoScalingRequestDuration)
+type callManager struct {
+	limiter       *rate.Limiter
+	backoffConfig util.BackoffConfig
 }
 
 type dynamoTableClient struct {
-	DynamoDB               dynamodbiface.DynamoDBAPI
-	ApplicationAutoScaling applicationautoscalingiface.ApplicationAutoScalingAPI
-	limiter                *rate.Limiter
-	backoffConfig          util.BackoffConfig
-	metrics                *metricsData
+	DynamoDB    dynamodbiface.DynamoDBAPI
+	callManager callManager
+	autoscale   autoscale
 }
 
 // NewDynamoDBTableClient makes a new DynamoTableClient.
@@ -52,33 +42,38 @@ func NewDynamoDBTableClient(cfg DynamoDBConfig) (chunk.TableClient, error) {
 		return nil, err
 	}
 
-	var applicationAutoScaling applicationautoscalingiface.ApplicationAutoScalingAPI
+	callManager := callManager{
+		limiter:       rate.NewLimiter(rate.Limit(cfg.APILimit), 1),
+		backoffConfig: cfg.backoffConfig,
+	}
+
+	var autoscale autoscale
 	if cfg.ApplicationAutoScaling.URL != nil {
-		session, err := awsSessionFromURL(cfg.ApplicationAutoScaling.URL)
+		autoscale, err = newAWSAutoscale(cfg, callManager)
 		if err != nil {
 			return nil, err
 		}
-		applicationAutoScaling = applicationautoscaling.New(session)
 	}
 
-	var metrics *metricsData
 	if cfg.MetricsURL != "" {
-		metrics, err = newMetrics(cfg)
+		autoscale, err = newMetrics(cfg)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return dynamoTableClient{
-		DynamoDB:               dynamoDB,
-		ApplicationAutoScaling: applicationAutoScaling,
-		limiter:                rate.NewLimiter(rate.Limit(cfg.APILimit), 1),
-		backoffConfig:          cfg.backoffConfig,
-		metrics:                metrics,
+		DynamoDB:    dynamoDB,
+		callManager: callManager,
+		autoscale:   autoscale,
 	}, nil
 }
 
 func (d dynamoTableClient) backoffAndRetry(ctx context.Context, fn func(context.Context) error) error {
+	return d.callManager.backoffAndRetry(ctx, fn)
+}
+
+func (d callManager) backoffAndRetry(ctx context.Context, fn func(context.Context) error) error {
 	if d.limiter != nil { // Tests will have a nil limiter.
 		d.limiter.Wait(ctx)
 	}
@@ -169,8 +164,8 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc
 		return err
 	}
 
-	if desc.WriteScale.Enabled && d.ApplicationAutoScaling != nil {
-		err := d.enableAutoScaling(ctx, desc)
+	if d.autoscale != nil {
+		err := d.autoscale.CreateTable(ctx, desc)
 		if err != nil {
 			return err
 		}
@@ -239,100 +234,15 @@ func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc
 		})
 	})
 
-	if d.ApplicationAutoScaling != nil {
-		err = d.backoffAndRetry(ctx, func(ctx context.Context) error {
-			return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DescribeScalableTargetsWithContext", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-				out, err := d.ApplicationAutoScaling.DescribeScalableTargetsWithContext(ctx, &applicationautoscaling.DescribeScalableTargetsInput{
-					ResourceIds:       []*string{aws.String("table/" + desc.Name)},
-					ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-					ServiceNamespace:  aws.String("dynamodb"),
-				})
-				if err != nil {
-					return err
-				}
-				switch l := len(out.ScalableTargets); l {
-				case 0:
-					return err
-				case 1:
-					desc.WriteScale.Enabled = true
-					if target := out.ScalableTargets[0]; target != nil {
-						if target.RoleARN != nil {
-							desc.WriteScale.RoleARN = *target.RoleARN
-						}
-						if target.MinCapacity != nil {
-							desc.WriteScale.MinCapacity = *target.MinCapacity
-						}
-						if target.MaxCapacity != nil {
-							desc.WriteScale.MaxCapacity = *target.MaxCapacity
-						}
-					}
-					return err
-				default:
-					return fmt.Errorf("more than one scalable target found for DynamoDB table")
-				}
-			})
-		})
-
-		err = d.backoffAndRetry(ctx, func(ctx context.Context) error {
-			return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DescribeScalingPoliciesWithContext", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-				out, err := d.ApplicationAutoScaling.DescribeScalingPoliciesWithContext(ctx, &applicationautoscaling.DescribeScalingPoliciesInput{
-					PolicyNames:       []*string{aws.String(autoScalingPolicyNamePrefix + desc.Name)},
-					ResourceId:        aws.String("table/" + desc.Name),
-					ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-					ServiceNamespace:  aws.String("dynamodb"),
-				})
-				if err != nil {
-					return err
-				}
-				switch l := len(out.ScalingPolicies); l {
-				case 0:
-					return err
-				case 1:
-					config := out.ScalingPolicies[0].TargetTrackingScalingPolicyConfiguration
-					if config != nil {
-						if config.ScaleInCooldown != nil {
-							desc.WriteScale.InCooldown = *config.ScaleInCooldown
-						}
-						if config.ScaleOutCooldown != nil {
-							desc.WriteScale.OutCooldown = *config.ScaleOutCooldown
-						}
-						if config.TargetValue != nil {
-							desc.WriteScale.TargetValue = *config.TargetValue
-						}
-					}
-					return err
-				default:
-					return fmt.Errorf("more than one scaling policy found for DynamoDB table")
-				}
-			})
-		})
+	if d.autoscale != nil {
+		err = d.autoscale.DescribeTable(ctx, &desc)
 	}
 	return
 }
 
 func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {
-	if expected.WriteScale.Enabled && d.metrics != nil {
-		if err := d.metrics.metricsAutoScale(ctx, &current, &expected); err != nil {
-			return err
-		}
-	}
-
-	if d.ApplicationAutoScaling != nil {
-		var err error
-		if !current.WriteScale.Enabled {
-			if expected.WriteScale.Enabled {
-				level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
-				err = d.enableAutoScaling(ctx, expected)
-			}
-		} else {
-			if !expected.WriteScale.Enabled {
-				level.Info(util.Logger).Log("msg", "disabling autoscaling on table", "table")
-				err = d.disableAutoScaling(ctx, expected)
-			} else if current.WriteScale != expected.WriteScale {
-				level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
-				err = d.enableAutoScaling(ctx, expected)
-			}
-		}
+	if d.autoscale != nil {
+		err := d.autoscale.UpdateTable(ctx, current, &expected)
 		if err != nil {
 			return err
 		}
@@ -391,81 +301,4 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected ch
 		})
 	}
 	return nil
-}
-
-func (d dynamoTableClient) enableAutoScaling(ctx context.Context, desc chunk.TableDesc) error {
-	// Registers or updates a scalable target
-	if err := d.backoffAndRetry(ctx, func(ctx context.Context) error {
-		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.RegisterScalableTarget", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-			input := &applicationautoscaling.RegisterScalableTargetInput{
-				MinCapacity:       aws.Int64(desc.WriteScale.MinCapacity),
-				MaxCapacity:       aws.Int64(desc.WriteScale.MaxCapacity),
-				ResourceId:        aws.String("table/" + desc.Name),
-				RoleARN:           aws.String(desc.WriteScale.RoleARN),
-				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-				ServiceNamespace:  aws.String("dynamodb"),
-			}
-			_, err := d.ApplicationAutoScaling.RegisterScalableTarget(input)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}); err != nil {
-		return err
-	}
-
-	// Puts or updates a scaling policy
-	return d.backoffAndRetry(ctx, func(ctx context.Context) error {
-		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.PutScalingPolicy", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-			input := &applicationautoscaling.PutScalingPolicyInput{
-				PolicyName:        aws.String(autoScalingPolicyNamePrefix + desc.Name),
-				PolicyType:        aws.String("TargetTrackingScaling"),
-				ResourceId:        aws.String("table/" + desc.Name),
-				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-				ServiceNamespace:  aws.String("dynamodb"),
-				TargetTrackingScalingPolicyConfiguration: &applicationautoscaling.TargetTrackingScalingPolicyConfiguration{
-					PredefinedMetricSpecification: &applicationautoscaling.PredefinedMetricSpecification{
-						PredefinedMetricType: aws.String("DynamoDBWriteCapacityUtilization"),
-					},
-					ScaleInCooldown:  aws.Int64(desc.WriteScale.InCooldown),
-					ScaleOutCooldown: aws.Int64(desc.WriteScale.OutCooldown),
-					TargetValue:      aws.Float64(desc.WriteScale.TargetValue),
-				},
-			}
-			_, err := d.ApplicationAutoScaling.PutScalingPolicy(input)
-			return err
-		})
-	})
-}
-
-func (d dynamoTableClient) disableAutoScaling(ctx context.Context, desc chunk.TableDesc) error {
-	// Deregister scalable target
-	if err := d.backoffAndRetry(ctx, func(ctx context.Context) error {
-		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DeregisterScalableTarget", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-			input := &applicationautoscaling.DeregisterScalableTargetInput{
-				ResourceId:        aws.String("table/" + desc.Name),
-				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-				ServiceNamespace:  aws.String("dynamodb"),
-			}
-			_, err := d.ApplicationAutoScaling.DeregisterScalableTarget(input)
-			return err
-		})
-	}); err != nil {
-		return err
-	}
-
-	// Delete scaling policy
-	return d.backoffAndRetry(ctx, func(ctx context.Context) error {
-		return instrument.TimeRequestHistogram(ctx, "ApplicationAutoScaling.DeleteScalingPolicy", applicationAutoScalingRequestDuration, func(ctx context.Context) error {
-			input := &applicationautoscaling.DeleteScalingPolicyInput{
-				PolicyName:        aws.String(autoScalingPolicyNamePrefix + desc.Name),
-				ResourceId:        aws.String("table/" + desc.Name),
-				ScalableDimension: aws.String("dynamodb:table:WriteCapacityUnits"),
-				ServiceNamespace:  aws.String("dynamodb"),
-			}
-			_, err := d.ApplicationAutoScaling.DeleteScalingPolicy(input)
-			return err
-		})
-	})
 }

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -61,9 +61,12 @@ func NewDynamoDBTableClient(cfg DynamoDBConfig) (chunk.TableClient, error) {
 		applicationAutoScaling = applicationautoscaling.New(session)
 	}
 
-	metrics, err := newMetrics(cfg)
-	if err != nil {
-		return nil, err
+	var metrics *metricsData
+	if cfg.MetricsURL != "" {
+		metrics, err = newMetrics(cfg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return dynamoTableClient{

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -115,10 +115,6 @@ func (d dynamoTableClient) ListTables(ctx context.Context) ([]string, error) {
 }
 
 func chunkTagsToDynamoDB(ts chunk.Tags) []*dynamodb.Tag {
-	if ts == nil {
-		return nil
-	}
-
 	var result []*dynamodb.Tag
 	for k, v := range ts {
 		result = append(result, &dynamodb.Tag{

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -353,7 +353,12 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected ch
 				return err
 			})
 		}); err != nil {
-			return err
+			recordDynamoError(expected.Name, err, "DynamoDB.UpdateTable")
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "LimitExceededException" {
+				level.Warn(util.Logger).Log("msg", "update limit exceeded", "err", err)
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -185,7 +185,7 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc
 	return nil
 }
 
-func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, status string, err error) {
+func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {
 	var tableARN *string
 	err = d.backoffAndRetry(ctx, func(ctx context.Context) error {
 		return instrument.TimeRequestHistogram(ctx, "DynamoDB.DescribeTable", dynamoRequestDuration, func(ctx context.Context) error {
@@ -206,7 +206,7 @@ func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc
 					}
 				}
 				if out.Table.TableStatus != nil {
-					status = *out.Table.TableStatus
+					isActive = (*out.Table.TableStatus == dynamodb.TableStatusActive)
 				}
 				tableARN = out.Table.TableArn
 			}

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -17,7 +17,7 @@ import (
 
 // Pluggable auto-scaler implementation
 type autoscale interface {
-	CreateTable(ctx context.Context, desc chunk.TableDesc) error
+	PostCreateTable(ctx context.Context, desc chunk.TableDesc) error
 	// This whole interface is very similar to chunk.TableClient, but
 	// DescribeTable needs to mutate desc
 	DescribeTable(ctx context.Context, desc *chunk.TableDesc) error
@@ -165,7 +165,7 @@ func (d dynamoTableClient) CreateTable(ctx context.Context, desc chunk.TableDesc
 	}
 
 	if d.autoscale != nil {
-		err := d.autoscale.CreateTable(ctx, desc)
+		err := d.autoscale.PostCreateTable(ctx, desc)
 		if err != nil {
 			return err
 		}

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -312,7 +312,7 @@ func (d dynamoTableClient) DescribeTable(ctx context.Context, name string) (desc
 
 func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {
 	if expected.WriteScale.Enabled && d.metrics != nil {
-		if err := d.metricsAutoScale(ctx, &current, &expected); err != nil {
+		if err := d.metrics.metricsAutoScale(ctx, &current, &expected); err != nil {
 			return err
 		}
 	}

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -322,12 +322,15 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected ch
 		var err error
 		if !current.WriteScale.Enabled {
 			if expected.WriteScale.Enabled {
+				level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
 				err = d.enableAutoScaling(ctx, expected)
 			}
 		} else {
 			if !expected.WriteScale.Enabled {
+				level.Info(util.Logger).Log("msg", "disabling autoscaling on table", "table")
 				err = d.disableAutoScaling(ctx, expected)
 			} else if current.WriteScale != expected.WriteScale {
+				level.Info(util.Logger).Log("msg", "enabling autoscaling on table", "table")
 				err = d.enableAutoScaling(ctx, expected)
 			}
 		}
@@ -337,6 +340,7 @@ func (d dynamoTableClient) UpdateTable(ctx context.Context, current, expected ch
 	}
 
 	if current.ProvisionedRead != expected.ProvisionedRead || current.ProvisionedWrite != expected.ProvisionedWrite {
+		level.Info(util.Logger).Log("msg", "updating provisioned throughput on table", "table", expected.Name, "old_read", current.ProvisionedRead, "old_write", current.ProvisionedWrite, "new_read", expected.ProvisionedRead, "new_write", expected.ProvisionedWrite)
 		if err := d.backoffAndRetry(ctx, func(ctx context.Context) error {
 			return instrument.TimeRequestHistogram(ctx, "DynamoDB.UpdateTable", dynamoRequestDuration, func(ctx context.Context) error {
 				_, err := d.DynamoDB.UpdateTableWithContext(ctx, &dynamodb.UpdateTableInput{

--- a/pkg/chunk/aws/dynamodb_table_client.go
+++ b/pkg/chunk/aws/dynamodb_table_client.go
@@ -55,7 +55,7 @@ func NewDynamoDBTableClient(cfg DynamoDBConfig) (chunk.TableClient, error) {
 		}
 	}
 
-	if cfg.MetricsURL != "" {
+	if cfg.Metrics.URL != "" {
 		autoscale, err = newMetrics(cfg)
 		if err != nil {
 			return nil, err

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -34,7 +34,7 @@ func fixtureWriteScale() chunk.AutoScalingConfig {
 	return chunk.AutoScalingConfig{
 		Enabled:     true,
 		MinCapacity: 10,
-		MaxCapacity: 300,
+		MaxCapacity: 250,
 		OutCooldown: 100,
 		InCooldown:  100,
 		TargetValue: 80.0,

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -34,7 +34,7 @@ func fixtureWriteScale() chunk.AutoScalingConfig {
 	return chunk.AutoScalingConfig{
 		Enabled:     true,
 		MinCapacity: 10,
-		MaxCapacity: 20,
+		MaxCapacity: 300,
 		OutCooldown: 100,
 		InCooldown:  100,
 		TargetValue: 80.0,

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -118,8 +118,8 @@ func TestTableManagerAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	applicationAutoScaling := newMockApplicationAutoScaling()
 	client := dynamoTableClient{
-		DynamoDB:               dynamoDB,
-		ApplicationAutoScaling: applicationAutoScaling,
+		DynamoDB:  dynamoDB,
+		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
 	}
 
 	cfg := chunk.SchemaConfig{
@@ -209,8 +209,8 @@ func TestTableManagerInactiveAutoScaling(t *testing.T) {
 	dynamoDB := newMockDynamoDB(0, 0)
 	applicationAutoScaling := newMockApplicationAutoScaling()
 	client := dynamoTableClient{
-		DynamoDB:               dynamoDB,
-		ApplicationAutoScaling: applicationAutoScaling,
+		DynamoDB:  dynamoDB,
+		autoscale: &awsAutoscale{ApplicationAutoScaling: applicationAutoScaling},
 	}
 
 	cfg := chunk.SchemaConfig{

--- a/pkg/chunk/aws/dynamodb_table_client_test.go
+++ b/pkg/chunk/aws/dynamodb_table_client_test.go
@@ -33,7 +33,7 @@ const (
 func fixtureWriteScale() chunk.AutoScalingConfig {
 	return chunk.AutoScalingConfig{
 		Enabled:     true,
-		MinCapacity: 10,
+		MinCapacity: 100,
 		MaxCapacity: 250,
 		OutCooldown: 100,
 		InCooldown:  100,

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -48,14 +48,17 @@ func (d dynamoTableClient) metricsAutoScale(ctx context.Context, current, expect
 	case m.queueLengths[2] < queueLengthScaledown && errorRate < errorFractionScaledown*float64(current.ProvisionedWrite):
 		// No big queue, low errors -> scale down
 		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaledown)
+		level.Info(util.Logger).Log("msg", "metrics scale-down", "table", current.Name, "write", expected.ProvisionedWrite)
 	case errorRate > 0 && m.queueLengths[2] > queueLengthMax:
 		// Too big queue, some errors -> scale up
 		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaleup)
+		level.Info(util.Logger).Log("msg", "metrics max queue scale-up", "table", current.Name, "write", expected.ProvisionedWrite)
 	case errorRate > 0 &&
 		m.queueLengths[2] > queueLengthAcceptable &&
 		m.queueLengths[2] > m.queueLengths[1] && m.queueLengths[1] > m.queueLengths[0]:
 		// Growing queue, some errors -> scale up
 		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaleup)
+		level.Info(util.Logger).Log("msg", "metrics queue growing scale-up", "table", current.Name, "write", expected.ProvisionedWrite)
 	default:
 		// Nothing much happening - set expected to current
 		expected.ProvisionedWrite = current.ProvisionedWrite

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -75,6 +75,10 @@ func (d dynamoTableClient) scaleDownWrite(current, expected *chunk.TableDesc, ne
 	if newWrite < expected.WriteScale.MinCapacity {
 		newWrite = expected.WriteScale.MinCapacity
 	}
+	// If we're already at or below the requested value, it's not a scale-down.
+	if newWrite >= current.ProvisionedWrite {
+		return
+	}
 	earliest := d.metrics.tableLastUpdated[current.Name].Add(time.Duration(expected.WriteScale.InCooldown) * time.Second)
 	if earliest.After(mtime.Now()) {
 		level.Info(util.Logger).Log("msg", "deferring "+msg, "table", current.Name, "till", earliest)

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
+	promApi "github.com/prometheus/client_golang/api"
+	promV1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/common/mtime"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+const (
+	cachePromDataFor       = 30 * time.Second
+	queueObservationPeriod = 2 * time.Minute
+	queueLengthScaledown   = 10000   // consider scaling down if queue smaller than this
+	queueLengthAcceptable  = 100000  // we don't mind queues smaller than this
+	queueLengthMax         = 1000000 // always scale up if queue bigger than this
+	errorFractionScaledown = 0.1
+	scaledown              = 0.9
+	scaleup                = 1.2
+)
+
+type metricsData struct {
+	promAPI      promV1.API
+	lastUpdated  time.Time
+	queueLengths []float64
+	errorRates   map[string]float64
+}
+
+func (d dynamoTableClient) metricsAutoScale(ctx context.Context, current, expected *chunk.TableDesc) error {
+	m := d.metrics
+	if err := m.update(ctx); err != nil {
+		return err
+	}
+
+	errorRate := m.errorRates[expected.Name]
+
+	level.Info(util.Logger).Log("msg", "checking metrics", "table", current.Name, "queueLengths", fmt.Sprint(m.queueLengths), "errorRate", errorRate)
+
+	switch {
+	case m.queueLengths[2] < queueLengthScaledown && errorRate < errorFractionScaledown*float64(current.ProvisionedWrite):
+		// No big queue, low errors -> scale down
+		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaledown)
+	case errorRate > 0 && m.queueLengths[2] > queueLengthMax:
+		// Too big queue, some errors -> scale up
+		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaleup)
+	case errorRate > 0 &&
+		m.queueLengths[2] > queueLengthAcceptable &&
+		m.queueLengths[2] > m.queueLengths[1] && m.queueLengths[1] > m.queueLengths[0]:
+		// Growing queue, some errors -> scale up
+		expected.ProvisionedWrite = int64(float64(current.ProvisionedWrite) * scaleup)
+	default:
+		// Nothing much happening - set expected to current
+		expected.ProvisionedWrite = current.ProvisionedWrite
+	}
+	return nil
+}
+
+func newMetrics(cfg DynamoDBConfig) (*metricsData, error) {
+	var promAPI promV1.API
+	if cfg.MetricsURL != "" {
+		client, err := promApi.NewClient(promApi.Config{Address: cfg.MetricsURL})
+		if err != nil {
+			return nil, err
+		}
+		promAPI = promV1.NewAPI(client)
+	}
+	return &metricsData{promAPI: promAPI}, nil
+}
+
+func (m *metricsData) update(ctx context.Context) error {
+	if m.lastUpdated.After(mtime.Now().Add(-cachePromDataFor)) {
+		return nil
+	}
+
+	qlMatrix, err := promQuery(ctx, m.promAPI, `sum(cortex_ingester_flush_queue_length)`, queueObservationPeriod, queueObservationPeriod/2)
+	if err != nil {
+		return err
+	}
+	if len(qlMatrix) != 1 {
+		return errors.Errorf("expected one sample stream for queue: %d", len(qlMatrix))
+	}
+	if len(qlMatrix[0].Values) != 3 {
+		return errors.Errorf("expected three values: %d", len(qlMatrix[0].Values))
+	}
+	m.queueLengths = make([]float64, len(qlMatrix[0].Values))
+	for i, v := range qlMatrix[0].Values {
+		m.queueLengths[i] = float64(v.Value)
+	}
+
+	deMatrix, err := promQuery(ctx, m.promAPI, `sum(rate(cortex_dynamo_failures_total{error="ProvisionedThroughputExceededException",operation=~".*Write.*"}[1m])) by (table) > 0`, 0, time.Second)
+	if err != nil {
+		return err
+	}
+	m.errorRates = make(map[string]float64)
+	for _, s := range deMatrix {
+		table, found := s.Metric["table"]
+		if !found {
+			continue
+		}
+		if len(s.Values) != 1 {
+			return errors.Errorf("expected one sample for table %s: %d", table, len(s.Values))
+		}
+		m.errorRates[string(table)] = float64(s.Values[0].Value)
+	}
+
+	m.lastUpdated = mtime.Now()
+	return nil
+}
+
+func promQuery(ctx context.Context, promAPI promV1.API, query string, duration, step time.Duration) (model.Matrix, error) {
+	queryRange := promV1.Range{
+		Start: mtime.Now().Add(-duration),
+		End:   mtime.Now(),
+		Step:  step,
+	}
+
+	value, err := promAPI.QueryRange(ctx, query, queryRange)
+	if err != nil {
+		return nil, err
+	}
+	matrix, ok := value.(model.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("Unable to convert value to matrix: %#v", value)
+	}
+	return matrix, nil
+}

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -123,16 +123,12 @@ func (d dynamoTableClient) scaleUpWrite(current, expected *chunk.TableDesc, newW
 }
 
 func newMetrics(cfg DynamoDBConfig) (*metricsData, error) {
-	var promAPI promV1.API
-	if cfg.MetricsURL != "" {
-		client, err := promApi.NewClient(promApi.Config{Address: cfg.MetricsURL})
-		if err != nil {
-			return nil, err
-		}
-		promAPI = promV1.NewAPI(client)
+	client, err := promApi.NewClient(promApi.Config{Address: cfg.MetricsURL})
+	if err != nil {
+		return nil, err
 	}
 	return &metricsData{
-		promAPI:           promAPI,
+		promAPI:           promV1.NewAPI(client),
 		queueLengthTarget: cfg.MetricsTargetQueueLen,
 		scaleUpFactor:     cfg.MetricsScaleUpFactor,
 		tableLastUpdated:  make(map[string]time.Time),

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -54,6 +54,10 @@ func (d dynamoTableClient) metricsAutoScale(ctx context.Context, current, expect
 		m.queueLengths[2] < float64(m.queueLengthTarget)*targetScaledown:
 		// No big queue, low errors -> scale down
 		d.scaleDownWrite(current, expected, int64(usageRate*100.0/expected.WriteScale.TargetValue), "metrics scale-down")
+	case errorRate == 0 &&
+		m.queueLengths[2] < m.queueLengths[1] && m.queueLengths[1] < m.queueLengths[0]:
+		// zero errors and falling queue -> scale down to current usage
+		d.scaleDownWrite(current, expected, int64(usageRate*100.0/expected.WriteScale.TargetValue), "zero errors scale-down")
 	case errorRate > 0 && m.queueLengths[2] > float64(m.queueLengthTarget)*targetMax:
 		// Too big queue, some errors -> scale up
 		d.scaleUpWrite(current, expected, int64(float64(current.ProvisionedWrite)*scaleup), "metrics max queue scale-up")

--- a/pkg/chunk/aws/metrics_autoscaling.go
+++ b/pkg/chunk/aws/metrics_autoscaling.go
@@ -36,7 +36,15 @@ type metricsData struct {
 	usageRates        map[string]float64
 }
 
-func (m *metricsData) metricsAutoScale(ctx context.Context, current, expected *chunk.TableDesc) error {
+func (m *metricsData) CreateTable(ctx context.Context, desc chunk.TableDesc) error {
+	return nil
+}
+
+func (m *metricsData) DescribeTable(ctx context.Context, desc *chunk.TableDesc) error {
+	return nil
+}
+
+func (m *metricsData) UpdateTable(ctx context.Context, current chunk.TableDesc, expected *chunk.TableDesc) error {
 	if err := m.update(ctx); err != nil {
 		return err
 	}
@@ -70,7 +78,7 @@ func (m *metricsData) metricsAutoScale(ctx context.Context, current, expected *c
 	return nil
 }
 
-func (m *metricsData) scaleDownWrite(current, expected *chunk.TableDesc, newWrite int64, msg string) {
+func (m *metricsData) scaleDownWrite(current chunk.TableDesc, expected *chunk.TableDesc, newWrite int64, msg string) {
 	if newWrite < expected.WriteScale.MinCapacity {
 		newWrite = expected.WriteScale.MinCapacity
 	}
@@ -105,7 +113,7 @@ func (m *metricsData) scaleDownWrite(current, expected *chunk.TableDesc, newWrit
 	m.tableLastUpdated[current.Name] = mtime.Now()
 }
 
-func (m *metricsData) scaleUpWrite(current, expected *chunk.TableDesc, newWrite int64, msg string) {
+func (m *metricsData) scaleUpWrite(current chunk.TableDesc, expected *chunk.TableDesc, newWrite int64, msg string) {
 	if newWrite > expected.WriteScale.MaxCapacity {
 		newWrite = expected.WriteScale.MaxCapacity
 	}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -156,11 +156,11 @@ func (m *mockPrometheus) SetResponse(q0, q1, q2 model.SampleValue, errorRates ..
 		for i := 0; i < len(rates)/2; i++ {
 			errorMatrix = append(errorMatrix,
 				&model.SampleStream{
-					Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("cortex_%d", i))},
+					Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("%s%d", tablePrefix, i))},
 					Values: []model.SamplePair{{Timestamp: 30000, Value: model.SampleValue(rates[i*2])}},
 				},
 				&model.SampleStream{
-					Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("chunks_%d", i))},
+					Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("%s%d", chunkTablePrefix, i))},
 					Values: []model.SamplePair{{Timestamp: 30000, Value: model.SampleValue(rates[i*2+1])}},
 				})
 		}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -70,21 +70,21 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	test(t, client, tableManager, "Large queues small errors",
 		startTime.Add(time.Minute*40),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 288, read, write)...), // - scale up index table
+			staticTable(0, read, 250, read, write)...), // - scale up index table
 	)
 
 	mockProm.SetResponse(0, 0, 0, 0, 0)
 	test(t, client, tableManager, "No queues no errors",
 		startTime.Add(time.Minute*100),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 259, read, 180)...), // - scale down both tables
+			staticTable(0, read, 225, read, 180)...), // - scale down both tables
 	)
 
 	mockProm.SetResponse(0, 0, 0, 0, 0)
 	test(t, client, tableManager, "No queues no errors",
 		startTime.Add(time.Minute*200),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 233, read, 162)...), // - scale down both again
+			staticTable(0, read, 202, read, 162)...), // - scale down both again
 	)
 
 	mockProm.SetResponse(0, 0, 0, 30, 30, 30, 30)
@@ -92,7 +92,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		startTime.Add(tablePeriod),
 		// Nothing much happening - expect table 0 write rates to stay as-is and table 1 to be created with defaults
 		append(append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, inactiveRead, 233, inactiveRead, 162)...),
+			staticTable(0, inactiveRead, 202, inactiveRead, 162)...),
 			staticTable(1, read, write, read, write)...),
 	)
 
@@ -101,7 +101,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	test(t, client, tableManager, "Next week plus a bit",
 		startTime.Add(tablePeriod).Add(time.Minute*10),
 		append(append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // Scale back last week's index table
+			staticTable(0, inactiveRead, 181, inactiveRead, 162)...), // Scale back last week's index table
 			staticTable(1, read, write, read, write)...),
 	)
 
@@ -110,7 +110,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	test(t, client, tableManager, "Next week plus a bit",
 		startTime.Add(tablePeriod).Add(time.Minute*20),
 		append(append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // no scaling back
+			staticTable(0, inactiveRead, 181, inactiveRead, 162)...), // no scaling back
 			staticTable(1, read, write, read, write)...),
 	)
 
@@ -118,7 +118,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	test(t, client, tableManager, "next week, queues building, errors on index table",
 		startTime.Add(tablePeriod).Add(time.Minute*30),
 		append(append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // no scaling back
+			staticTable(0, inactiveRead, 181, inactiveRead, 162)...), // no scaling back
 			staticTable(1, read, 240, read, write)...), // scale up index table
 	)
 }

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -19,7 +19,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 
 	client := dynamoTableClient{
 		DynamoDB: dynamoDB,
-		metrics:  &metricsData{promAPI: &mockProm},
+		metrics:  &metricsData{promAPI: &mockProm, queueLengthTarget: 100000},
 	}
 
 	// Set up table-manager config

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	promV1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+func TestTableManagerMetricsAutoScaling(t *testing.T) {
+	dynamoDB := newMockDynamoDB(0, 0)
+	mockProm := mockPrometheus{}
+
+	client := dynamoTableClient{
+		DynamoDB: dynamoDB,
+		metrics:  &metricsData{promAPI: &mockProm},
+	}
+
+	// Set up table-manager config
+	cfg := chunk.SchemaConfig{
+		OriginalTableName:   "a",
+		UsePeriodicTables:   true,
+		IndexTables:         fixturePeriodicTableConfig(tablePrefix, 2, fixtureWriteScale(), fixtureWriteScale()),
+		ChunkTables:         fixturePeriodicTableConfig(chunkTablePrefix, 2, fixtureWriteScale(), fixtureWriteScale()),
+		CreationGracePeriod: gracePeriod,
+	}
+
+	tableManager, err := chunk.NewTableManager(cfg, maxChunkAge, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create tables
+	startTime := time.Unix(0, 0).Add(maxChunkAge).Add(gracePeriod)
+
+	test(t, client, tableManager, "Create tables",
+		startTime,
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, write, read, write)...),
+	)
+
+	mockProm.SetResponse(0, 100000, 100000, 0, 0)
+	test(t, client, tableManager, "Queues but no errors",
+		startTime.Add(time.Minute*10),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, write, read, write)...), // - remain flat
+	)
+
+	mockProm.SetResponse(0, 120000, 100000, 100, 200)
+	test(t, client, tableManager, "Shrinking queues",
+		startTime.Add(time.Minute*20),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, write, read, write)...), //  - remain flat
+	)
+
+	mockProm.SetResponse(0, 120000, 200000, 100, 0)
+	test(t, client, tableManager, "Building queues",
+		startTime.Add(time.Minute*30),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, 240, read, write)...), // - scale up index table
+	)
+
+	mockProm.SetResponse(0, 5000000, 5000000, 1, 0)
+	test(t, client, tableManager, "Large queues small errors",
+		startTime.Add(time.Minute*40),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, 288, read, write)...), // - scale up index table
+	)
+
+	mockProm.SetResponse(0, 0, 0, 0, 0)
+	test(t, client, tableManager, "No queues no errors",
+		startTime.Add(time.Minute*100),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, 259, read, 180)...), // - scale down both tables
+	)
+
+	mockProm.SetResponse(0, 0, 0, 0, 0)
+	test(t, client, tableManager, "No queues no errors",
+		startTime.Add(time.Minute*200),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, 233, read, 162)...), // - scale down both again
+	)
+
+	mockProm.SetResponse(0, 0, 0, 30, 30, 30, 30)
+	test(t, client, tableManager, "Next week",
+		startTime.Add(tablePeriod),
+		// Nothing much happening - expect table 0 write rates to stay as-is and table 1 to be created with defaults
+		append(append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, inactiveRead, 233, inactiveRead, 162)...),
+			staticTable(1, read, write, read, write)...),
+	)
+
+	// No errors on last week's index table, still some on chunk table
+	mockProm.SetResponse(0, 0, 0, 0, 30, 30, 30)
+	test(t, client, tableManager, "Next week plus a bit",
+		startTime.Add(tablePeriod).Add(time.Minute*10),
+		append(append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // Scale back last week's index table
+			staticTable(1, read, write, read, write)...),
+	)
+
+	// No errors on last week's tables but some queueing
+	mockProm.SetResponse(20000, 20000, 20000, 0, 0, 1, 1)
+	test(t, client, tableManager, "Next week plus a bit",
+		startTime.Add(tablePeriod).Add(time.Minute*20),
+		append(append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // no scaling back
+			staticTable(1, read, write, read, write)...),
+	)
+
+	mockProm.SetResponse(120000, 130000, 140000, 0, 0, 1, 0)
+	test(t, client, tableManager, "next week, queues building, errors on index table",
+		startTime.Add(tablePeriod).Add(time.Minute*30),
+		append(append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, inactiveRead, 209, inactiveRead, 162)...), // no scaling back
+			staticTable(1, read, 240, read, write)...), // scale up index table
+	)
+}
+
+// Helper to return pre-canned results to Prometheus queries
+type mockPrometheus struct {
+	rangeValues []model.Value
+}
+
+func (m *mockPrometheus) SetResponse(q0, q1, q2 model.SampleValue, errorRate ...model.SampleValue) {
+	errorRates := model.Matrix{}
+	for i := 0; i < len(errorRate)/2; i++ {
+		errorRates = append(errorRates,
+			&model.SampleStream{
+				Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("cortex_%d", i))},
+				Values: []model.SamplePair{{Timestamp: 30000, Value: errorRate[i*2]}},
+			},
+			&model.SampleStream{
+				Metric: model.Metric{"table": model.LabelValue(fmt.Sprintf("chunks_%d", i))},
+				Values: []model.SamplePair{{Timestamp: 30000, Value: errorRate[i*2+1]}},
+			})
+	}
+	// Mock metrics from Prometheus
+	m.rangeValues = []model.Value{
+		// Queue lengths
+		model.Matrix{
+			&model.SampleStream{Values: []model.SamplePair{
+				{Timestamp: 0, Value: q0},
+				{Timestamp: 15000, Value: q1},
+				{Timestamp: 30000, Value: q2},
+			}},
+		},
+		errorRates,
+	}
+}
+
+func (m *mockPrometheus) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) QueryRange(ctx context.Context, query string, r promV1.Range) (model.Value, error) {
+	if len(m.rangeValues) == 0 {
+		return nil, errors.New("mockPrometheus.QueryRange: out of values")
+	}
+	// Take the first value and move the slice up
+	ret := m.rangeValues[0]
+	m.rangeValues = m.rangeValues[1:]
+	return ret, nil
+}
+
+func (m *mockPrometheus) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) AlertManagers(ctx context.Context) (promV1.AlertManagersResult, error) {
+	return promV1.AlertManagersResult{}, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) CleanTombstones(ctx context.Context) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockPrometheus) Config(ctx context.Context) (promV1.ConfigResult, error) {
+	return promV1.ConfigResult{}, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockPrometheus) Flags(ctx context.Context) (promV1.FlagsResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) Snapshot(ctx context.Context, skipHead bool) (promV1.SnapshotResult, error) {
+	return promV1.SnapshotResult{}, errors.New("not implemented")
+}
+
+func (m *mockPrometheus) Targets(ctx context.Context) (promV1.TargetsResult, error) {
+	return promV1.TargetsResult{}, errors.New("not implemented")
+}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -19,7 +19,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 
 	client := dynamoTableClient{
 		DynamoDB: dynamoDB,
-		metrics: &metricsData{
+		autoscale: &metricsData{
 			promAPI:           &mockProm,
 			queueLengthTarget: 100000,
 			scaleUpFactor:     1.2,

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -22,6 +22,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		metrics: &metricsData{
 			promAPI:           &mockProm,
 			queueLengthTarget: 100000,
+			scaleUpFactor:     1.2,
 			tableLastUpdated:  make(map[string]time.Time),
 		},
 	}

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -20,10 +20,12 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 	client := dynamoTableClient{
 		DynamoDB: dynamoDB,
 		autoscale: &metricsData{
-			promAPI:           &mockProm,
-			queueLengthTarget: 100000,
-			scaleUpFactor:     1.2,
-			tableLastUpdated:  make(map[string]time.Time),
+			promAPI: &mockProm,
+			cfg: MetricsAutoScalingConfig{
+				TargetQueueLen: 100000,
+				ScaleUpFactor:  1.2,
+			},
+			tableLastUpdated: make(map[string]time.Time),
 		},
 	}
 

--- a/pkg/chunk/aws/metrics_autoscaling_test.go
+++ b/pkg/chunk/aws/metrics_autoscaling_test.go
@@ -84,25 +84,32 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 			staticTable(0, read, 250, read, write)...), // - scale up index table
 	)
 
-	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{100, 20})
+	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{120, 40})
 	test(t, client, tableManager, "No queues no errors",
 		startTime.Add(time.Minute*100),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 125, read, 25)...), // - scale down both tables
+			staticTable(0, read, 150, read, 50)...), // - scale down both tables
 	)
 
 	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{50, 10})
 	test(t, client, tableManager, "in cooldown period",
 		startTime.Add(time.Minute*101),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 125, read, 25)...), // - no change; in cooldown period
+			staticTable(0, read, 150, read, 50)...), // - no change; in cooldown period
 	)
 
-	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{50, 10})
+	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{90, 10})
 	test(t, client, tableManager, "No queues no errors",
 		startTime.Add(time.Minute*200),
 		append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, read, 100, read, 20)...), // - scale down both again
+			staticTable(0, read, 112, read, 20)...), // - scale down both again
+	)
+
+	mockProm.SetResponse(0, 0, 0, []int{0, 0}, []int{50, 10})
+	test(t, client, tableManager, "de minimis change",
+		startTime.Add(time.Minute*220),
+		append(baseTable("a", inactiveRead, inactiveWrite),
+			staticTable(0, read, 112, read, 20)...), // - should see no change
 	)
 
 	mockProm.SetResponse(0, 0, 0, []int{30, 30, 30, 30}, []int{50, 10, 100, 20})
@@ -110,7 +117,7 @@ func TestTableManagerMetricsAutoScaling(t *testing.T) {
 		startTime.Add(tablePeriod),
 		// Nothing much happening - expect table 0 write rates to stay as-is and table 1 to be created with defaults
 		append(append(baseTable("a", inactiveRead, inactiveWrite),
-			staticTable(0, inactiveRead, 100, inactiveRead, 20)...),
+			staticTable(0, inactiveRead, 112, inactiveRead, 20)...),
 			staticTable(1, read, write, read, write)...),
 	)
 

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -111,6 +111,7 @@ type DynamoDBConfig struct {
 	APILimit               float64
 	ApplicationAutoScaling util.URLValue
 	MetricsURL             string
+	MetricsTargetQueueLen  int64
 	ChunkGangSize          int
 	ChunkGetMaxParallelism int
 	backoffConfig          util.BackoffConfig
@@ -123,6 +124,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.APILimit, "dynamodb.api-limit", 2.0, "DynamoDB table management requests per second limit.")
 	f.Var(&cfg.ApplicationAutoScaling, "applicationautoscaling.url", "ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.")
 	f.StringVar(&cfg.MetricsURL, "metrics.url", "", "Use metrics-based autoscaling, via this query URL")
+	f.Int64Var(&cfg.MetricsTargetQueueLen, "metrics.target-queue-length", 100000, "Queue length above which we will scale up capacity")
 	f.IntVar(&cfg.ChunkGangSize, "dynamodb.chunk.gang.size", 10, "Number of chunks to group together to parallelise fetches (zero to disable)")
 	f.IntVar(&cfg.ChunkGetMaxParallelism, "dynamodb.chunk.get.max.parallelism", 32, "Max number of chunk-get operations to start in parallel")
 	f.DurationVar(&cfg.backoffConfig.MinBackoff, "dynamodb.min-backoff", 100*time.Millisecond, "Minimum backoff time")

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -110,6 +110,7 @@ type DynamoDBConfig struct {
 	DynamoDB               util.URLValue
 	APILimit               float64
 	ApplicationAutoScaling util.URLValue
+	MetricsURL             string
 	ChunkGangSize          int
 	ChunkGetMaxParallelism int
 	backoffConfig          util.BackoffConfig
@@ -121,6 +122,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<table-name> to use a mock in-memory implementation.")
 	f.Float64Var(&cfg.APILimit, "dynamodb.api-limit", 2.0, "DynamoDB table management requests per second limit.")
 	f.Var(&cfg.ApplicationAutoScaling, "applicationautoscaling.url", "ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.")
+	f.StringVar(&cfg.MetricsURL, "metrics.url", "", "Use metrics-based autoscaling, via this query URL")
 	f.IntVar(&cfg.ChunkGangSize, "dynamodb.chunk.gang.size", 10, "Number of chunks to group together to parallelise fetches (zero to disable)")
 	f.IntVar(&cfg.ChunkGetMaxParallelism, "dynamodb.chunk.get.max.parallelism", 32, "Max number of chunk-get operations to start in parallel")
 	f.DurationVar(&cfg.backoffConfig.MinBackoff, "dynamodb.min-backoff", 100*time.Millisecond, "Minimum backoff time")

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -112,6 +112,7 @@ type DynamoDBConfig struct {
 	ApplicationAutoScaling util.URLValue
 	MetricsURL             string
 	MetricsTargetQueueLen  int64
+	MetricsScaleUpFactor   float64
 	ChunkGangSize          int
 	ChunkGetMaxParallelism int
 	backoffConfig          util.BackoffConfig
@@ -125,6 +126,7 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.ApplicationAutoScaling, "applicationautoscaling.url", "ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.")
 	f.StringVar(&cfg.MetricsURL, "metrics.url", "", "Use metrics-based autoscaling, via this query URL")
 	f.Int64Var(&cfg.MetricsTargetQueueLen, "metrics.target-queue-length", 100000, "Queue length above which we will scale up capacity")
+	f.Float64Var(&cfg.MetricsScaleUpFactor, "metrics.scale-up-factor", 1.3, "Scale up capacity by this multiple")
 	f.IntVar(&cfg.ChunkGangSize, "dynamodb.chunk.gang.size", 10, "Number of chunks to group together to parallelise fetches (zero to disable)")
 	f.IntVar(&cfg.ChunkGetMaxParallelism, "dynamodb.chunk.get.max.parallelism", 32, "Max number of chunk-get operations to start in parallel")
 	f.DurationVar(&cfg.backoffConfig.MinBackoff, "dynamodb.min-backoff", 100*time.Millisecond, "Minimum backoff time")

--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -110,9 +110,7 @@ type DynamoDBConfig struct {
 	DynamoDB               util.URLValue
 	APILimit               float64
 	ApplicationAutoScaling util.URLValue
-	MetricsURL             string
-	MetricsTargetQueueLen  int64
-	MetricsScaleUpFactor   float64
+	Metrics                MetricsAutoScalingConfig
 	ChunkGangSize          int
 	ChunkGetMaxParallelism int
 	backoffConfig          util.BackoffConfig
@@ -124,14 +122,12 @@ func (cfg *DynamoDBConfig) RegisterFlags(f *flag.FlagSet) {
 		"If only region is specified as a host, proper endpoint will be deduced. Use inmemory:///<table-name> to use a mock in-memory implementation.")
 	f.Float64Var(&cfg.APILimit, "dynamodb.api-limit", 2.0, "DynamoDB table management requests per second limit.")
 	f.Var(&cfg.ApplicationAutoScaling, "applicationautoscaling.url", "ApplicationAutoscaling endpoint URL with escaped Key and Secret encoded.")
-	f.StringVar(&cfg.MetricsURL, "metrics.url", "", "Use metrics-based autoscaling, via this query URL")
-	f.Int64Var(&cfg.MetricsTargetQueueLen, "metrics.target-queue-length", 100000, "Queue length above which we will scale up capacity")
-	f.Float64Var(&cfg.MetricsScaleUpFactor, "metrics.scale-up-factor", 1.3, "Scale up capacity by this multiple")
 	f.IntVar(&cfg.ChunkGangSize, "dynamodb.chunk.gang.size", 10, "Number of chunks to group together to parallelise fetches (zero to disable)")
 	f.IntVar(&cfg.ChunkGetMaxParallelism, "dynamodb.chunk.get.max.parallelism", 32, "Max number of chunk-get operations to start in parallel")
 	f.DurationVar(&cfg.backoffConfig.MinBackoff, "dynamodb.min-backoff", 100*time.Millisecond, "Minimum backoff time")
 	f.DurationVar(&cfg.backoffConfig.MaxBackoff, "dynamodb.max-backoff", 50*time.Second, "Maximum backoff time")
 	f.IntVar(&cfg.backoffConfig.MaxRetries, "dynamodb.max-retries", 20, "Maximum number of times to retry an operation")
+	cfg.Metrics.RegisterFlags(f)
 }
 
 // StorageConfig specifies config for storing data on AWS.

--- a/pkg/chunk/cassandra/table_client.go
+++ b/pkg/chunk/cassandra/table_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 
@@ -51,10 +50,10 @@ func (c *tableClient) CreateTable(ctx context.Context, desc chunk.TableDesc) err
 	return errors.WithStack(err)
 }
 
-func (c *tableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, status string, err error) {
+func (c *tableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {
 	return chunk.TableDesc{
 		Name: name,
-	}, dynamodb.TableStatusActive, nil
+	}, true, nil
 }
 
 func (c *tableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {

--- a/pkg/chunk/gcp/table_client.go
+++ b/pkg/chunk/gcp/table_client.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigtable"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"google.golang.org/grpc/status"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
@@ -75,10 +74,10 @@ func alreadyExistsError(err error) bool {
 	return ok && strings.Contains(serr.Message(), "already exists")
 }
 
-func (c *tableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, status string, err error) {
+func (c *tableClient) DescribeTable(ctx context.Context, name string) (desc chunk.TableDesc, isActive bool, err error) {
 	return chunk.TableDesc{
 		Name: name,
-	}, dynamodb.TableStatusActive, nil
+	}, true, nil
 }
 
 func (c *tableClient) UpdateTable(ctx context.Context, current, expected chunk.TableDesc) error {

--- a/pkg/chunk/inmemory_storage_client.go
+++ b/pkg/chunk/inmemory_storage_client.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/go-kit/kit/log/level"
 	"github.com/weaveworks/cortex/pkg/util"
 )
@@ -70,20 +69,20 @@ func (m *MockStorage) CreateTable(_ context.Context, desc TableDesc) error {
 }
 
 // DescribeTable implements StorageClient.
-func (m *MockStorage) DescribeTable(_ context.Context, name string) (desc TableDesc, status string, err error) {
+func (m *MockStorage) DescribeTable(_ context.Context, name string) (desc TableDesc, isActive bool, err error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
 	table, ok := m.tables[name]
 	if !ok {
-		return TableDesc{}, "", fmt.Errorf("not found")
+		return TableDesc{}, false, fmt.Errorf("not found")
 	}
 
 	return TableDesc{
 		Name:             name,
 		ProvisionedRead:  table.read,
 		ProvisionedWrite: table.write,
-	}, dynamodb.TableStatusActive, nil
+	}, true, nil
 }
 
 // UpdateTable implements StorageClient.

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -208,8 +208,8 @@ func (cfg *AutoScalingConfig) RegisterFlags(argPrefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.RoleARN, argPrefix+".role-arn", "", "AWS AutoScaling role ARN")
 	f.Int64Var(&cfg.MinCapacity, argPrefix+".min-capacity", 3000, "DynamoDB minimum provision capacity.")
 	f.Int64Var(&cfg.MaxCapacity, argPrefix+".max-capacity", 6000, "DynamoDB maximum provision capacity.")
-	f.Int64Var(&cfg.OutCooldown, argPrefix+".out-cooldown", 3000, "DynamoDB minimum time between each autoscaling event that increases provision capacity.")
-	f.Int64Var(&cfg.InCooldown, argPrefix+".in-cooldown", 3000, "DynamoDB minimum time between each autoscaling event that decreases provision capacity.")
+	f.Int64Var(&cfg.OutCooldown, argPrefix+".out-cooldown", 1800, "DynamoDB minimum seconds between each autoscale up.")
+	f.Int64Var(&cfg.InCooldown, argPrefix+".in-cooldown", 1800, "DynamoDB minimum seconds between each autoscale down.")
 	f.Float64Var(&cfg.TargetValue, argPrefix+".target-value", 80, "DynamoDB target ratio of consumed capacity to provisioned capacity.")
 }
 

--- a/pkg/chunk/table_client.go
+++ b/pkg/chunk/table_client.go
@@ -6,7 +6,7 @@ import "context"
 type TableClient interface {
 	ListTables(ctx context.Context) ([]string, error)
 	CreateTable(ctx context.Context, desc TableDesc) error
-	DescribeTable(ctx context.Context, name string) (desc TableDesc, status string, err error)
+	DescribeTable(ctx context.Context, name string) (desc TableDesc, isActive bool, err error)
 	UpdateTable(ctx context.Context, current, expected TableDesc) error
 }
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -82,22 +81,6 @@ func (ts Tags) Equals(other Tags) bool {
 	}
 
 	return true
-}
-
-// AWSTags converts ts into a []*dynamodb.Tag.
-func (ts Tags) AWSTags() []*dynamodb.Tag {
-	if ts == nil {
-		return nil
-	}
-
-	var result []*dynamodb.Tag
-	for k, v := range ts {
-		result = append(result, &dynamodb.Tag{
-			Key:   aws.String(k),
-			Value: aws.String(v),
-		})
-	}
-	return result
 }
 
 // TableManager creates and manages the provisioned throughput on DynamoDB tables

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -253,7 +252,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDesc) error {
 	for _, expected := range descriptions {
 		level.Info(util.Logger).Log("msg", "checking provisioned throughput on table", "table", expected.Name)
-		current, status, err := m.client.DescribeTable(ctx, expected.Name)
+		current, isActive, err := m.client.DescribeTable(ctx, expected.Name)
 		if err != nil {
 			return err
 		}
@@ -265,8 +264,8 @@ func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDes
 			continue
 		}
 
-		if status != dynamodb.TableStatusActive {
-			level.Info(util.Logger).Log("msg", "skipping update on table, not yet ACTIVE", "table", expected.Name, "status", status)
+		if !isActive {
+			level.Info(util.Logger).Log("msg", "skipping update on table, not yet ACTIVE", "table", expected.Name)
 			continue
 		}
 

--- a/pkg/chunk/table_manager.go
+++ b/pkg/chunk/table_manager.go
@@ -251,7 +251,7 @@ func (m *TableManager) createTables(ctx context.Context, descriptions []TableDes
 
 func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDesc) error {
 	for _, expected := range descriptions {
-		level.Info(util.Logger).Log("msg", "checking provisioned throughput on table", "table", expected.Name)
+		level.Debug(util.Logger).Log("msg", "checking provisioned throughput on table", "table", expected.Name)
 		current, isActive, err := m.client.DescribeTable(ctx, expected.Name)
 		if err != nil {
 			return err
@@ -274,7 +274,6 @@ func (m *TableManager) updateTables(ctx context.Context, descriptions []TableDes
 			continue
 		}
 
-		level.Info(util.Logger).Log("msg", "updating provisioned throughput on table", "table", expected.Name, "old_read", current.ProvisionedRead, "old_write", current.ProvisionedWrite, "new_read", expected.ProvisionedRead, "new_write", expected.ProvisionedWrite)
 		err = m.client.UpdateTable(ctx, current, expected)
 		if err != nil {
 			return err

--- a/pkg/chunk/table_manager_test.go
+++ b/pkg/chunk/table_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/mtime"
@@ -60,11 +59,11 @@ func (m *mockTableClient) CreateTable(_ context.Context, desc TableDesc) error {
 	return nil
 }
 
-func (m *mockTableClient) DescribeTable(_ context.Context, name string) (desc TableDesc, status string, err error) {
+func (m *mockTableClient) DescribeTable(_ context.Context, name string) (desc TableDesc, isActive bool, err error) {
 	m.Lock()
 	defer m.Unlock()
 
-	return m.tables[name], dynamodb.TableStatusActive, nil
+	return m.tables[name], true, nil
 }
 
 func (m *mockTableClient) UpdateTable(_ context.Context, current, expected TableDesc) error {

--- a/vendor/github.com/prometheus/client_golang/api/client.go
+++ b/vendor/github.com/prometheus/client_golang/api/client.go
@@ -1,0 +1,131 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.7
+
+// Package api provides clients for the HTTP APIs.
+package api
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// DefaultRoundTripper is used if no RoundTripper is set in Config.
+var DefaultRoundTripper http.RoundTripper = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+// Config defines configuration parameters for a new client.
+type Config struct {
+	// The address of the Prometheus to connect to.
+	Address string
+
+	// RoundTripper is used by the Client to drive HTTP requests. If not
+	// provided, DefaultRoundTripper will be used.
+	RoundTripper http.RoundTripper
+}
+
+func (cfg *Config) roundTripper() http.RoundTripper {
+	if cfg.RoundTripper == nil {
+		return DefaultRoundTripper
+	}
+	return cfg.RoundTripper
+}
+
+// Client is the interface for an API client.
+type Client interface {
+	URL(ep string, args map[string]string) *url.URL
+	Do(context.Context, *http.Request) (*http.Response, []byte, error)
+}
+
+// NewClient returns a new Client.
+//
+// It is safe to use the returned Client from multiple goroutines.
+func NewClient(cfg Config) (Client, error) {
+	u, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+
+	return &httpClient{
+		endpoint: u,
+		client:   http.Client{Transport: cfg.roundTripper()},
+	}, nil
+}
+
+type httpClient struct {
+	endpoint *url.URL
+	client   http.Client
+}
+
+func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
+	p := path.Join(c.endpoint.Path, ep)
+
+	for arg, val := range args {
+		arg = ":" + arg
+		p = strings.Replace(p, arg, val, -1)
+	}
+
+	u := *c.endpoint
+	u.Path = p
+
+	return &u
+}
+
+func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	resp, err := c.client.Do(req)
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan struct{})
+	go func() {
+		body, err = ioutil.ReadAll(resp.Body)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		err = resp.Body.Close()
+		<-done
+		if err == nil {
+			err = ctx.Err()
+		}
+	case <-done:
+	}
+
+	return resp, body, err
+}

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -1,0 +1,502 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.7
+
+// Package v1 provides bindings to the Prometheus HTTP API v1:
+// http://prometheus.io/docs/querying/api/
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	statusAPIError = 422
+
+	apiPrefix = "/api/v1"
+
+	epAlertManagers   = apiPrefix + "/alertmanagers"
+	epQuery           = apiPrefix + "/query"
+	epQueryRange      = apiPrefix + "/query_range"
+	epLabelValues     = apiPrefix + "/label/:name/values"
+	epSeries          = apiPrefix + "/series"
+	epTargets         = apiPrefix + "/targets"
+	epSnapshot        = apiPrefix + "/admin/tsdb/snapshot"
+	epDeleteSeries    = apiPrefix + "/admin/tsdb/delete_series"
+	epCleanTombstones = apiPrefix + "/admin/tsdb/clean_tombstones"
+	epConfig          = apiPrefix + "/status/config"
+	epFlags           = apiPrefix + "/status/flags"
+)
+
+// ErrorType models the different API error types.
+type ErrorType string
+
+// HealthStatus models the health status of a scrape target.
+type HealthStatus string
+
+const (
+	// Possible values for ErrorType.
+	ErrBadData     ErrorType = "bad_data"
+	ErrTimeout               = "timeout"
+	ErrCanceled              = "canceled"
+	ErrExec                  = "execution"
+	ErrBadResponse           = "bad_response"
+
+	// Possible values for HealthStatus.
+	HealthGood    HealthStatus = "up"
+	HealthUnknown HealthStatus = "unknown"
+	HealthBad     HealthStatus = "down"
+)
+
+// Error is an error returned by the API.
+type Error struct {
+	Type ErrorType
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Msg)
+}
+
+// Range represents a sliced time range.
+type Range struct {
+	// The boundaries of the time range.
+	Start, End time.Time
+	// The maximum time between two slices within the boundaries.
+	Step time.Duration
+}
+
+// API provides bindings for Prometheus's v1 API.
+type API interface {
+	// AlertManagers returns an overview of the current state of the Prometheus alert manager discovery.
+	AlertManagers(ctx context.Context) (AlertManagersResult, error)
+	// CleanTombstones removes the deleted data from disk and cleans up the existing tombstones.
+	CleanTombstones(ctx context.Context) error
+	// Config returns the current Prometheus configuration.
+	Config(ctx context.Context) (ConfigResult, error)
+	// DeleteSeries deletes data for a selection of series in a time range.
+	DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error
+	// Flags returns the flag values that Prometheus was launched with.
+	Flags(ctx context.Context) (FlagsResult, error)
+	// LabelValues performs a query for the values of the given label.
+	LabelValues(ctx context.Context, label string) (model.LabelValues, error)
+	// Query performs a query for the given time.
+	Query(ctx context.Context, query string, ts time.Time) (model.Value, error)
+	// QueryRange performs a query for the given range.
+	QueryRange(ctx context.Context, query string, r Range) (model.Value, error)
+	// Series finds series by label matchers.
+	Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error)
+	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
+	// under the TSDB's data directory and returns the directory as response.
+	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
+	// Targets returns an overview of the current state of the Prometheus target discovery.
+	Targets(ctx context.Context) (TargetsResult, error)
+}
+
+// AlertManagersResult contains the result from querying the alertmanagers endpoint.
+type AlertManagersResult struct {
+	Active  []AlertManager `json:"activeAlertManagers"`
+	Dropped []AlertManager `json:"droppedAlertManagers"`
+}
+
+// AlertManager models a configured Alert Manager.
+type AlertManager struct {
+	URL string `json:"url"`
+}
+
+// ConfigResult contains the result from querying the config endpoint.
+type ConfigResult struct {
+	YAML string `json:"yaml"`
+}
+
+// FlagsResult contains the result from querying the flag endpoint.
+type FlagsResult map[string]string
+
+// SnapshotResult contains the result from querying the snapshot endpoint.
+type SnapshotResult struct {
+	Name string `json:"name"`
+}
+
+// TargetsResult contains the result from querying the targets endpoint.
+type TargetsResult struct {
+	Active  []ActiveTarget  `json:"activeTargets"`
+	Dropped []DroppedTarget `json:"droppedTargets"`
+}
+
+// ActiveTarget models an active Prometheus scrape target.
+type ActiveTarget struct {
+	DiscoveredLabels model.LabelSet `json:"discoveredLabels"`
+	Labels           model.LabelSet `json:"labels"`
+	ScrapeURL        string         `json:"scrapeUrl"`
+	LastError        string         `json:"lastError"`
+	LastScrape       time.Time      `json:"lastScrape"`
+	Health           HealthStatus   `json:"health"`
+}
+
+// DroppedTarget models a dropped Prometheus scrape target.
+type DroppedTarget struct {
+	DiscoveredLabels model.LabelSet `json:"discoveredLabels"`
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Type)
+	}
+	return err
+}
+
+// NewAPI returns a new API for the client.
+//
+// It is safe to use the returned API from multiple goroutines.
+func NewAPI(c api.Client) API {
+	return &httpAPI{client: apiClient{c}}
+}
+
+type httpAPI struct {
+	client api.Client
+}
+
+func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error) {
+	u := h.client.URL(epAlertManagers, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return AlertManagersResult{}, err
+	}
+
+	var res AlertManagersResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) CleanTombstones(ctx context.Context) error {
+	u := h.client.URL(epCleanTombstones, nil)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
+	u := h.client.URL(epConfig, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return ConfigResult{}, err
+	}
+
+	var res ConfigResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	u := h.client.URL(epDeleteSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	q.Set("start", startTime.Format(time.RFC3339Nano))
+	q.Set("end", endTime.Format(time.RFC3339Nano))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = h.client.Do(ctx, req)
+	return err
+}
+
+func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
+	u := h.client.URL(epFlags, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return FlagsResult{}, err
+	}
+
+	var res FlagsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
+	u := h.client.URL(epLabelValues, map[string]string{"name": label})
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	var labelValues model.LabelValues
+	err = json.Unmarshal(body, &labelValues)
+	return labelValues, err
+}
+
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	u := h.client.URL(epQuery, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	if !ts.IsZero() {
+		q.Set("time", ts.Format(time.RFC3339Nano))
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var qres queryResult
+	err = json.Unmarshal(body, &qres)
+
+	return model.Value(qres.v), err
+}
+
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range) (model.Value, error) {
+	u := h.client.URL(epQueryRange, nil)
+	q := u.Query()
+
+	var (
+		start = r.Start.Format(time.RFC3339Nano)
+		end   = r.End.Format(time.RFC3339Nano)
+		step  = strconv.FormatFloat(r.Step.Seconds(), 'f', 3, 64)
+	)
+
+	q.Set("query", query)
+	q.Set("start", start)
+	q.Set("end", end)
+	q.Set("step", step)
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var qres queryResult
+	err = json.Unmarshal(body, &qres)
+
+	return model.Value(qres.v), err
+}
+
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	u := h.client.URL(epSeries, nil)
+	q := u.Query()
+
+	for _, m := range matches {
+		q.Add("match[]", m)
+	}
+
+	q.Set("start", startTime.Format(time.RFC3339Nano))
+	q.Set("end", endTime.Format(time.RFC3339Nano))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var mset []model.LabelSet
+	err = json.Unmarshal(body, &mset)
+	return mset, err
+}
+
+func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
+	u := h.client.URL(epSnapshot, nil)
+	q := u.Query()
+
+	q.Set("skip_head", strconv.FormatBool(skipHead))
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return SnapshotResult{}, err
+	}
+
+	var res SnapshotResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
+	u := h.client.URL(epTargets, nil)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	_, body, err := h.client.Do(ctx, req)
+	if err != nil {
+		return TargetsResult{}, err
+	}
+
+	var res TargetsResult
+	err = json.Unmarshal(body, &res)
+	return res, err
+}
+
+// apiClient wraps a regular client and processes successful API responses.
+// Successful also includes responses that errored at the API level.
+type apiClient struct {
+	api.Client
+}
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType ErrorType       `json:"errorType"`
+	Error     string          `json:"error"`
+}
+
+func apiError(code int) bool {
+	// These are the codes that Prometheus sends when it returns an error.
+	return code == statusAPIError || code == http.StatusBadRequest
+}
+
+func (c apiClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	resp, body, err := c.Client.Do(ctx, req)
+	if err != nil {
+		return resp, body, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && !apiError(code) {
+		return resp, body, &Error{
+			Type: ErrBadResponse,
+			Msg:  fmt.Sprintf("bad response code %d", resp.StatusCode),
+		}
+	}
+
+	var result apiResponse
+
+	if err = json.Unmarshal(body, &result); err != nil {
+		return resp, body, &Error{
+			Type: ErrBadResponse,
+			Msg:  err.Error(),
+		}
+	}
+
+	if apiError(code) != (result.Status == "error") {
+		err = &Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if apiError(code) && result.Status == "error" {
+		err = &Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, []byte(result.Data), err
+}


### PR DESCRIPTION
Fixes #735 

To use this feature, set `-dynamodb....scale.enabled` on in command-line args but do not supply an AWS autoscaler `-applicationautoscaling.url`.
Also set `-metrics.url` to point at a Prometheus API-compatible server which will serve the metrics.

(at the time of writing this can't be a multi-tenant server because I didn't put in an option for the tenant)

PR also includes much refactoring of existing tests because I couldn't stand so much repetition.

Outstanding things I should do:
 - [x] allow the parameters like `queueLengthAcceptable` to be changed
 - [x] use the min/max capacity if configured
 - [x] implement `out-cooldown` and `in-cooldown`
 - [x] scale last week's table to zero even though this week's may be queuing
 - [x] protect against scaling-down when the ingesters hiccup (e.g. all crash at once)
 - [ ] protect against scaling-down when Prometheus restarts and has no data

For extra credit:
 - [ ] expose some metrics - e.g. requested throughput
 - [ ] more aggressive scale-up when the queue is really big
 - [x] look at the recent rate of usage when scaling down instead of a percentage
 - [ ] automatically increase capacity when an ingester rollout is under way (or fix #467)
 - [ ] support use of Cortex to supply the metrics