### PR TITLE
Use alpine:3.8 as a base image, install ca-certs.

### DIFF
--- a/cmd/alertmanager/Dockerfile
+++ b/cmd/alertmanager/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       alertmanager /bin/alertmanager
 RUN        apk add --no-cache ca-certificates
+COPY       alertmanager /bin/alertmanager
 EXPOSE     80
 ENTRYPOINT [ "/bin/alertmanager" ]
 

--- a/cmd/alertmanager/Dockerfile
+++ b/cmd/alertmanager/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       alertmanager /bin/alertmanager
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/alertmanager" ]
 

--- a/cmd/configs/Dockerfile
+++ b/cmd/configs/Dockerfile
@@ -1,7 +1,8 @@
-FROM       quay.io/prometheus/busybox:latest
-WORKDIR /
-COPY configs /bin/configs
-COPY migrations /migrations/
+FROM       alpine:3.8
+WORKDIR    /
+COPY       configs /bin/configs
+COPY       migrations /migrations/
+RUN        apk add --no-cache ca-certificates
 ENTRYPOINT [ "/bin/configs" ]
 
 ARG revision

--- a/cmd/configs/Dockerfile
+++ b/cmd/configs/Dockerfile
@@ -1,8 +1,8 @@
 FROM       alpine:3.8
 WORKDIR    /
+RUN        apk add --no-cache ca-certificates
 COPY       configs /bin/configs
 COPY       migrations /migrations/
-RUN        apk add --no-cache ca-certificates
 ENTRYPOINT [ "/bin/configs" ]
 
 ARG revision

--- a/cmd/distributor/Dockerfile
+++ b/cmd/distributor/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       distributor /bin/distributor
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/distributor" ]
 

--- a/cmd/distributor/Dockerfile
+++ b/cmd/distributor/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       distributor /bin/distributor
 RUN        apk add --no-cache ca-certificates
+COPY       distributor /bin/distributor
 EXPOSE     80
 ENTRYPOINT [ "/bin/distributor" ]
 

--- a/cmd/ingester/Dockerfile
+++ b/cmd/ingester/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       ingester /bin/ingester
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/ingester" ]
 

--- a/cmd/ingester/Dockerfile
+++ b/cmd/ingester/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       ingester /bin/ingester
 RUN        apk add --no-cache ca-certificates
+COPY       ingester /bin/ingester
 EXPOSE     80
 ENTRYPOINT [ "/bin/ingester" ]
 

--- a/cmd/lite/Dockerfile
+++ b/cmd/lite/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       lite /bin/cortex
 RUN        apk add --no-cache ca-certificates
+COPY       lite /bin/cortex
 EXPOSE     80
 ENTRYPOINT [ "/bin/cortex" ]
 

--- a/cmd/lite/Dockerfile
+++ b/cmd/lite/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       lite /bin/cortex
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/cortex" ]
 

--- a/cmd/querier/Dockerfile
+++ b/cmd/querier/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       querier /bin/querier
 RUN        apk add --no-cache ca-certificates
+COPY       querier /bin/querier
 EXPOSE     80
 ENTRYPOINT [ "/bin/querier" ]
 

--- a/cmd/querier/Dockerfile
+++ b/cmd/querier/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       querier /bin/querier
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/querier" ]
 

--- a/cmd/ruler/Dockerfile
+++ b/cmd/ruler/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       ruler /bin/ruler
+RUN        apk add --no-cache ca-certificates
 EXPOSE     80
 ENTRYPOINT [ "/bin/ruler" ]
 

--- a/cmd/ruler/Dockerfile
+++ b/cmd/ruler/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       ruler /bin/ruler
 RUN        apk add --no-cache ca-certificates
+COPY       ruler /bin/ruler
 EXPOSE     80
 ENTRYPOINT [ "/bin/ruler" ]
 

--- a/cmd/table-manager/Dockerfile
+++ b/cmd/table-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine:3.8
-COPY       table-manager /bin/table-manager
 RUN        apk add --no-cache ca-certificates
+COPY       table-manager /bin/table-manager
 EXPOSE     9094
 ENTRYPOINT [ "/bin/table-manager" ]
 

--- a/cmd/table-manager/Dockerfile
+++ b/cmd/table-manager/Dockerfile
@@ -1,5 +1,6 @@
-FROM       quay.io/prometheus/busybox:latest
+FROM       alpine:3.8
 COPY       table-manager /bin/table-manager
+RUN        apk add --no-cache ca-certificates
 EXPOSE     9094
 ENTRYPOINT [ "/bin/table-manager" ]
 


### PR DESCRIPTION
I needed to exec in and curl the queriers to test some timeouts, and this was hard with the busybox image.  Using alpine is much easier.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>