### PR TITLE
Erase references to flushed chunks so they can be garbage-collected

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -208,6 +208,9 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 
 	// now remove the chunks
 	userState.fpLocker.Lock(fp)
+	for i := 0; i < len(chunks); i++ {
+		series.chunkDescs[i] = nil // erase reference so the chunk can be garbage-collected
+	}
 	series.chunkDescs = series.chunkDescs[len(chunks):]
 	i.memoryChunks.Sub(float64(len(chunks)))
 	if len(series.chunkDescs) == 0 {


### PR DESCRIPTION
Go treats the whole underlying array as live, so chunks that are to the left of the start of the slice hang around in memory until the next time the slice is extended by allocating a new array.  Defeat this by zeroing the pointers.

I couldn't find a great reference for this behaviour, but it does match what I see in profiles: there are about 1.7 times as many memory blocks as there are chunks reported by the ingester.
Some less-great references:
http://grokbase.com/t/gg/golang-nuts/14a6c2z17b/go-nuts-unreachable-elements-in-slice-and-garbage-collection
https://stackoverflow.com/a/28432812/448734