### PR TITLE
Make series creation scale better with number of cores

### DIFF
--- a/pkg/ingester/index.go
+++ b/pkg/ingester/index.go
@@ -8,18 +8,29 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
+const indexShards = 32
+
 type invertedIndex struct {
+	shards []indexShard
+}
+
+type indexShard struct {
 	mtx sync.RWMutex
 	idx map[model.LabelName]map[model.LabelValue][]model.Fingerprint // entries are sorted in fp order?
 }
 
 func newInvertedIndex() *invertedIndex {
+	shards := make([]indexShard, indexShards)
+	for i := 0; i < indexShards; i++ {
+		shards[i].idx = map[model.LabelName]map[model.LabelValue][]model.Fingerprint{}
+	}
 	return &invertedIndex{
-		idx: map[model.LabelName]map[model.LabelValue][]model.Fingerprint{},
+		shards: shards,
 	}
 }
 
-func (i *invertedIndex) add(metric model.Metric, fp model.Fingerprint) {
+func (ii *invertedIndex) add(metric model.Metric, fp model.Fingerprint) {
+	i := &ii.shards[hashFP(fp)%indexShards]
 	i.mtx.Lock()
 	defer i.mtx.Unlock()
 
@@ -40,56 +51,73 @@ func (i *invertedIndex) add(metric model.Metric, fp model.Fingerprint) {
 	}
 }
 
-func (i *invertedIndex) lookup(matchers []*labels.Matcher) []model.Fingerprint {
+func (ii *invertedIndex) lookup(matchers []*labels.Matcher) []model.Fingerprint {
 	if len(matchers) == 0 {
 		return nil
 	}
-	i.mtx.RLock()
-	defer i.mtx.RUnlock()
 
-	// intersection is initially nil, which is a special case.
-	var intersection []model.Fingerprint
-	for _, matcher := range matchers {
-		values, ok := i.idx[model.LabelName(matcher.Name)]
-		if !ok {
-			return nil
-		}
-		var toIntersect []model.Fingerprint
-		if matcher.Type == labels.MatchEqual {
-			fps := values[model.LabelValue(matcher.Value)]
-			toIntersect = merge(toIntersect, fps)
-		} else {
-			for value, fps := range values {
-				if matcher.Matches(string(value)) {
-					toIntersect = merge(toIntersect, fps)
+	result := []model.Fingerprint{}
+
+outer:
+	for i := range ii.shards {
+		ii.shards[i].mtx.RLock()
+
+		// per-shard intersection is initially nil, which is a special case.
+		var intersection []model.Fingerprint
+		for _, matcher := range matchers {
+			values, ok := ii.shards[i].idx[model.LabelName(matcher.Name)]
+			if !ok {
+				continue outer
+			}
+			var toIntersect []model.Fingerprint
+			if matcher.Type == labels.MatchEqual {
+				fps := values[model.LabelValue(matcher.Value)]
+				toIntersect = merge(toIntersect, fps)
+			} else {
+				for value, fps := range values {
+					if matcher.Matches(string(value)) {
+						toIntersect = merge(toIntersect, fps)
+					}
 				}
 			}
+			intersection = intersect(intersection, toIntersect)
+			if len(intersection) == 0 {
+				continue outer
+			}
 		}
-		intersection = intersect(intersection, toIntersect)
-		if len(intersection) == 0 {
-			return nil
-		}
+
+		ii.shards[i].mtx.RUnlock()
+		result = append(result, intersection...)
 	}
 
-	return intersection
+	sort.Sort(fingerprints(result))
+	return result
 }
 
-func (i *invertedIndex) lookupLabelValues(name model.LabelName) model.LabelValues {
-	i.mtx.RLock()
-	defer i.mtx.RUnlock()
+func (ii *invertedIndex) lookupLabelValues(name model.LabelName) model.LabelValues {
+	results := make([]model.LabelValues, 0, indexShards)
 
-	values, ok := i.idx[name]
-	if !ok {
-		return nil
+	for i := range ii.shards {
+		ii.shards[i].mtx.RLock()
+		values, ok := ii.shards[i].idx[name]
+		if !ok {
+			continue
+		}
+		shardResult := make(model.LabelValues, 0, len(values))
+		for val := range values {
+			shardResult = append(shardResult, val)
+		}
+		ii.shards[i].mtx.RUnlock()
+
+		sort.Sort(labelValues(shardResult))
+		results = append(results, shardResult)
 	}
-	res := make(model.LabelValues, 0, len(values))
-	for val := range values {
-		res = append(res, val)
-	}
-	return res
+
+	return mergeLabelValueLists(results)
 }
 
-func (i *invertedIndex) delete(metric model.Metric, fp model.Fingerprint) {
+func (ii *invertedIndex) delete(metric model.Metric, fp model.Fingerprint) {
+	i := &ii.shards[hashFP(fp)%indexShards]
 	i.mtx.Lock()
 	defer i.mtx.Unlock()
 
@@ -146,6 +174,51 @@ func intersect(a, b []model.Fingerprint) []model.Fingerprint {
 // fingerprints between or within the input lists.
 func merge(a, b []model.Fingerprint) []model.Fingerprint {
 	result := make([]model.Fingerprint, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i] < b[j] {
+			result = append(result, a[i])
+			i++
+		} else {
+			result = append(result, b[j])
+			j++
+		}
+	}
+	result = append(result, a[i:]...)
+	result = append(result, b[j:]...)
+	return result
+}
+
+type labelValues model.LabelValues
+
+func (a labelValues) Len() int           { return len(a) }
+func (a labelValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a labelValues) Less(i, j int) bool { return a[i] < a[j] }
+
+type fingerprints []model.Fingerprint
+
+func (a fingerprints) Len() int           { return len(a) }
+func (a fingerprints) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a fingerprints) Less(i, j int) bool { return a[i] < a[j] }
+
+func mergeLabelValueLists(lvss []model.LabelValues) model.LabelValues {
+	switch len(lvss) {
+	case 0:
+		return nil
+	case 1:
+		return lvss[0]
+	case 2:
+		return mergeTwoLabelValueLists(lvss[0], lvss[1])
+	default:
+		n := len(lvss) / 2
+		left := mergeLabelValueLists(lvss[:n])
+		right := mergeLabelValueLists(lvss[n:])
+		return mergeTwoLabelValueLists(left, right)
+	}
+}
+
+func mergeTwoLabelValueLists(a, b model.LabelValues) model.LabelValues {
+	result := make(model.LabelValues, 0, len(a)+len(b))
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
 		if a[i] < b[j] {

--- a/pkg/ingester/series_map.go
+++ b/pkg/ingester/series_map.go
@@ -53,7 +53,7 @@ func (sm *seriesMap) get(fp model.Fingerprint) (*memorySeries, bool) {
 	return ms, ok
 }
 
-// put adds a mapping to the seriesMap. It panics if s == nil.
+// put adds a mapping to the seriesMap.
 func (sm *seriesMap) put(fp model.Fingerprint, s *memorySeries) {
 	shard := &sm.shards[hashFP(fp)%seriesMapShards]
 	shard.mtx.Lock()
@@ -70,9 +70,12 @@ func (sm *seriesMap) put(fp model.Fingerprint, s *memorySeries) {
 func (sm *seriesMap) del(fp model.Fingerprint) {
 	shard := &sm.shards[hashFP(fp)%seriesMapShards]
 	shard.mtx.Lock()
+	_, ok := shard.m[fp]
 	delete(shard.m, fp)
 	shard.mtx.Unlock()
-	atomic.AddInt32(&sm.size, -1)
+	if ok {
+		atomic.AddInt32(&sm.size, -1)
+	}
 }
 
 // iter returns a channel that produces all mappings in the seriesMap. The

--- a/vendor/github.com/segmentio/fasthash/.gitignore
+++ b/vendor/github.com/segmentio/fasthash/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Emacs
+*~

--- a/vendor/github.com/segmentio/fasthash/LICENSE
+++ b/vendor/github.com/segmentio/fasthash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/segmentio/fasthash/README.md
+++ b/vendor/github.com/segmentio/fasthash/README.md
@@ -1,0 +1,54 @@
+# fasthash [![CircleCI](https://circleci.com/gh/segmentio/fasthash.svg?style=shield)](https://circleci.com/gh/segmentio/fasthash) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/fasthash)](https://goreportcard.com/report/github.com/segmentio/fasthash) [![GoDoc](https://godoc.org/github.com/segmentio/fasthash?status.svg)](https://godoc.org/github.com/segmentio/fasthash)
+Go package porting the standard hashing algorithms to a more efficient implementation.
+
+## Motivations
+
+Go has great support for hashing algorithms in the standard library, but the
+APIs are all exposed as interfaces, which means passing strings or byte slices
+to those require dynamic memory allocations. Hashing a string typically requires
+2 allocations, one for the Hash value, and one to covert the string to a byte
+slice.
+
+This package attempts to solve this issue by exposing functions that implement
+string hashing algorithms and don't require dynamic memory alloations.
+
+## Testing
+
+To ensure consistency between the `fasthash` package and the standard library,
+all tests must be implemented to run against the standard hash functions and
+validate that both packages produced the same results.
+
+## Benchmarks
+
+The implementations also have to prove that they are more efficient in terms of
+CPU and memory usage than the functions found in the standard library.  
+Here's an example with fnv-1a:
+```
+BenchmarkHash64/standard_hash_function 20000000   105.0 ns/op   342.31 MB/s   56 B/op   2 allocs/op
+BenchmarkHash64/hash_function          50000000    38.6 ns/op   932.35 MB/s    0 B/op   0 allocs/op
+```
+
+# Usage Example: FNV-1a
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/segmentio/fasthash/fnv1a"
+)
+
+func main() {
+    // Hash a single string.
+    h1 := fnv1a.HashString64("Hello World!")
+    fmt.Println("FNV-1a hash of 'Hello World!':", h1)
+
+    // Incrementally compute a hash value from a sequence of strings.
+    h2 := fnv1a.Init64
+    h2 = fnv1a.AddString64(h2, "A")
+    h2 = fnv1a.AddString64(h2, "B")
+    h2 = fnv1a.AddString64(h2, "C")
+    fmt.Println("FNV-1a hash of 'ABC':", h2)
+}
+```

--- a/vendor/github.com/segmentio/fasthash/fasthash.go
+++ b/vendor/github.com/segmentio/fasthash/fasthash.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString64 makes a hashing function from the hashing algorithm returned by f.
+func HashString64(f func() hash.Hash64) func(string) uint64 {
+	return func(s string) uint64 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum64()
+	}
+}
+
+// HashUint64 makes a hashing function from the hashing algorithm return by f.
+func HashUint64(f func() hash.Hash64) func(uint64) uint64 {
+	return func(u uint64) uint64 {
+		b := [8]byte{}
+		binary.BigEndian.PutUint64(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum64()
+	}
+}

--- a/vendor/github.com/segmentio/fasthash/fasthash32.go
+++ b/vendor/github.com/segmentio/fasthash/fasthash32.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString32 makes a hashing function from the hashing algorithm returned by f.
+func HashString32(f func() hash.Hash32) func(string) uint32 {
+	return func(s string) uint32 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum32()
+	}
+}
+
+// HashUint32 makes a hashing function from the hashing algorithm return by f.
+func HashUint32(f func() hash.Hash32) func(uint32) uint32 {
+	return func(u uint32) uint32 {
+		b := [4]byte{}
+		binary.BigEndian.PutUint32(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum32()
+	}
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash.go
@@ -1,0 +1,71 @@
+package fnv1a
+
+const (
+	// FNV-1a
+	offset64 = uint64(14695981039346656037)
+	prime64  = uint64(1099511628211)
+
+	// Init64 is what 64 bits hash values should be initialized with.
+	Init64 = offset64
+)
+
+// HashString64 returns the hash of s.
+func HashString64(s string) uint64 {
+	return AddString64(Init64, s)
+}
+
+// HashUint64 returns the hash of u.
+func HashUint64(u uint64) uint64 {
+	return AddUint64(Init64, u)
+}
+
+// AddString64 adds the hash of s to the precomputed hash value h.
+func AddString64(h uint64, s string) uint64 {
+	/*
+		This is an unrolled version of this algorithm:
+
+		for _, c := range s {
+			h = (h ^ uint64(c)) * prime64
+		}
+
+		It seems to be ~1.5x faster than the simple loop in BenchmarkHash64:
+
+		- BenchmarkHash64/hash_function-4   30000000   56.1 ns/op   642.15 MB/s   0 B/op   0 allocs/op
+		- BenchmarkHash64/hash_function-4   50000000   38.6 ns/op   932.35 MB/s   0 B/op   0 allocs/op
+
+	*/
+
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h ^ uint64(s[i])) * prime64
+		h = (h ^ uint64(s[i+1])) * prime64
+		h = (h ^ uint64(s[i+2])) * prime64
+		h = (h ^ uint64(s[i+3])) * prime64
+		h = (h ^ uint64(s[i+4])) * prime64
+		h = (h ^ uint64(s[i+5])) * prime64
+		h = (h ^ uint64(s[i+6])) * prime64
+		h = (h ^ uint64(s[i+7])) * prime64
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h ^ uint64(c)) * prime64
+	}
+
+	return h
+}
+
+// AddUint64 adds the hash value of the 8 bytes of u to h.
+func AddUint64(h uint64, u uint64) uint64 {
+	h = (h ^ ((u >> 56) & 0xFF)) * prime64
+	h = (h ^ ((u >> 48) & 0xFF)) * prime64
+	h = (h ^ ((u >> 40) & 0xFF)) * prime64
+	h = (h ^ ((u >> 32) & 0xFF)) * prime64
+	h = (h ^ ((u >> 24) & 0xFF)) * prime64
+	h = (h ^ ((u >> 16) & 0xFF)) * prime64
+	h = (h ^ ((u >> 8) & 0xFF)) * prime64
+	h = (h ^ ((u >> 0) & 0xFF)) * prime64
+	return h
+}

--- a/vendor/github.com/segmentio/fasthash/fnv1a/hash32.go
+++ b/vendor/github.com/segmentio/fasthash/fnv1a/hash32.go
@@ -1,0 +1,53 @@
+package fnv1a
+
+const (
+	// FNV-1a
+	offset32 = uint32(2166136261)
+	prime32  = uint32(16777619)
+
+	// Init32 is what 32 bits hash values should be initialized with.
+	Init32 = offset32
+)
+
+// HashString32 returns the hash of s.
+func HashString32(s string) uint32 {
+	return AddString32(Init32, s)
+}
+
+// HashUint32 returns the hash of u.
+func HashUint32(u uint32) uint32 {
+	return AddUint32(Init32, u)
+}
+
+// AddString32 adds the hash of s to the precomputed hash value h.
+func AddString32(h uint32, s string) uint32 {
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h ^ uint32(s[i])) * prime32
+		h = (h ^ uint32(s[i+1])) * prime32
+		h = (h ^ uint32(s[i+2])) * prime32
+		h = (h ^ uint32(s[i+3])) * prime32
+		h = (h ^ uint32(s[i+4])) * prime32
+		h = (h ^ uint32(s[i+5])) * prime32
+		h = (h ^ uint32(s[i+6])) * prime32
+		h = (h ^ uint32(s[i+7])) * prime32
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h ^ uint32(c)) * prime32
+	}
+
+	return h
+}
+
+// AddUint32 adds the hash value of the 8 bytes of u to h.
+func AddUint32(h, u uint32) uint32 {
+	h = (h ^ ((u >> 24) & 0xFF)) * prime32
+	h = (h ^ ((u >> 16) & 0xFF)) * prime32
+	h = (h ^ ((u >> 8) & 0xFF)) * prime32
+	h = (h ^ ((u >> 0) & 0xFF)) * prime32
+	return h
+}


### PR DESCRIPTION
Adding a new user with ~15m series, saw the ingesters latency go through the roof.

Benchmarked series creation and saw it doesn't parallelise.   Made series creation scale better with number of cores (up to ~16 cores).

This is achieved by sharding many of the datastructures on the series creation path, such as the seriesMap, the inmemory index et

Graph of test run time vs parallelisation for 1 to 32 goroutines.  Test was run on a 32 vCPU-optimised droplet.

<img width="595" alt="screen shot 2018-08-08 at 15 56 34" src="https://user-images.githubusercontent.com/444037/43841627-e5765d8e-9b23-11e8-9a51-a15cb9833793.png">
