### PR TITLE
Stop sharding amongst ingesters by metric name; use all the labels.

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -1,0 +1,13 @@
+# Cortex Arguments Explained
+
+## Distributor
+
+- `-distributor.shard-by-metric-name`
+
+   In the original Cortex design, samples were sharded amongst distributors by the combination of (userid, metric name).  Sharding by metric name was designed to reduce the number of ingesters you need to hit on the read path; the downside was that you could hotspot the write path.
+
+   In hindsight, this seems like the wrong choice: we do many orders of magnitude more writes than reads, and ingester reads are in-memory and cheap. It seems the right thing to do is to use all the labels to shard, improving load balancing and support for very high cardinality metrics.
+
+   Set this flag to `false` for the new behaviour.
+
+   **Upgrade notes**: As part of the change which introduced this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag (and the disable it later). When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the new stale period all the old series will be flushed, and you should end up with much better load balancing. Reads will always catch all the data from all ingesters from this change onwards.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -10,7 +10,7 @@
 
    Set this flag to `false` for the new behaviour.
 
-   **Upgrade notes**: As part of the change which introduced this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag (and the disable it later). When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the new stale period all the old series will be flushed, and you should end up with much better load balancing. Reads will always catch all the data from all ingesters from this change onwards.
+   **Upgrade notes**: As this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag. When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the next stale period all the old series will be flushed, and you should end up with much better load balancing. With this flag enabled in the queriers, reads will always catch all the data from all ingesters.
 
 - `-ingester.max-series-per-metric`
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -2,7 +2,7 @@
 
 ## Distributor
 
-- `-distributor.shard-by-metric-name`
+- `-distributor.shard-by-metric-name-only`
 
    In the original Cortex design, samples were sharded amongst distributors by the combination of (userid, metric name).  Sharding by metric name was designed to reduce the number of ingesters you need to hit on the read path; the downside was that you could hotspot the write path.
 
@@ -11,3 +11,7 @@
    Set this flag to `false` for the new behaviour.
 
    **Upgrade notes**: As part of the change which introduced this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag (and the disable it later). When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the new stale period all the old series will be flushed, and you should end up with much better load balancing. Reads will always catch all the data from all ingesters from this change onwards.
+
+- `-ingester.max-series-per-metric`
+
+   Limit for the number of series a given metric can have in a single ingester.  When running with `-distributor.shard-by-metric-name-only=true`, this limit will enforce the maximum number of series a metric can have 'globally', but when running with `-distributor.shard-by-metric-name-only=true` the actual limit will be higher, depending on number of ingesters and replication factor.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -2,16 +2,16 @@
 
 ## Distributor
 
-- `-distributor.shard-by-metric-name-only`
+- `-distributor.shard-by-all-labels`
 
    In the original Cortex design, samples were sharded amongst distributors by the combination of (userid, metric name).  Sharding by metric name was designed to reduce the number of ingesters you need to hit on the read path; the downside was that you could hotspot the write path.
 
    In hindsight, this seems like the wrong choice: we do many orders of magnitude more writes than reads, and ingester reads are in-memory and cheap. It seems the right thing to do is to use all the labels to shard, improving load balancing and support for very high cardinality metrics.
 
-   Set this flag to `false` for the new behaviour.
+   Set this flag to `true` for the new behaviour.
 
    **Upgrade notes**: As this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag. When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the next stale period all the old series will be flushed, and you should end up with much better load balancing. With this flag enabled in the queriers, reads will always catch all the data from all ingesters.
 
 - `-ingester.max-series-per-metric`
 
-   Limit for the number of series a given metric can have in a single ingester.  When running with `-distributor.shard-by-metric-name-only=true`, this limit will enforce the maximum number of series a metric can have 'globally', but when running with `-distributor.shard-by-metric-name-only=true` the actual limit will be higher, depending on number of ingesters and replication factor.
+   Limit for the number of series a given metric can have in a single ingester.  When running with `-distributor.shard-by-all-labels=false` (the default), this limit will enforce the maximum number of series a metric can have 'globally', but when running with `-distributor.shard-by-all-labels=true` the actual limit will be higher, depending on number of ingesters and replication factor.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -81,7 +81,7 @@ type Config struct {
 	ShardByMetricName bool
 
 	// for testing
-	ingesterClientFactory func(addr string, cfg ingester_client.Config) (client.IngesterClient, error)
+	ingesterClientFactory client.Factory
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -94,7 +94,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
 	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
 	flag.BoolVar(&cfg.HealthCheckIngesters, "distributor.health-check-ingesters", false, "Run a health check on each ingester client during periodic cleanup.")
-	flag.BoolVar(&cfg.ShardByMetricName, "distributor.shard-by-metric-name", true, "If samples shoud be distributed solely by user and metric name, as opposed to all labels.")
+	flag.BoolVar(&cfg.ShardByMetricName, "distributor.shard-by-metric-name-only", true, "If samples shoud be distributed solely by user and metric name, as opposed to all labels.")
 }
 
 // New constructs a new Distributor

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -19,85 +19,10 @@ import (
 	"github.com/weaveworks/cortex/pkg/ring"
 )
 
-// mockRing doesn't do any consistent hashing, just returns same ingesters for every query.
-type mockRing struct {
-	prometheus.Counter
-	ingesters []*ring.IngesterDesc
-}
-
-func (r mockRing) Get(key uint32, op ring.Operation) (ring.ReplicationSet, error) {
-	return ring.ReplicationSet{
-		Ingesters: r.ingesters[:3],
-		MaxErrors: 1,
-	}, nil
-}
-
-func (r mockRing) BatchGet(keys []uint32, op ring.Operation) ([]ring.ReplicationSet, error) {
-	result := []ring.ReplicationSet{}
-	for i := 0; i < len(keys); i++ {
-		result = append(result, ring.ReplicationSet{
-			Ingesters: r.ingesters[:3],
-			MaxErrors: 1,
-		})
-	}
-	return result, nil
-}
-
-func (r mockRing) GetAll() (ring.ReplicationSet, error) {
-	return ring.ReplicationSet{
-		Ingesters: r.ingesters,
-		MaxErrors: 1,
-	}, nil
-}
-
-func (r mockRing) ReplicationFactor() int {
-	return 3
-}
-
-type mockIngester struct {
-	client.IngesterClient
-	happy bool
-	stats client.UsersStatsResponse
-}
-
-func (i mockIngester) Push(ctx context.Context, in *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
-	if !i.happy {
-		return nil, fmt.Errorf("Fail")
-	}
-	return &client.WriteResponse{}, nil
-}
-
-func (i mockIngester) Query(ctx context.Context, in *client.QueryRequest, opts ...grpc.CallOption) (*client.QueryResponse, error) {
-	if !i.happy {
-		return nil, fmt.Errorf("Fail")
-	}
-	return &client.QueryResponse{
-		Timeseries: []client.TimeSeries{
-			{
-				Labels: []client.LabelPair{
-					{
-						Name:  []byte("__name__"),
-						Value: []byte("foo"),
-					},
-				},
-				Samples: []client.Sample{
-					{
-						Value:       0,
-						TimestampMs: 0,
-					},
-					{
-						Value:       1,
-						TimestampMs: 1,
-					},
-				},
-			},
-		},
-	}, nil
-}
-
-func (i mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
-	return &i.stats, nil
-}
+var (
+	errFail = fmt.Errorf("Fail")
+	success = &client.WriteResponse{}
+)
 
 func TestDistributorPush(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
@@ -110,7 +35,7 @@ func TestDistributorPush(t *testing.T) {
 		// A push of no samples shouldn't block or return error, even if ingesters are sad
 		{
 			ingesters:        []mockIngester{{}, {}, {}},
-			expectedResponse: &client.WriteResponse{},
+			expectedResponse: success,
 		},
 
 		// A push to 3 happy ingesters should succeed
@@ -121,7 +46,7 @@ func TestDistributorPush(t *testing.T) {
 				{happy: true},
 				{happy: true},
 			},
-			expectedResponse: &client.WriteResponse{},
+			expectedResponse: success,
 		},
 
 		// A push to 2 happy ingesters should succeed
@@ -132,7 +57,7 @@ func TestDistributorPush(t *testing.T) {
 				{happy: true},
 				{happy: true},
 			},
-			expectedResponse: &client.WriteResponse{},
+			expectedResponse: success,
 		},
 
 		// A push to 1 happy ingesters should fail
@@ -143,14 +68,14 @@ func TestDistributorPush(t *testing.T) {
 				{},
 				{happy: true},
 			},
-			expectedError: fmt.Errorf("Fail"),
+			expectedError: errFail,
 		},
 
 		// A push to 0 happy ingesters should fail
 		{
 			samples:       10,
 			ingesters:     []mockIngester{{}, {}, {}},
-			expectedError: fmt.Errorf("Fail"),
+			expectedError: errFail,
 		},
 
 		// A push exceeding burst size should fail
@@ -165,56 +90,10 @@ func TestDistributorPush(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			ingesterDescs := []*ring.IngesterDesc{}
-			ingesters := map[string]mockIngester{}
-			for i, ingester := range tc.ingesters {
-				addr := fmt.Sprintf("%d", i)
-				ingesterDescs = append(ingesterDescs, &ring.IngesterDesc{
-					Addr:      addr,
-					Timestamp: time.Now().Unix(),
-				})
-				ingesters[addr] = ingester
-			}
-
-			ring := mockRing{
-				Counter: prometheus.NewCounter(prometheus.CounterOpts{
-					Name: "foo",
-				}),
-				ingesters: ingesterDescs,
-			}
-
-			d, err := New(Config{
-				RemoteTimeout:       1 * time.Minute,
-				ClientCleanupPeriod: 1 * time.Minute,
-				IngestionRateLimit:  20,
-				IngestionBurstSize:  20,
-
-				ingesterClientFactory: func(addr string, _ client.Config) (client.IngesterClient, error) {
-					return ingesters[addr], nil
-				},
-			}, ring)
-			if err != nil {
-				t.Fatal(err)
-			}
+			d := prepare(t, tc.ingesters)
 			defer d.Stop()
 
-			request := &client.WriteRequest{}
-			for i := 0; i < tc.samples; i++ {
-				ts := client.TimeSeries{
-					Labels: []client.LabelPair{
-						{Name: []byte("__name__"), Value: []byte("foo")},
-						{Name: []byte("bar"), Value: []byte("baz")},
-						{Name: []byte("sample"), Value: []byte(fmt.Sprintf("%d", i))},
-					},
-				}
-				ts.Samples = []client.Sample{
-					{
-						Value:       float64(i),
-						TimestampMs: int64(i),
-					},
-				}
-				request.Timeseries = append(request.Timeseries, ts)
-			}
+			request := makeWriteRequest(tc.samples)
 			response, err := d.Push(ctx, request)
 			assert.Equal(t, tc.expectedResponse, response, "Wrong response")
 			assert.Equal(t, tc.expectedError, err, "Wrong error")
@@ -238,23 +117,6 @@ func TestDistributorQuery(t *testing.T) {
 	matchers := []*labels.Matcher{
 		nameMatcher,
 		jobMatcher,
-	}
-
-	expectedResponse := func(start, end int) model.Matrix {
-		result := model.Matrix{
-			&model.SampleStream{
-				Metric: model.Metric{"__name__": "foo"},
-			},
-		}
-		for i := start; i < end; i++ {
-			result[0].Values = append(result[0].Values,
-				model.SamplePair{
-					Value:     model.SampleValue(i),
-					Timestamp: model.Time(i),
-				},
-			)
-		}
-		return result
 	}
 
 	for i, tc := range []struct {
@@ -289,7 +151,7 @@ func TestDistributorQuery(t *testing.T) {
 				{happy: false},
 				{happy: true},
 			},
-			expectedError: fmt.Errorf("Fail"),
+			expectedError: errFail,
 		},
 
 		// A query to 0 happy ingesters should succeed
@@ -299,41 +161,11 @@ func TestDistributorQuery(t *testing.T) {
 				{happy: false},
 				{happy: false},
 			},
-			expectedError: fmt.Errorf("Fail"),
+			expectedError: errFail,
 		},
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			ingesterDescs := []*ring.IngesterDesc{}
-			ingesters := map[string]mockIngester{}
-			for i, ingester := range tc.ingesters {
-				addr := fmt.Sprintf("%d", i)
-				ingesterDescs = append(ingesterDescs, &ring.IngesterDesc{
-					Addr:      addr,
-					Timestamp: time.Now().Unix(),
-				})
-				ingesters[addr] = ingester
-			}
-
-			ring := mockRing{
-				Counter: prometheus.NewCounter(prometheus.CounterOpts{
-					Name: "foo",
-				}),
-				ingesters: ingesterDescs,
-			}
-
-			d, err := New(Config{
-				RemoteTimeout:       1 * time.Minute,
-				ClientCleanupPeriod: 1 * time.Minute,
-				IngestionRateLimit:  10000,
-				IngestionBurstSize:  10000,
-
-				ingesterClientFactory: func(addr string, _ client.Config) (client.IngesterClient, error) {
-					return ingesters[addr], nil
-				},
-			}, ring)
-			if err != nil {
-				t.Fatal(err)
-			}
+			d := prepare(t, tc.ingesters)
 			defer d.Stop()
 
 			for _, matcher := range matchers {
@@ -343,4 +175,166 @@ func TestDistributorQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func prepare(t *testing.T, ingesters []mockIngester) *Distributor {
+	ingesterDescs := []*ring.IngesterDesc{}
+	ingestersByAddr := map[string]mockIngester{}
+	for i, ingester := range ingesters {
+		addr := fmt.Sprintf("%d", i)
+		ingesterDescs = append(ingesterDescs, &ring.IngesterDesc{
+			Addr:      addr,
+			Timestamp: time.Now().Unix(),
+		})
+		ingestersByAddr[addr] = ingester
+	}
+
+	ring := mockRing{
+		Counter: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "foo",
+		}),
+		ingesters:         ingesterDescs,
+		replicationFactor: 3,
+	}
+
+	factory := func(addr string, _ client.Config) (client.IngesterClient, error) {
+		return ingestersByAddr[addr], nil
+	}
+
+	d, err := New(Config{
+		RemoteTimeout:         1 * time.Minute,
+		ClientCleanupPeriod:   1 * time.Minute,
+		IngestionRateLimit:    20,
+		IngestionBurstSize:    20,
+		ingesterClientFactory: factory,
+	}, ring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func makeWriteRequest(samples int) *client.WriteRequest {
+	request := &client.WriteRequest{}
+	for i := 0; i < samples; i++ {
+		ts := client.TimeSeries{
+			Labels: []client.LabelPair{
+				{Name: []byte("__name__"), Value: []byte("foo")},
+				{Name: []byte("bar"), Value: []byte("baz")},
+				{Name: []byte("sample"), Value: []byte(fmt.Sprintf("%d", i))},
+			},
+		}
+		ts.Samples = []client.Sample{
+			{
+				Value:       float64(i),
+				TimestampMs: int64(i),
+			},
+		}
+		request.Timeseries = append(request.Timeseries, ts)
+	}
+	return request
+}
+
+func expectedResponse(start, end int) model.Matrix {
+	result := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{"__name__": "foo"},
+		},
+	}
+	for i := start; i < end; i++ {
+		result[0].Values = append(result[0].Values,
+			model.SamplePair{
+				Value:     model.SampleValue(i),
+				Timestamp: model.Time(i),
+			},
+		)
+	}
+	return result
+}
+
+// mockRing doesn't do virtual nodes, just returns mod(key) + replicationFactor
+// ingesters.
+type mockRing struct {
+	prometheus.Counter
+	ingesters         []*ring.IngesterDesc
+	replicationFactor uint32
+}
+
+func (r mockRing) Get(key uint32, op ring.Operation) (ring.ReplicationSet, error) {
+	result := ring.ReplicationSet{
+		MaxErrors: 1,
+	}
+	for i := uint32(0); i < r.replicationFactor; i++ {
+		n := (key + i) % uint32(len(r.ingesters))
+		result.Ingesters = append(result.Ingesters, r.ingesters[n])
+	}
+	return result, nil
+}
+
+func (r mockRing) BatchGet(keys []uint32, op ring.Operation) ([]ring.ReplicationSet, error) {
+	result := []ring.ReplicationSet{}
+	for i := 0; i < len(keys); i++ {
+		rs, err := r.Get(keys[i], op)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rs)
+	}
+	return result, nil
+}
+
+func (r mockRing) GetAll() (ring.ReplicationSet, error) {
+	return ring.ReplicationSet{
+		Ingesters: r.ingesters,
+		MaxErrors: 1,
+	}, nil
+}
+
+func (r mockRing) ReplicationFactor() int {
+	return int(r.replicationFactor)
+}
+
+type mockIngester struct {
+	client.IngesterClient
+	happy bool
+	stats client.UsersStatsResponse
+}
+
+func (i mockIngester) Push(ctx context.Context, in *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
+	if !i.happy {
+		return nil, errFail
+	}
+	return &client.WriteResponse{}, nil
+}
+
+func (i mockIngester) Query(ctx context.Context, in *client.QueryRequest, opts ...grpc.CallOption) (*client.QueryResponse, error) {
+	if !i.happy {
+		return nil, errFail
+	}
+	return &client.QueryResponse{
+		Timeseries: []client.TimeSeries{
+			{
+				Labels: []client.LabelPair{
+					{
+						Name:  []byte("__name__"),
+						Value: []byte("foo"),
+					},
+				},
+				Samples: []client.Sample{
+					{
+						Value:       0,
+						TimestampMs: 0,
+					},
+					{
+						Value:       1,
+						TimestampMs: 1,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (i mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
+	return &i.stats, nil
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -273,7 +273,7 @@ func expectedResponse(start, end int) model.Matrix {
 				"sample":   model.LabelValue(fmt.Sprintf("%d", i)),
 			},
 			Values: []model.SamplePair{
-				model.SamplePair{
+				{
 					Value:     model.SampleValue(i),
 					Timestamp: model.Time(i),
 				},

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3,6 +3,9 @@ package distributor
 import (
 	"fmt"
 	"net/http"
+	"sort"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,171 +25,195 @@ import (
 var (
 	errFail = fmt.Errorf("Fail")
 	success = &client.WriteResponse{}
+	ctx     = user.InjectOrgID(context.Background(), "user")
 )
 
 func TestDistributorPush(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), "user")
 	for i, tc := range []struct {
-		ingesters        []mockIngester
+		numIngesters     int
+		happyIngesters   int
 		samples          int
 		expectedResponse *client.WriteResponse
 		expectedError    error
 	}{
 		// A push of no samples shouldn't block or return error, even if ingesters are sad
 		{
-			ingesters:        []mockIngester{{}, {}, {}},
+			numIngesters:     3,
+			happyIngesters:   0,
 			expectedResponse: success,
 		},
 
 		// A push to 3 happy ingesters should succeed
 		{
-			samples: 10,
-			ingesters: []mockIngester{
-				{happy: true},
-				{happy: true},
-				{happy: true},
-			},
+			numIngesters:     3,
+			happyIngesters:   3,
+			samples:          10,
 			expectedResponse: success,
 		},
 
 		// A push to 2 happy ingesters should succeed
 		{
-			samples: 10,
-			ingesters: []mockIngester{
-				{},
-				{happy: true},
-				{happy: true},
-			},
+			numIngesters:     3,
+			happyIngesters:   2,
+			samples:          10,
 			expectedResponse: success,
 		},
 
 		// A push to 1 happy ingesters should fail
 		{
-			samples: 10,
-			ingesters: []mockIngester{
-				{},
-				{},
-				{happy: true},
-			},
-			expectedError: errFail,
+			numIngesters:   3,
+			happyIngesters: 1,
+			samples:        10,
+			expectedError:  errFail,
 		},
 
 		// A push to 0 happy ingesters should fail
 		{
-			samples:       10,
-			ingesters:     []mockIngester{{}, {}, {}},
-			expectedError: errFail,
+			numIngesters:   3,
+			happyIngesters: 0,
+			samples:        10,
+			expectedError:  errFail,
 		},
 
 		// A push exceeding burst size should fail
 		{
-			samples: 30,
-			ingesters: []mockIngester{
-				{happy: true},
-				{happy: true},
-				{happy: true},
-			},
-			expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (20) exceeded while adding 30 samples"),
+			numIngesters:   3,
+			happyIngesters: 3,
+			samples:        30,
+			expectedError:  httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (20) exceeded while adding 30 samples"),
 		},
 	} {
-		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			d := prepare(t, tc.ingesters)
+		for _, shardByMetricName := range []bool{true, false} {
+			t.Run(fmt.Sprintf("[%d](shardByMetricName=%v)", i, shardByMetricName), func(t *testing.T) {
+				d := prepare(t, tc.numIngesters, tc.happyIngesters, shardByMetricName)
+				defer d.Stop()
+
+				request := makeWriteRequest(tc.samples)
+				response, err := d.Push(ctx, request)
+				assert.Equal(t, tc.expectedResponse, response)
+				assert.Equal(t, tc.expectedError, err)
+			})
+		}
+	}
+}
+
+func TestDistributorPushQuery(t *testing.T) {
+	nameMatcher := mustEqualMatcher("__name__", "foo")
+	barMatcher := mustEqualMatcher("bar", "baz")
+
+	type testcase struct {
+		name              string
+		numIngesters      int
+		happyIngesters    int
+		samples           int
+		matchers          []*labels.Matcher
+		expectedResponse  model.Matrix
+		expectedError     error
+		shardByMetricName bool
+	}
+
+	// We'll programatically build the test cases now, as we want complete
+	// coverage along quite a few different axis.
+	testcases := []testcase{}
+
+	// Run every test in both sharding modes.
+	for _, shardByMetricName := range []bool{true, false} {
+
+		// Test with between 3 and 10 ingesters.
+		for numIngesters := 3; numIngesters < 10; numIngesters++ {
+
+			// Test with between 0 and numIngesters "happy" ingesters.
+			for happyIngesters := 0; happyIngesters <= numIngesters; happyIngesters++ {
+
+				// Queriers with more than one failed ingester should fail.
+				if numIngesters-happyIngesters > 1 {
+					testcases = append(testcases, testcase{
+						name:              fmt.Sprintf("ExpectFail(shardByMetricName=%v,numIngester=%d,happyIngester=%d)", shardByMetricName, numIngesters, happyIngesters),
+						numIngesters:      numIngesters,
+						happyIngesters:    happyIngesters,
+						matchers:          []*labels.Matcher{nameMatcher, barMatcher},
+						expectedError:     errFail,
+						shardByMetricName: shardByMetricName,
+					})
+					continue
+				}
+
+				// Reading all the samples back should succeed.
+				testcases = append(testcases, testcase{
+					name:              fmt.Sprintf("ReadAll(shardByMetricName=%v,numIngester=%d,happyIngester=%d)", shardByMetricName, numIngesters, happyIngesters),
+					numIngesters:      numIngesters,
+					happyIngesters:    happyIngesters,
+					samples:           10,
+					matchers:          []*labels.Matcher{nameMatcher, barMatcher},
+					expectedResponse:  expectedResponse(0, 10),
+					shardByMetricName: shardByMetricName,
+				})
+
+				// As should reading none of the samples back.
+				testcases = append(testcases, testcase{
+					name:              fmt.Sprintf("ReadNone(shardByMetricName=%v,numIngester=%d,happyIngester=%d)", shardByMetricName, numIngesters, happyIngesters),
+					numIngesters:      numIngesters,
+					happyIngesters:    happyIngesters,
+					samples:           10,
+					matchers:          []*labels.Matcher{nameMatcher, mustEqualMatcher("not", "found")},
+					expectedResponse:  expectedResponse(0, 0),
+					shardByMetricName: shardByMetricName,
+				})
+
+				// And reading each sample individually.
+				for i := 0; i < 10; i++ {
+					testcases = append(testcases, testcase{
+						name:              fmt.Sprintf("ReadOne(shardByMetricName=%v, sample=%d,numIngester=%d,happyIngester=%d)", shardByMetricName, i, numIngesters, happyIngesters),
+						numIngesters:      numIngesters,
+						happyIngesters:    happyIngesters,
+						samples:           10,
+						matchers:          []*labels.Matcher{nameMatcher, mustEqualMatcher("sample", strconv.Itoa(i))},
+						expectedResponse:  expectedResponse(i, i+1),
+						shardByMetricName: shardByMetricName,
+					})
+				}
+			}
+		}
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := prepare(t, tc.numIngesters, tc.happyIngesters, tc.shardByMetricName)
 			defer d.Stop()
 
 			request := makeWriteRequest(tc.samples)
-			response, err := d.Push(ctx, request)
-			assert.Equal(t, tc.expectedResponse, response, "Wrong response")
-			assert.Equal(t, tc.expectedError, err, "Wrong error")
+			writeResponse, err := d.Push(ctx, request)
+			assert.Equal(t, &client.WriteResponse{}, writeResponse)
+			assert.Nil(t, err)
+
+			response, err := d.Query(ctx, 0, 10, tc.matchers...)
+			sort.Sort(response)
+			assert.Equal(t, tc.expectedResponse, response)
+			assert.Equal(t, tc.expectedError, err)
 		})
 	}
 }
 
-func TestDistributorQuery(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), "user")
-
-	nameMatcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	jobMatcher, err := labels.NewMatcher(labels.MatchEqual, "job", "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	matchers := []*labels.Matcher{
-		nameMatcher,
-		jobMatcher,
-	}
-
-	for i, tc := range []struct {
-		ingesters        []mockIngester
-		expectedResponse model.Matrix
-		expectedError    error
-	}{
-		// A query to 3 happy ingesters should succeed
-		{
-			ingesters: []mockIngester{
-				{happy: true},
-				{happy: true},
-				{happy: true},
-			},
-			expectedResponse: expectedResponse(0, 2),
-		},
-
-		// A query to 2 happy ingesters should succeed
-		{
-			ingesters: []mockIngester{
-				{happy: false},
-				{happy: true},
-				{happy: true},
-			},
-			expectedResponse: expectedResponse(0, 2),
-		},
-
-		// A query to 1 happy ingesters should fail
-		{
-			ingesters: []mockIngester{
-				{happy: false},
-				{happy: false},
-				{happy: true},
-			},
-			expectedError: errFail,
-		},
-
-		// A query to 0 happy ingesters should succeed
-		{
-			ingesters: []mockIngester{
-				{happy: false},
-				{happy: false},
-				{happy: false},
-			},
-			expectedError: errFail,
-		},
-	} {
-		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			d := prepare(t, tc.ingesters)
-			defer d.Stop()
-
-			for _, matcher := range matchers {
-				response, err := d.Query(ctx, 0, 10, matcher)
-				assert.Equal(t, tc.expectedResponse, response, "Wrong response")
-				assert.Equal(t, tc.expectedError, err, "Wrong error")
-			}
+func prepare(t *testing.T, numIngesters, happyIngesters int, shardByMetricName bool) *Distributor {
+	ingesters := []mockIngester{}
+	for i := 0; i < happyIngesters; i++ {
+		ingesters = append(ingesters, mockIngester{
+			happy: true,
 		})
 	}
-}
+	for i := happyIngesters; i < numIngesters; i++ {
+		ingesters = append(ingesters, mockIngester{})
+	}
 
-func prepare(t *testing.T, ingesters []mockIngester) *Distributor {
 	ingesterDescs := []*ring.IngesterDesc{}
-	ingestersByAddr := map[string]mockIngester{}
-	for i, ingester := range ingesters {
+	ingestersByAddr := map[string]*mockIngester{}
+	for i := range ingesters {
 		addr := fmt.Sprintf("%d", i)
 		ingesterDescs = append(ingesterDescs, &ring.IngesterDesc{
 			Addr:      addr,
 			Timestamp: time.Now().Unix(),
 		})
-		ingestersByAddr[addr] = ingester
+		ingestersByAddr[addr] = &ingesters[i]
 	}
 
 	ring := mockRing{
@@ -207,6 +234,7 @@ func prepare(t *testing.T, ingesters []mockIngester) *Distributor {
 		IngestionRateLimit:    20,
 		IngestionBurstSize:    20,
 		ingesterClientFactory: factory,
+		ShardByMetricName:     true,
 	}, ring)
 	if err != nil {
 		t.Fatal(err)
@@ -236,20 +264,31 @@ func makeWriteRequest(samples int) *client.WriteRequest {
 }
 
 func expectedResponse(start, end int) model.Matrix {
-	result := model.Matrix{
-		&model.SampleStream{
-			Metric: model.Metric{"__name__": "foo"},
-		},
-	}
+	result := model.Matrix{}
 	for i := start; i < end; i++ {
-		result[0].Values = append(result[0].Values,
-			model.SamplePair{
-				Value:     model.SampleValue(i),
-				Timestamp: model.Time(i),
+		result = append(result, &model.SampleStream{
+			Metric: model.Metric{
+				"__name__": "foo",
+				"bar":      "baz",
+				"sample":   model.LabelValue(fmt.Sprintf("%d", i)),
 			},
-		)
+			Values: []model.SamplePair{
+				model.SamplePair{
+					Value:     model.SampleValue(i),
+					Timestamp: model.Time(i),
+				},
+			},
+		})
 	}
 	return result
+}
+
+func mustEqualMatcher(k, v string) *labels.Matcher {
+	m, err := labels.NewMatcher(labels.MatchEqual, k, v)
+	if err != nil {
+		panic(err)
+	}
+	return m
 }
 
 // mockRing doesn't do virtual nodes, just returns mod(key) + replicationFactor
@@ -295,46 +334,78 @@ func (r mockRing) ReplicationFactor() int {
 }
 
 type mockIngester struct {
+	sync.Mutex
 	client.IngesterClient
-	happy bool
-	stats client.UsersStatsResponse
+	happy      bool
+	stats      client.UsersStatsResponse
+	timeseries map[uint32]*client.TimeSeries
 }
 
-func (i mockIngester) Push(ctx context.Context, in *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
+func (i *mockIngester) Push(ctx context.Context, req *client.WriteRequest, opts ...grpc.CallOption) (*client.WriteResponse, error) {
+	i.Lock()
+	defer i.Unlock()
+
 	if !i.happy {
 		return nil, errFail
 	}
+
+	if i.timeseries == nil {
+		i.timeseries = map[uint32]*client.TimeSeries{}
+	}
+
+	orgid, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for j := range req.Timeseries {
+		hash, _ := shardByAllLabels(orgid, req.Timeseries[j].Labels)
+		existing, ok := i.timeseries[hash]
+		if !ok {
+			i.timeseries[hash] = &req.Timeseries[j]
+		} else {
+			existing.Samples = append(existing.Samples, req.Timeseries[j].Samples...)
+		}
+	}
+
 	return &client.WriteResponse{}, nil
 }
 
-func (i mockIngester) Query(ctx context.Context, in *client.QueryRequest, opts ...grpc.CallOption) (*client.QueryResponse, error) {
+func (i *mockIngester) Query(ctx context.Context, req *client.QueryRequest, opts ...grpc.CallOption) (*client.QueryResponse, error) {
+	i.Lock()
+	defer i.Unlock()
+
 	if !i.happy {
 		return nil, errFail
 	}
-	return &client.QueryResponse{
-		Timeseries: []client.TimeSeries{
-			{
-				Labels: []client.LabelPair{
-					{
-						Name:  []byte("__name__"),
-						Value: []byte("foo"),
-					},
-				},
-				Samples: []client.Sample{
-					{
-						Value:       0,
-						TimestampMs: 0,
-					},
-					{
-						Value:       1,
-						TimestampMs: 1,
-					},
-				},
-			},
-		},
-	}, nil
+
+	_, _, matchers, err := client.FromQueryRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := client.QueryResponse{}
+	for _, ts := range i.timeseries {
+		if match(ts.Labels, matchers) {
+			response.Timeseries = append(response.Timeseries, *ts)
+		}
+	}
+	return &response, nil
 }
 
-func (i mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
+func (i *mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
 	return &i.stats, nil
+}
+
+func match(labels []client.LabelPair, matchers []*labels.Matcher) bool {
+outer:
+	for _, matcher := range matchers {
+		for _, labels := range labels {
+			if matcher.Name == string(labels.Name) && matcher.Matches(string(labels.Value)) {
+				continue outer
+			}
+		}
+		return false
+	}
+	return true
 }

--- a/pkg/ingester/client/pool_test.go
+++ b/pkg/ingester/client/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -57,7 +58,7 @@ func TestIngesterCache(t *testing.T) {
 		buildCount++
 		return mockIngester{happy: true, status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 	}
-	pool := NewIngesterPool(factory, Config{}, 50*time.Millisecond)
+	pool := NewIngesterPool(factory, Config{}, 50*time.Millisecond, log.NewNopLogger())
 
 	pool.GetClientFor("1")
 	if buildCount != 1 {
@@ -110,6 +111,7 @@ func TestCleanUnhealthy(t *testing.T) {
 	}
 	pool := &IngesterPool{
 		clients: clients,
+		logger:  log.NewNopLogger(),
 	}
 	pool.CleanUnhealthy()
 	for _, addr := range badAddrs {

--- a/pkg/util/matchers.go
+++ b/pkg/util/matchers.go
@@ -30,6 +30,7 @@ func SplitFiltersAndMatchers(allMatchers []*labels.Matcher) (filters, matchers [
 	return
 }
 
+// ExtractMetricNameFromLabelPairs extracts the metric name for a slice of LabelPairs.
 func ExtractMetricNameFromLabelPairs(labels []client.LabelPair) ([]byte, error) {
 	for _, label := range labels {
 		if label.Name.Equal(labelNameBytes) {

--- a/pkg/util/matchers.go
+++ b/pkg/util/matchers.go
@@ -5,6 +5,11 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+)
+
+var (
+	labelNameBytes = []byte(model.MetricNameLabel)
 )
 
 // SplitFiltersAndMatchers splits empty matchers off, which are treated as filters, see #220
@@ -23,6 +28,15 @@ func SplitFiltersAndMatchers(allMatchers []*labels.Matcher) (filters, matchers [
 		}
 	}
 	return
+}
+
+func ExtractMetricNameFromLabelPairs(labels []client.LabelPair) ([]byte, error) {
+	for _, label := range labels {
+		if label.Name.Equal(labelNameBytes) {
+			return label.Value, nil
+		}
+	}
+	return nil, fmt.Errorf("No metric name label")
 }
 
 // ExtractMetricNameFromMetric extract the metric name from a model.Metric


### PR DESCRIPTION
Stop sharding amongst ingesters by metric name; use all the labels.

Sharding by metric name was designed to reduce the number of ingesters you need to hit on the read path; the downside was that you could hotspot the write path.

In hindsight, this seems like the wrong choice: we do many orders of magnitude more writes than reads, and ingester reads are in-memory and cheap. It seems the right thing to do is to use all the labels to shard, improving load balancing and support for very high cardinality metrics.

And check for sorted labels.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>