### PR TITLE
Protect ingester against very large queries.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -531,6 +531,7 @@ func (i *Ingester) Describe(ch chan<- *prometheus.Desc) {
 	ch <- i.chunkAge.Desc()
 	ch <- i.queries.Desc()
 	ch <- i.queriedSamples.Desc()
+	ch <- i.queriedSeries.Desc()
 	ch <- i.memoryChunks.Desc()
 }
 
@@ -576,5 +577,6 @@ func (i *Ingester) Collect(ch chan<- prometheus.Metric) {
 	ch <- i.chunkAge
 	ch <- i.queries
 	ch <- i.queriedSamples
+	ch <- i.queriedSeries
 	ch <- i.memoryChunks
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -141,8 +141,8 @@ type Ingester struct {
 	chunkLength         prometheus.Histogram
 	chunkAge            prometheus.Histogram
 	queries             prometheus.Counter
-	queriedSamples      prometheus.Counter
-	queriedSeries       prometheus.Counter
+	queriedSamples      prometheus.Histogram
+	queriedSeries       prometheus.Histogram
 	memoryChunks        prometheus.Gauge
 }
 
@@ -224,13 +224,15 @@ func New(cfg Config, chunkStore ChunkStore) (*Ingester, error) {
 			Name: "cortex_ingester_queries_total",
 			Help: "The total number of queries the ingester has handled.",
 		}),
-		queriedSamples: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingester_queried_samples_total",
-			Help: "The total number of samples returned from queries.",
+		queriedSamples: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_queried_samples",
+			Help:    "The total number of samples returned from queries.",
+			Buckets: prometheus.DefBuckets,
 		}),
-		queriedSeries: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingester_queried_series_total",
-			Help: "The total number of series returned from queries.",
+		queriedSeries: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingester_queried_series",
+			Help:    "The total number of series returned from queries.",
+			Buckets: prometheus.DefBuckets,
 		}),
 	}
 
@@ -405,8 +407,8 @@ func (i *Ingester) query(ctx context.Context, from, through model.Time, matchers
 
 		return nil
 	})
-	i.queriedSamples.Add(float64(queriedSamples))
-	i.queriedSeries.Add(float64(queriedSeries))
+	i.queriedSamples.Observe(float64(queriedSamples))
+	i.queriedSeries.Observe(float64(queriedSeries))
 	return result, err
 }
 

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -31,22 +31,17 @@ const (
 
 func defaultIngesterTestConfig() Config {
 	consul := ring.NewInMemoryKVClient()
-	return Config{
-		LifecyclerConfig: ring.LifecyclerConfig{
-			KVClient: consul,
-
-			NumTokens:       1,
-			HeartbeatPeriod: 5 * time.Second,
-			ListenPort:      func(i int) *int { return &i }(0),
-
-			Addr: "localhost",
-			ID:   "localhost",
-		},
-
-		FlushCheckPeriod:  99999 * time.Hour,
-		MaxChunkIdle:      99999 * time.Hour,
-		ConcurrentFlushes: 1,
-	}
+	cfg := Config{}
+	util.DefaultValues(&cfg)
+	cfg.FlushCheckPeriod = 99999 * time.Hour
+	cfg.MaxChunkIdle = 99999 * time.Hour
+	cfg.ConcurrentFlushes = 1
+	cfg.LifecyclerConfig.KVClient = consul
+	cfg.LifecyclerConfig.NumTokens = 1
+	cfg.LifecyclerConfig.ListenPort = func(i int) *int { return &i }(0)
+	cfg.LifecyclerConfig.Addr = "localhost"
+	cfg.LifecyclerConfig.ID = "localhost"
+	return cfg
 }
 
 // TestIngesterRestart tests a restarting ingester doesn't keep adding more tokens.


### PR DESCRIPTION
This is Conference Driven Development from #PromCon2018 :) 

We had an outage where a very large query took out the ingesters.  Quick patch protecting it.