### PR TITLE
Remove grpc request from distributor logs

### DIFF
--- a/cmd/distributor/main.go
+++ b/cmd/distributor/main.go
@@ -43,6 +43,7 @@ func main() {
 			GRPCMiddleware: []grpc.UnaryServerInterceptor{
 				middleware.ServerUserHeaderInterceptor,
 			},
+			ExcludeRequestInLog: true,
 		}
 		ringConfig        ring.Config
 		distributorConfig distributor.Config


### PR DESCRIPTION
Currently getting 200K+ log lines which are no use to anyone.

Similar action was taken in #709 for the ingester.
