### PR TITLE
Only login to docker hub if you provide the secret

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,9 @@ jobs:
     - run:
         name: Deploy
         command: |
-          docker login -e "$DOCKER_REGISTRY_EMAIL" -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
+          if [ -n "$DOCKER_REGISTRY_PASSWORD" ]; then
+            docker login -e "$DOCKER_REGISTRY_EMAIL" -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
+          fi
           if [ -n "$QUAY_PASSWORD" ]; then
             docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io;
           fi


### PR DESCRIPTION
Only login to docker hub if a docker hub password is specified. This allows someone to only upload to quay if they want.