### PR TITLE
Don't check the build image is up-to-date when not using it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,7 @@ jobs:
     - checkout
     - run:
         name: Lint
-        command: |
-          touch build-image/.uptodate
-          make BUILD_IN_CONTAINER=false lint
+        command: make BUILD_IN_CONTAINER=false lint
 
   test:
     <<: *defaults
@@ -41,9 +39,7 @@ jobs:
     - checkout
     - run:
         name: Test
-        command: |
-          touch build-image/.uptodate
-          make BUILD_IN_CONTAINER=false test
+        command: make BUILD_IN_CONTAINER=false test
 
   integration:
     docker:
@@ -57,9 +53,7 @@ jobs:
     - checkout
     - run:
         name: Integration Test
-        command: |
-          touch build-image/.uptodate
-          MIGRATIONS_DIR=$(pwd)/cmd/configs/migrations make BUILD_IN_CONTAINER=false configs-integration-test
+        command: MIGRATIONS_DIR=$(pwd)/cmd/configs/migrations make BUILD_IN_CONTAINER=false configs-integration-test
 
   build:
     <<: *defaults
@@ -78,15 +72,11 @@ jobs:
 
     - run:
         name: Build
-        command: |
-          touch build-image/.uptodate
-          make BUILD_IN_CONTAINER=false
+        command: make BUILD_IN_CONTAINER=false
 
     - run:
         name: Save Images
-        command: |
-          touch build-image/.uptodate &&
-          make BUILD_IN_CONTAINER=false save-images
+        command: make BUILD_IN_CONTAINER=false save-images
 
     - save_cache:
         key: v1-cortex-{{ .Branch }}-{{ .Revision }}
@@ -113,9 +103,7 @@ jobs:
 
     - run:
         name: Load Images
-        command: |
-          touch build-image/.uptodate &&
-          make BUILD_IN_CONTAINER=false load-images
+        command: make BUILD_IN_CONTAINER=false load-images
 
     - run:
         name: Deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ jobs:
 
     - run:
         name: Build
-        command: make BUILD_IN_CONTAINER=false
+        command: |
+          touch build-image/.uptodate
+          make BUILD_IN_CONTAINER=false
 
     - run:
         name: Save Images

--- a/Makefile
+++ b/Makefile
@@ -107,20 +107,20 @@ configs-integration-test: build-image/$(UPTODATE)
 
 else
 
-$(EXES): build-image/$(UPTODATE)
+$(EXES):
 	go build $(GO_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
-%.pb.go: build-image/$(UPTODATE)
+%.pb.go:
 	protoc -I ./vendor:./$(@D) --gogoslick_out=plugins=grpc:./$(@D) ./$(patsubst %.pb.go,%.proto,$@)
 
-lint: build-image/$(UPTODATE)
+lint:
 	./tools/lint -notestpackage -ignorespelling queriers -ignorespelling Queriers .
 
-test: build-image/$(UPTODATE)
+test:
 	./tools/test -netgo
 
-shell: build-image/$(UPTODATE)
+shell:
 	bash
 
 configs-integration-test:


### PR DESCRIPTION
We had a bunch of rules in `Makefile` insisting the build image was up-to-date in the `else` clause of `BUILD_IN_CONTAINER`, and a matching bunch of CI instructions to `touch` the file.

Lose (almost) all of this.
