### PR TITLE
Use sync.Map in ingester userStates

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -422,14 +422,14 @@ func (i *Ingester) query(ctx context.Context, from, through model.Time, matchers
 func (i *Ingester) LabelValues(ctx old_ctx.Context, req *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
-	resp := &client.LabelValuesResponse{}
 	state, ok, err := i.userStates.getViaContext(ctx)
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return resp, nil
+		return &client.LabelValuesResponse{}, nil
 	}
 
+	resp := &client.LabelValuesResponse{}
 	for _, v := range state.index.lookupLabelValues(model.LabelName(req.LabelName)) {
 		resp.LabelValues = append(resp.LabelValues, string(v))
 	}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -107,6 +107,15 @@ func (us *userStates) get(userID string) (*userState, bool) {
 	return state.(*userState), ok
 }
 
+func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("no user id")
+	}
+	state, ok := us.get(userID)
+	return state, ok, nil
+}
+
 func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric) (*userState, model.Fingerprint, *memorySeries, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -110,24 +110,6 @@ func (us *userStates) get(userID string) (*userState, bool) {
 	return state, ok
 }
 
-func (us *userStates) getOrCreate(ctx context.Context) (*userState, error) {
-	userID, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("no user id")
-	}
-
-	us.mtx.RLock()
-	state, ok := us.states[userID]
-	us.mtx.RUnlock()
-	if ok {
-		return state, nil
-	}
-
-	us.mtx.Lock()
-	defer us.mtx.Unlock()
-	return us.unlockedGetOrCreate(userID), nil
-}
-
 func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric) (*userState, model.Fingerprint, *memorySeries, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -54,7 +54,7 @@ func newUserStates(cfg *UserStatesConfig) *userStates {
 }
 
 func (us *userStates) cp() map[string]*userState {
-	states := make(map[string]*userState, us.numUsers())
+	states := map[string]*userState{}
 	us.states.Range(func(key, value interface{}) bool {
 		states[key.(string)] = value.(*userState)
 		return true


### PR DESCRIPTION
As suggested here: https://github.com/weaveworks/cortex/issues/858#issuecomment-401445831

Hoping this will give better concurrency than map+RWMutex.

The docs say:
> sync.Map is optimized for use [...] with keys that are stable over time

We will tend to have a steady set of users sending data, with lots of additions at startup and very few deletions.

The first commit is an extension in the same vein as #861; it is included here because it simplifies the changes needed for `sync.Map`.

I renamed `unlockedGet()` to `getSeries()` since we no longer have a lock; I confess I don't see why it was named that way anyway.