### PR TITLE
 Record validation errors in metrics, not log lines

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/go-kit/kit/log/level"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -238,16 +237,14 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 			return nil, err
 		}
 
-		if err := d.cfg.validationConfig.ValidateLabels(ts.Labels); err != nil {
-			level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "error validating sample", "err", err)
+		if err := d.cfg.validationConfig.ValidateLabels(userID, ts.Labels); err != nil {
 			lastPartialErr = err
 			continue
 		}
 
 		metricName, _ := extract.MetricNameFromLabelPairs(ts.Labels)
 		for _, s := range ts.Samples {
-			if err := d.cfg.validationConfig.ValidateSample(metricName, s); err != nil {
-				level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "error validating sample", "err", err)
+			if err := d.cfg.validationConfig.ValidateSample(userID, metricName, s); err != nil {
 				lastPartialErr = err
 				continue
 			}

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -39,7 +39,7 @@ var DiscardedSamples = prometheus.NewCounterVec(
 		Name: "cortex_discarded_samples_total",
 		Help: "The total number of samples that were discarded.",
 	},
-	[]string{discardReasonLabel, "userID"},
+	[]string{discardReasonLabel, "user"},
 )
 
 func init() {

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestValidateLabels(t *testing.T) {
 	var cfg Config
+	userID := "testUser"
 	util.DefaultValues(&cfg)
 	cfg.MaxLabelValueLength = 25
 	cfg.MaxLabelNameLength = 25
@@ -48,7 +49,7 @@ func TestValidateLabels(t *testing.T) {
 		},
 	} {
 
-		err := cfg.ValidateLabels(client.ToLabelPairs(c.metric))
+		err := cfg.ValidateLabels(userID, client.ToLabelPairs(c.metric))
 		assert.Equal(t, c.err, err, "wrong error")
 	}
 }


### PR DESCRIPTION
When a customer configures things incorrectly they can swamp our service logs fairly easily if we log each time they send us bad data.

NB: adds the userID to a service-level metric

Related to #577, #849