### PR TITLE
Start using the flag's default values in tests.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -87,11 +87,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.IngesterClientConfig.RegisterFlags(f)
 	cfg.PoolConfig.RegisterFlags(f)
 
-	flag.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
-	flag.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
-	flag.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
-	flag.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
-	flag.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
+	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
+	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
+	f.Float64Var(&cfg.IngestionRateLimit, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
+	f.IntVar(&cfg.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
+	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
 }
 
 // New constructs a new Distributor

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks/common/user"
 	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/ring"
+	"github.com/weaveworks/cortex/pkg/util"
 )
 
 var (
@@ -237,16 +238,14 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, shardByAllLabels bo
 		return ingestersByAddr[addr], nil
 	}
 
-	d, err := New(Config{
-		PoolConfig: client.PoolConfig{
-			RemoteTimeout:       1 * time.Minute,
-			ClientCleanupPeriod: 1 * time.Minute,
-		},
-		IngestionRateLimit:    20,
-		IngestionBurstSize:    20,
-		ingesterClientFactory: factory,
-		ShardByAllLabels:      shardByAllLabels,
-	}, ring)
+	var cfg Config
+	util.DefaultValues(&cfg)
+	cfg.IngestionRateLimit = 20
+	cfg.IngestionBurstSize = 20
+	cfg.ingesterClientFactory = factory
+	cfg.ShardByAllLabels = shardByAllLabels
+
+	d, err := New(cfg, ring)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -63,7 +63,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	}
 	// We have seen 20MB returns from queries - add a bit of headroom
 	f.IntVar(&cfg.MaxRecvMsgSize, "ingester.client.max-recv-message-size", 64*1024*1024, "Maximum message size, in bytes, this client will receive.")
-	flag.BoolVar(&cfg.CompressToIngester, "ingester.client.compress-to-ingester", false, "Compress data in calls to ingesters.")
+	f.BoolVar(&cfg.CompressToIngester, "ingester.client.compress-to-ingester", false, "Compress data in calls to ingesters.")
 	// moved from distributor pkg, but flag prefix left as back compat fallback for existing users.
-	flag.BoolVar(&cfg.legacyCompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters. (DEPRECATED: use ingester.client.compress-to-ingester instead")
+	f.BoolVar(&cfg.legacyCompressToIngester, "distributor.compress-to-ingester", false, "Compress data in calls to ingesters. (DEPRECATED: use ingester.client.compress-to-ingester instead")
 }

--- a/pkg/ingester/client/pool.go
+++ b/pkg/ingester/client/pool.go
@@ -28,8 +28,8 @@ type PoolConfig struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
 func (cfg *PoolConfig) RegisterFlags(f *flag.FlagSet) {
-	flag.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
-	flag.BoolVar(&cfg.HealthCheckIngesters, "distributor.health-check-ingesters", false, "Run a health check on each ingester client during periodic cleanup.")
+	f.DurationVar(&cfg.ClientCleanupPeriod, "distributor.client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
+	f.BoolVar(&cfg.HealthCheckIngesters, "distributor.health-check-ingesters", false, "Run a health check on each ingester client during periodic cleanup.")
 }
 
 // Pool holds a cache of grpc_health_v1 clients.

--- a/pkg/util/flags.go
+++ b/pkg/util/flags.go
@@ -22,6 +22,15 @@ func RegisterFlags(rs ...Registerer) {
 	}
 }
 
+// DefaultValues intiates a set of configs (Registerers) with their defaults.
+func DefaultValues(rs ...Registerer) {
+	fs := flag.NewFlagSet("", flag.PanicOnError)
+	for _, r := range rs {
+		r.RegisterFlags(fs)
+	}
+	fs.Parse([]string{})
+}
+
 // DayValue is a model.Time that can be used as a flag.
 // NB it only parses days!
 type DayValue struct {


### PR DESCRIPTION
Its quite brittle to have the test specify default config values; when you add a new config value in one package, some random test in another package could start failing.

Also helps weed out places where we've used `flag` instead of the passed `f`.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>