### PR TITLE
Include metric name in error message for too many labels

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -326,9 +326,9 @@ func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 
 func TestIngesterRejectOldSamples(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
-	cfg.RejectOldSamples = true
-	cfg.RejectOldSamplesMaxAge = 24 * time.Hour
-	cfg.CreationGracePeriod = 4 * time.Hour
+	cfg.validationConfig.RejectOldSamples = true
+	cfg.validationConfig.RejectOldSamplesMaxAge = 24 * time.Hour
+	cfg.validationConfig.CreationGracePeriod = 4 * time.Hour
 
 	_, ing := newTestStore(t, cfg)
 	defer ing.Shutdown()

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -15,6 +15,7 @@ const (
 	errInvalidLabel      = "sample invalid label: '%s'"
 	errLabelNameTooLong  = "label name too long: '%s'"
 	errLabelValueTooLong = "label value too long: '%s'"
+	errTooManyLabels     = "sample for '%s' has %d label names; limit %d"
 )
 
 // ValidateConfig has config for validation settings and options
@@ -48,7 +49,7 @@ func ValidateSample(s *model.Sample, config *ValidateConfig) error {
 	numLabelNames := len(s.Metric)
 	if numLabelNames > config.MaxLabelNamesPerSeries {
 		discardedSamples.WithLabelValues(maxLabelNamesPerSeries).Inc()
-		return httpgrpc.Errorf(http.StatusBadRequest, "sample has %d label names which is greater than the accepted maximum of %d", numLabelNames, config.MaxLabelNamesPerSeries)
+		return httpgrpc.Errorf(http.StatusBadRequest, errTooManyLabels, metricName, numLabelNames, config.MaxLabelNamesPerSeries)
 	}
 
 	for k, v := range s.Metric {

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -11,10 +11,10 @@ import (
 
 const (
 	errMissingMetricName = "sample missing metric name"
-	errInvalidMetricName = "sample invalid metric name: '%s'"
-	errInvalidLabel      = "sample invalid label: '%s'"
-	errLabelNameTooLong  = "label name too long: '%s'"
-	errLabelValueTooLong = "label value too long: '%s'"
+	errInvalidMetricName = "sample invalid metric name: %.200q"
+	errInvalidLabel      = "sample invalid label: %.200q metric %.200q"
+	errLabelNameTooLong  = "label name too long: %.200q metric %.200q"
+	errLabelValueTooLong = "label value too long: %.200q metric %.200q"
 	errTooManyLabels     = "sample for '%s' has %d label names; limit %d"
 )
 
@@ -54,13 +54,13 @@ func ValidateSample(s *model.Sample, config *ValidateConfig) error {
 
 	for k, v := range s.Metric {
 		if !k.IsValid() {
-			return httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, k)
+			return httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, k, metricName)
 		}
 		if len(k) > config.MaxLabelNameLength {
-			return httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, k)
+			return httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, k, metricName)
 		}
 		if len(v) > config.MaxLabelValueLength {
-			return httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, v)
+			return httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, v, metricName)
 		}
 	}
 	return nil

--- a/pkg/ingester/validate.go
+++ b/pkg/ingester/validate.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"net/http"
+	"time"
 
 	"flag"
 
@@ -16,6 +17,8 @@ const (
 	errLabelNameTooLong  = "label name too long: %.200q metric %.200q"
 	errLabelValueTooLong = "label value too long: %.200q metric %.200q"
 	errTooManyLabels     = "sample for '%s' has %d label names; limit %d"
+	errTooOld            = "sample for '%s' has timestamp too old: %v"
+	errTooNew            = "sample for '%s' has timestamp too new: %v"
 )
 
 // ValidateConfig has config for validation settings and options
@@ -26,6 +29,10 @@ type ValidateConfig struct {
 	MaxLabelValueLength int
 	// maximum number of label/value pairs timeseries.
 	MaxLabelNamesPerSeries int
+	// Config for rejecting old samples.
+	RejectOldSamples       bool
+	RejectOldSamplesMaxAge time.Duration
+	CreationGracePeriod    time.Duration
 }
 
 // RegisterFlags registers a set of command line flags for setting options regarding sample validation at ingestion time.
@@ -33,6 +40,8 @@ func (cfg *ValidateConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxLabelNameLength, "ingester.validation.max-length-label-name", 1024, "Maximum length accepted for label names")
 	f.IntVar(&cfg.MaxLabelValueLength, "ingester.validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
 	f.IntVar(&cfg.MaxLabelNamesPerSeries, "ingester.max-label-names-per-series", 20, "Maximum number of label names per series.")
+	f.BoolVar(&cfg.RejectOldSamples, "ingester.reject-old-samples", false, "Reject old samples.")
+	f.DurationVar(&cfg.RejectOldSamplesMaxAge, "ingester.reject-old-samples.max-age", 14*24*time.Hour, "Maximum accepted sample age before rejecting.")
 }
 
 // ValidateSample returns an err if the sample is invalid
@@ -44,6 +53,15 @@ func ValidateSample(s *model.Sample, config *ValidateConfig) error {
 
 	if !model.IsValidMetricName(metricName) {
 		return httpgrpc.Errorf(http.StatusBadRequest, errInvalidMetricName, metricName)
+	}
+
+	if config.RejectOldSamples && s.Timestamp < model.Now().Add(-config.RejectOldSamplesMaxAge) {
+		discardedSamples.WithLabelValues(greaterThanMaxSampleAge).Inc()
+		return httpgrpc.Errorf(http.StatusBadRequest, errTooOld, metricName, s.Timestamp)
+	}
+	if s.Timestamp > model.Now().Add(config.CreationGracePeriod) {
+		discardedSamples.WithLabelValues(tooFarInFuture).Inc()
+		return httpgrpc.Errorf(http.StatusBadRequest, errTooNew, metricName, s.Timestamp)
 	}
 
 	numLabelNames := len(s.Metric)

--- a/pkg/ingester/validate_test.go
+++ b/pkg/ingester/validate_test.go
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid", "foo ": "bar"},
-			httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, "foo "),
+			httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, "foo ", "valid"),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid"},
@@ -37,11 +37,11 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelName", "this_is_a_really_really_long_name_that_should_cause_an_error": "test_value_please_ignore"},
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, "this_is_a_really_really_long_name_that_should_cause_an_error"),
+			httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, "this_is_a_really_really_long_name_that_should_cause_an_error", "badLabelName"),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelValue", "much_shorter_name": "test_value_please_ignore_no_really_nothing_to_see_here"},
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, "test_value_please_ignore_no_really_nothing_to_see_here"),
+			httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, "test_value_please_ignore_no_really_nothing_to_see_here", "badLabelValue"),
 		},
 	} {
 		err := ValidateSample(&model.Sample{


### PR DESCRIPTION
Also make the error string a const for consistency and shorten it for readability