### PR TITLE
Add the CNCF TOC presentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To learn more about Cortex, consult the following documents / talks:
 - [Original design document for Project Frankenstein](http://goo.gl/prdUYV)
 - PromCon 2016 Talk: "Project Frankenstein: Multitenant, Scale-Out Prometheus": [video](https://youtu.be/3Tb4Wc0kfCM), [slides](http://www.slideshare.net/weaveworks/project-frankenstein-a-multitenant-horizontally-scalable-prometheus-as-a-service)
 - KubeCon Prometheus Day talk "Weave Cortex: Multi-tenant, horizontally scalable Prometheus as a Service" [slides](http://www.slideshare.net/weaveworks/weave-cortex-multitenant-horizontally-scalable-prometheus-as-a-service)
+- CNCF TOC Presentation; "Horizontally Scalable, Multi-tenant Prometheus" [slides](https://docs.google.com/presentation/d/190oIFgujktVYxWZLhLYN4q8p9dtQYoe4sxHgn4deBSI/edit#slide=id.g3b8e2d6f7e_0_6)
 
 ## <a name="help"></a>Getting Help
 


### PR DESCRIPTION
Adds the CNCF TOC presentation for people to look at when learning about Cortex