### PR TITLE
Put the nginx pid in /tmp

### DIFF
--- a/k8s/nginx-config.yaml
+++ b/k8s/nginx-config.yaml
@@ -6,7 +6,7 @@ data:
   nginx.conf: |-
     worker_processes  5;  ## Default: 1
     error_log  /dev/stderr;
-    pid        nginx.pid;
+    pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
 
     events {


### PR DESCRIPTION
To fix this:

```
$ kubectl logs nginx-55b9f744d5-bhrtd
2018/08/02 10:37:04 [emerg] 1#1: open() "/etc/nginx/nginx.pid" failed (30: Read-only file system)
nginx: [emerg] open() "/etc/nginx/nginx.pid" failed (30: Read-only file system)
```

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>