### PR TITLE
Use global metrics for the ingester

### DIFF
--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/go-kit/kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // get gzip compressor registered
 
@@ -82,7 +81,6 @@ func main() {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
 	}
-	prometheus.MustRegister(ingester)
 	defer ingester.Shutdown()
 
 	client.RegisterIngesterServer(server.GRPC, ingester)

--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -105,7 +105,6 @@ func main() {
 		level.Error(util.Logger).Log("err", err)
 		os.Exit(1)
 	}
-	prometheus.MustRegister(ingester)
 	defer ingester.Shutdown()
 
 	tableClient, err := storage.NewTableClient(storageConfig)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -27,18 +27,9 @@ import (
 )
 
 const (
-	ingesterSubsystem = "ingester"
-
 	// Reasons to discard samples.
 	outOfOrderTimestamp = "timestamp_out_of_order"
 	duplicateSample     = "multiple_values_for_timestamp"
-
-	// DefaultConcurrentFlush is the number of series to flush concurrently
-	DefaultConcurrentFlush = 50
-	// DefaultMaxSeriesPerUser is the maximum number of series allowed per user.
-	DefaultMaxSeriesPerUser = 5000000
-	// DefaultMaxSeriesPerMetric is the maximum number of series in one metric (of a single user).
-	DefaultMaxSeriesPerMetric = 50000
 )
 
 var (
@@ -111,7 +102,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.FlushOpTimeout, "ingester.flush-op-timeout", 1*time.Minute, "Timeout for individual flush operations.")
 	f.DurationVar(&cfg.MaxChunkIdle, "ingester.max-chunk-idle", 5*time.Minute, "Maximum chunk idle time before flushing.")
 	f.DurationVar(&cfg.MaxChunkAge, "ingester.max-chunk-age", 12*time.Hour, "Maximum chunk age before flushing.")
-	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", DefaultConcurrentFlush, "Number of concurrent goroutines flushing to dynamodb.")
+	f.IntVar(&cfg.ConcurrentFlushes, "ingester.concurrent-flushes", 50, "Number of concurrent goroutines flushing to dynamodb.")
 	f.StringVar(&cfg.ChunkEncoding, "ingester.chunk-encoding", "1", "Encoding version to use for chunks.")
 	f.IntVar(&cfg.MaxSeriesPerQuery, "ingester.max-series-per-query", 10000, "The maximum number of series that a query can return.")
 	f.IntVar(&cfg.MaxSamplesPerQuery, "ingester.max-samples-per-query", 100000, "The maximum number of samples that a query can return.")
@@ -155,27 +146,6 @@ type ChunkStore interface {
 
 // New constructs a new Ingester.
 func New(cfg Config, chunkStore ChunkStore) (*Ingester, error) {
-	if cfg.FlushCheckPeriod == 0 {
-		cfg.FlushCheckPeriod = 1 * time.Minute
-	}
-	if cfg.MaxChunkIdle == 0 {
-		cfg.MaxChunkIdle = 1 * time.Hour
-	}
-	if cfg.ConcurrentFlushes <= 0 {
-		cfg.ConcurrentFlushes = DefaultConcurrentFlush
-	}
-	if cfg.ChunkEncoding == "" {
-		cfg.ChunkEncoding = "1"
-	}
-	if cfg.userStatesConfig.RateUpdatePeriod == 0 {
-		cfg.userStatesConfig.RateUpdatePeriod = 15 * time.Second
-	}
-	if cfg.userStatesConfig.MaxSeriesPerUser <= 0 {
-		cfg.userStatesConfig.MaxSeriesPerUser = DefaultMaxSeriesPerUser
-	}
-	if cfg.userStatesConfig.MaxSeriesPerMetric <= 0 {
-		cfg.userStatesConfig.MaxSeriesPerMetric = DefaultMaxSeriesPerMetric
-	}
 	if cfg.ingesterClientFactory == nil {
 		cfg.ingesterClientFactory = client.MakeIngesterClient
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -163,9 +163,7 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 
 func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
-	cfg.userStatesConfig = UserStatesConfig{
-		MaxSeriesPerUser: 1,
-	}
+	cfg.userStatesConfig.MaxSeriesPerUser = 1
 
 	_, ing := newTestStore(t, cfg)
 	defer ing.Shutdown()
@@ -232,9 +230,7 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 
 func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
-	cfg.userStatesConfig = UserStatesConfig{
-		MaxSeriesPerMetric: 1,
-	}
+	cfg.userStatesConfig.MaxSeriesPerMetric = 1
 
 	_, ing := newTestStore(t, cfg)
 	defer ing.Shutdown()

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -102,7 +102,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 			return err
 		}
 
-		i.memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
+		memoryChunks.Add(float64(len(series.chunkDescs) - prevNumChunks))
 		receivedChunks.Add(float64(len(descs)))
 	}
 

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -65,8 +65,8 @@ type UserStatesConfig struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *UserStatesConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.RateUpdatePeriod, "ingester.rate-update-period", 15*time.Second, "Period with which to update the per-user ingestion rates.")
-	f.IntVar(&cfg.MaxSeriesPerUser, "ingester.max-series-per-user", DefaultMaxSeriesPerUser, "Maximum number of active series per user.")
-	f.IntVar(&cfg.MaxSeriesPerMetric, "ingester.max-series-per-metric", DefaultMaxSeriesPerMetric, "Maximum number of active series per metric name.")
+	f.IntVar(&cfg.MaxSeriesPerUser, "ingester.max-series-per-user", 5000000, "Maximum number of active series per user.")
+	f.IntVar(&cfg.MaxSeriesPerMetric, "ingester.max-series-per-metric", 50000, "Maximum number of active series per metric name.")
 }
 
 func newUserStates(cfg *UserStatesConfig) *userStates {

--- a/pkg/util/priority_queue_test.go
+++ b/pkg/util/priority_queue_test.go
@@ -6,8 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
+
+var testLengthMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "test_length",
+	Help: "test",
+})
 
 type simpleItem int64
 
@@ -34,7 +40,7 @@ func (r richItem) Key() string {
 }
 
 func TestPriorityQueueBasic(t *testing.T) {
-	queue := NewPriorityQueue()
+	queue := NewPriorityQueue(testLengthMetric)
 	assert.Equal(t, 0, queue.Length(), "Expected length = 0")
 
 	queue.Enqueue(simpleItem(1))
@@ -49,7 +55,7 @@ func TestPriorityQueueBasic(t *testing.T) {
 }
 
 func TestPriorityQueuePriorities(t *testing.T) {
-	queue := NewPriorityQueue()
+	queue := NewPriorityQueue(testLengthMetric)
 	queue.Enqueue(simpleItem(1))
 	queue.Enqueue(simpleItem(2))
 
@@ -61,7 +67,7 @@ func TestPriorityQueuePriorities(t *testing.T) {
 }
 
 func TestPriorityQueuePriorities2(t *testing.T) {
-	queue := NewPriorityQueue()
+	queue := NewPriorityQueue(testLengthMetric)
 	queue.Enqueue(simpleItem(2))
 	queue.Enqueue(simpleItem(1))
 
@@ -73,7 +79,7 @@ func TestPriorityQueuePriorities2(t *testing.T) {
 }
 
 func TestPriorityQueueWait(t *testing.T) {
-	queue := NewPriorityQueue()
+	queue := NewPriorityQueue(testLengthMetric)
 
 	done := make(chan struct{})
 	go func() {


### PR DESCRIPTION
Also remove the initialisation of default config in `ingester.New`, as we're using `DefaultConfig` in the tests now.

Fixes #283