### PR TITLE
Run-time reloadable per-user overrides for the various limits in Cortex.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	rate_limited = "rate_limited"
+	rateLimited = "rate_limited"
 )
 
 var (
@@ -268,7 +268,7 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 	if !limiter.AllowN(time.Now(), numSamples) {
 		// Return a 4xx here to have the client discard the data and not retry. If a client
 		// is sending too much data consistently we will unlikely ever catch up otherwise.
-		validation.DiscardedSamples.WithLabelValues(rate_limited, userID).Add(float64(numSamples))
+		validation.DiscardedSamples.WithLabelValues(rateLimited, userID).Add(float64(numSamples))
 		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, "ingestion rate limit (%v) exceeded while adding %d samples", limiter.Limit(), numSamples)
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -238,17 +238,19 @@ func (d *Distributor) Push(ctx context.Context, req *client.WriteRequest) (*clie
 		}
 
 		metricName, _ := extract.MetricNameFromLabelPairs(ts.Labels)
+		samples := make([]client.Sample, 0, len(ts.Samples))
 		for _, s := range ts.Samples {
 			if err := d.limits.ValidateSample(userID, metricName, s); err != nil {
 				lastPartialErr = err
 				continue
 			}
+			samples = append(samples, s)
 		}
 
 		keys = append(keys, key)
 		sampleTrackers = append(sampleTrackers, sampleTracker{
 			labels:  ts.Labels,
-			samples: ts.Samples,
+			samples: samples,
 		})
 		numSamples += len(ts.Samples)
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -241,8 +241,8 @@ func prepare(t *testing.T, numIngesters, happyIngesters int, shardByAllLabels bo
 
 	var cfg Config
 	util.DefaultValues(&cfg)
-	cfg.IngestionRateLimit = 20
-	cfg.IngestionBurstSize = 20
+	cfg.limits.IngestionRate = 20
+	cfg.limits.IngestionBurstSize = 20
 	cfg.ingesterClientFactory = factory
 	cfg.ShardByAllLabels = shardByAllLabels
 
@@ -475,10 +475,10 @@ func TestDistributorValidation(t *testing.T) {
 			d := prepare(t, 3, 3, true)
 			defer d.Stop()
 
-			d.cfg.validationConfig.CreationGracePeriod = 2 * time.Hour
-			d.cfg.validationConfig.RejectOldSamples = true
-			d.cfg.validationConfig.RejectOldSamplesMaxAge = 24 * time.Hour
-			d.cfg.validationConfig.MaxLabelNamesPerSeries = 2
+			d.limits.Defaults.CreationGracePeriod = 2 * time.Hour
+			d.limits.Defaults.RejectOldSamples = true
+			d.limits.Defaults.RejectOldSamplesMaxAge = 24 * time.Hour
+			d.limits.Defaults.MaxLabelNamesPerSeries = 2
 
 			_, err := d.Push(ctx, client.ToWriteRequest(tc.samples))
 			require.Equal(t, tc.err, err)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -163,7 +163,7 @@ func TestIngesterAppendOutOfOrderAndDuplicate(t *testing.T) {
 
 func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
-	cfg.userStatesConfig.MaxSeriesPerUser = 1
+	cfg.limits.MaxSeriesPerUser = 1
 
 	_, ing := newTestStore(t, cfg)
 	defer ing.Shutdown()
@@ -230,7 +230,7 @@ func TestIngesterUserSeriesLimitExceeded(t *testing.T) {
 
 func TestIngesterMetricSeriesLimitExceeded(t *testing.T) {
 	cfg := defaultIngesterTestConfig()
-	cfg.userStatesConfig.MaxSeriesPerMetric = 1
+	cfg.limits.MaxSeriesPerMetric = 1
 
 	_, ing := newTestStore(t, cfg)
 	defer ing.Shutdown()

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -64,7 +64,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 		}
 	}()
 
-	userStates := newUserStates(&i.cfg.userStatesConfig)
+	userStates := newUserStates(i.limits, i.cfg)
 	fromIngesterID := ""
 
 	for {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -48,7 +48,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxSeriesPerMetric, "ingester.max-series-per-metric", 50000, "Maximum number of active series per metric name.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides.")
-	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Minute, "Period with this to reload the overrides.")
+	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Second, "Period with this to reload the overrides.")
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1,0 +1,62 @@
+package validation
+
+import (
+	"flag"
+	"time"
+
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+// Limits describe all the limits for users; can be used to describe global default
+// limits via flags, or per-user limits via yaml config.
+type Limits struct {
+	// Distributor enforced limits.
+	IngestionRate          float64       `yaml:"ingestion_rate"`
+	IngestionBurstSize     int           `yaml:"ingestion_burst_size"`
+	MaxLabelNameLength     int           `yaml:"max_label_name_length"`
+	MaxLabelValueLength    int           `yaml:"max_label_value_length"`
+	MaxLabelNamesPerSeries int           `yaml:"max_label_names_per_series"`
+	RejectOldSamples       bool          `yaml:"reject_old_samples"`
+	RejectOldSamplesMaxAge time.Duration `yaml:"reject_old_samples_max_age"`
+	CreationGracePeriod    time.Duration `yaml:"creation_grace_period"`
+
+	// Ingester enforces limits.
+	MaxSeriesPerQuery  int `yaml:"max_series_per_query"`
+	MaxSamplesPerQuery int `yaml:"max_samples_per_query"`
+	MaxSeriesPerUser   int `yaml:"max_series_per_user"`
+	MaxSeriesPerMetric int `yaml:"max_series_per_metric"`
+
+	// Config for overrides, convenient if it goes here.
+	PerTenantOverrideConfig string
+	PerTenantOverridePeriod time.Duration
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (l *Limits) RegisterFlags(f *flag.FlagSet) {
+	f.Float64Var(&l.IngestionRate, "distributor.ingestion-rate-limit", 25000, "Per-user ingestion rate limit in samples per second.")
+	f.IntVar(&l.IngestionBurstSize, "distributor.ingestion-burst-size", 50000, "Per-user allowed ingestion burst size (in number of samples).")
+	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names")
+	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name")
+	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
+	f.BoolVar(&l.RejectOldSamples, "validation.reject-old-samples", false, "Reject old samples.")
+	f.DurationVar(&l.RejectOldSamplesMaxAge, "validation.reject-old-samples.max-age", 14*24*time.Hour, "Maximum accepted sample age before rejecting.")
+	f.DurationVar(&l.CreationGracePeriod, "validation.create-grace-period", 10*time.Minute, "Duration which table will be created/deleted before/after it's needed; we won't accept sample from before this time.")
+
+	f.IntVar(&l.MaxSeriesPerQuery, "ingester.max-series-per-query", 10000, "The maximum number of series that a query can return.")
+	f.IntVar(&l.MaxSamplesPerQuery, "ingester.max-samples-per-query", 100000, "The maximum number of samples that a query can return.")
+	f.IntVar(&l.MaxSeriesPerUser, "ingester.max-series-per-user", 5000000, "Maximum number of active series per user.")
+	f.IntVar(&l.MaxSeriesPerMetric, "ingester.max-series-per-metric", 50000, "Maximum number of active series per metric name.")
+
+	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "File name of per-user overrides.")
+	f.DurationVar(&l.PerTenantOverridePeriod, "limits.per-user-override-period", 10*time.Minute, "Period with this to reload the overrides.")
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// We want to set c to the defaults and then overwrite it with the input.
+	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
+	// again, we have to hide it using a type indirection.  See prometheus/config.
+	util.DefaultValues(l)
+	type plain Limits
+	return unmarshal((*plain)(l))
+}

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -30,6 +30,7 @@ type Overrides struct {
 // NewOverrides makes a new Overrides.
 func NewOverrides(defaults Limits) (*Overrides, error) {
 	if defaults.PerTenantOverrideConfig == "" {
+		level.Info(util.Logger).Log("msg", "per-tenant overides disabled")
 		return &Overrides{
 			Defaults:  defaults,
 			overrides: map[string]Limits{},
@@ -53,7 +54,7 @@ func NewOverrides(defaults Limits) (*Overrides, error) {
 }
 
 func (o *Overrides) loop() {
-	ticker := time.NewTimer(o.Defaults.PerTenantOverridePeriod)
+	ticker := time.NewTicker(o.Defaults.PerTenantOverridePeriod)
 	defer ticker.Stop()
 
 	for {
@@ -62,7 +63,7 @@ func (o *Overrides) loop() {
 			overrides, err := loadOverrides(o.Defaults.PerTenantOverrideConfig)
 			if err != nil {
 				overridesReloadSuccess.Set(0)
-				level.Error(util.Logger).Log("msg", "failed to reload overrrides", "err", err)
+				level.Error(util.Logger).Log("msg", "failed to reload overrides", "err", err)
 				continue
 			}
 			overridesReloadSuccess.Set(1)

--- a/pkg/util/validation/override.go
+++ b/pkg/util/validation/override.go
@@ -1,0 +1,228 @@
+package validation
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+var overridesReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "cortex_overrides_last_reload_successful",
+	Help: "Whether the last overrides reload attempt was successful.",
+})
+
+// Overrides periodically fetch a set of per-user overrides, and provides convenience
+// functions for fetching the correct value.
+type Overrides struct {
+	Defaults     Limits
+	overridesMtx sync.RWMutex
+	overrides    map[string]Limits
+	quit         chan struct{}
+}
+
+// NewOverrides makes a new Overrides.
+func NewOverrides(defaults Limits) (*Overrides, error) {
+	if defaults.PerTenantOverrideConfig == "" {
+		return &Overrides{
+			Defaults:  defaults,
+			overrides: map[string]Limits{},
+			quit:      make(chan struct{}),
+		}, nil
+	}
+
+	overrides, err := loadOverrides(defaults.PerTenantOverrideConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	o := &Overrides{
+		Defaults:  defaults,
+		overrides: overrides,
+		quit:      make(chan struct{}),
+	}
+
+	go o.loop()
+	return o, nil
+}
+
+func (o *Overrides) loop() {
+	ticker := time.NewTimer(o.Defaults.PerTenantOverridePeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			overrides, err := loadOverrides(o.Defaults.PerTenantOverrideConfig)
+			if err != nil {
+				overridesReloadSuccess.Set(0)
+				level.Error(util.Logger).Log("msg", "failed to reload overrrides", "err", err)
+				continue
+			}
+			overridesReloadSuccess.Set(1)
+
+			o.overridesMtx.Lock()
+			o.overrides = overrides
+			o.overridesMtx.Unlock()
+		case <-o.quit:
+			return
+		}
+	}
+}
+
+// Stop background reloading of overrides.
+func (o *Overrides) Stop() {
+	close(o.quit)
+}
+
+func loadOverrides(filename string) (map[string]Limits, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var overrides struct {
+		Overrides map[string]Limits `yaml:"overrides"`
+	}
+
+	decoder := yaml.NewDecoder(f)
+	decoder.SetStrict(true)
+	if err := decoder.Decode(&overrides); err != nil {
+		return nil, err
+	}
+
+	return overrides.Overrides, nil
+}
+
+func (o *Overrides) getBool(userID string, f func(*Limits) bool) bool {
+	o.overridesMtx.RLock()
+	defer o.overridesMtx.RUnlock()
+	override, ok := o.overrides[userID]
+	if !ok {
+		return f(&o.Defaults)
+	}
+	return f(&override)
+}
+
+func (o *Overrides) getInt(userID string, f func(*Limits) int) int {
+	o.overridesMtx.RLock()
+	defer o.overridesMtx.RUnlock()
+	override, ok := o.overrides[userID]
+	if !ok {
+		return f(&o.Defaults)
+	}
+	return f(&override)
+}
+
+func (o *Overrides) getFloat(userID string, f func(*Limits) float64) float64 {
+	o.overridesMtx.RLock()
+	defer o.overridesMtx.RUnlock()
+	override, ok := o.overrides[userID]
+	if !ok {
+		return f(&o.Defaults)
+	}
+	return f(&override)
+}
+
+func (o *Overrides) getDuration(userID string, f func(*Limits) time.Duration) time.Duration {
+	o.overridesMtx.RLock()
+	defer o.overridesMtx.RUnlock()
+	override, ok := o.overrides[userID]
+	if !ok {
+		return f(&o.Defaults)
+	}
+	return f(&override)
+}
+
+// IngestionRate returns the limit on ingester rate (samples per second).
+func (o *Overrides) IngestionRate(userID string) float64 {
+	return o.getFloat(userID, func(l *Limits) float64 {
+		return l.IngestionRate
+	})
+}
+
+// IngestionBurstSize returns the burst size for ingestion rate.
+func (o *Overrides) IngestionBurstSize(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.IngestionBurstSize
+	})
+}
+
+// MaxLabelNameLength returns maximum length a label name can be.
+func (o *Overrides) MaxLabelNameLength(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxLabelNameLength
+	})
+}
+
+// MaxLabelValueLength returns maximum length a label value can be. This also is
+// the maximum length of a metric name.
+func (o *Overrides) MaxLabelValueLength(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxLabelValueLength
+	})
+}
+
+// MaxLabelNamesPerSeries returns maximum number of label/value pairs timeseries.
+func (o *Overrides) MaxLabelNamesPerSeries(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxLabelNamesPerSeries
+	})
+}
+
+// RejectOldSamples returns true when we should reject samples older than certain
+// age.
+func (o *Overrides) RejectOldSamples(userID string) bool {
+	return o.getBool(userID, func(l *Limits) bool {
+		return l.RejectOldSamples
+	})
+}
+
+// RejectOldSamplesMaxAge returns the age at which samples should be rejected.
+func (o *Overrides) RejectOldSamplesMaxAge(userID string) time.Duration {
+	return o.getDuration(userID, func(l *Limits) time.Duration {
+		return l.RejectOldSamplesMaxAge
+	})
+}
+
+// CreationGracePeriod is misnamed, and actually returns how far into the future
+// we should accept samples.
+func (o *Overrides) CreationGracePeriod(userID string) time.Duration {
+	return o.getDuration(userID, func(l *Limits) time.Duration {
+		return l.CreationGracePeriod
+	})
+}
+
+// MaxSeriesPerQuery returns the maximum number of series a query is allowed to hit.
+func (o *Overrides) MaxSeriesPerQuery(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxSeriesPerQuery
+	})
+}
+
+// MaxSamplesPerQuery returns the maximum number of samples in a query (from the ingester).
+func (o *Overrides) MaxSamplesPerQuery(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxSamplesPerQuery
+	})
+}
+
+// MaxSeriesPerUser returns the maximum number of series a user is allowed to store.
+func (o *Overrides) MaxSeriesPerUser(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxSeriesPerUser
+	})
+}
+
+// MaxSeriesPerMetric returns the maximum number of series allowed per metric.
+func (o *Overrides) MaxSeriesPerMetric(userID string) int {
+	return o.getInt(userID, func(l *Limits) int {
+		return l.MaxSeriesPerMetric
+	})
+}

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -6,18 +6,22 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
 func TestValidateLabels(t *testing.T) {
-	var cfg Config
+	var cfg Limits
 	userID := "testUser"
 	util.DefaultValues(&cfg)
 	cfg.MaxLabelValueLength = 25
 	cfg.MaxLabelNameLength = 25
 	cfg.MaxLabelNamesPerSeries = 64
+	overrides, err := NewOverrides(cfg)
+	require.NoError(t, err)
 
 	for _, c := range []struct {
 		metric model.Metric
@@ -49,7 +53,7 @@ func TestValidateLabels(t *testing.T) {
 		},
 	} {
 
-		err := cfg.ValidateLabels(userID, client.ToLabelPairs(c.metric))
+		err := overrides.ValidateLabels(userID, client.ToLabelPairs(c.metric))
 		assert.Equal(t, c.err, err, "wrong error")
 	}
 }


### PR DESCRIPTION
This allows us to set relatively low default limits for most users, and then on a per-case basic raise them for individual users.  This allows us to run a more tightly-provisioned cluster without fear a single user will 10x their load and bring the cluster down.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>