### PR TITLE
Log length of labels exceeding max length

### DIFF
--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -19,8 +19,8 @@ const (
 	errMissingMetricName = "sample missing metric name"
 	errInvalidMetricName = "sample invalid metric name: %.200q"
 	errInvalidLabel      = "sample invalid label: %.200q metric %.200q"
-	errLabelNameTooLong  = "label name too long: %.200q metric %.200q"
-	errLabelValueTooLong = "label value too long: %.200q metric %.200q"
+	errLabelNameTooLong  = "label name too long (%d): %.200q metric %.200q"
+	errLabelValueTooLong = "label value too long (%d): %.200q metric %.200q"
 	errTooManyLabels     = "sample for '%s' has %d label names; limit %d"
 	errTooOld            = "sample for '%s' has timestamp too old: %d"
 	errTooNew            = "sample for '%s' has timestamp too new: %d"
@@ -107,10 +107,10 @@ func (cfg *Config) ValidateLabels(ls []client.LabelPair) error {
 			return httpgrpc.Errorf(http.StatusBadRequest, errInvalidLabel, l.Name, metricName)
 		}
 		if len(l.Name) > cfg.MaxLabelNameLength {
-			return httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, l.Name, metricName)
+			return httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, len(l.Name), l.Name, metricName)
 		}
 		if len(l.Value) > cfg.MaxLabelValueLength {
-			return httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, l.Value, metricName)
+			return httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, len(l.Value), l.Value, metricName)
 		}
 	}
 	return nil

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -40,11 +40,11 @@ func TestValidateLabels(t *testing.T) {
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelName", "this_is_a_really_really_long_name_that_should_cause_an_error": "test_value_please_ignore"},
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, "this_is_a_really_really_long_name_that_should_cause_an_error", "badLabelName"),
+			httpgrpc.Errorf(http.StatusBadRequest, errLabelNameTooLong, 60, "this_is_a_really_really_long_name_that_should_cause_an_error", "badLabelName"),
 		},
 		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelValue", "much_shorter_name": "test_value_please_ignore_no_really_nothing_to_see_here"},
-			httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, "test_value_please_ignore_no_really_nothing_to_see_here", "badLabelValue"),
+			httpgrpc.Errorf(http.StatusBadRequest, errLabelValueTooLong, 54, "test_value_please_ignore_no_really_nothing_to_see_here", "badLabelValue"),
 		},
 	} {
 


### PR DESCRIPTION
This logs the actual length we encountered when validation of label
name or value fails due to it being too long.