### PR TITLE
Stream chunks from ingester to querier on queries.

### DIFF
--- a/cmd/lite/main.go
+++ b/cmd/lite/main.go
@@ -121,7 +121,7 @@ func main() {
 	tableManager.Start()
 	defer tableManager.Stop()
 
-	queryable, engine := querier.Make(querierConfig, dist, chunkStore)
+	queryable, engine := querier.New(querierConfig, dist, chunkStore)
 
 	if configStoreConfig.ConfigsAPIURL.String() != "" || configStoreConfig.DBConfig.URI != "" {
 		rulesAPI, err := ruler.NewRulesAPI(configStoreConfig)

--- a/cmd/querier/main.go
+++ b/cmd/querier/main.go
@@ -97,7 +97,7 @@ func main() {
 	}
 	defer worker.Stop()
 
-	queryable, engine := querier.Make(querierConfig, dist, chunkStore)
+	queryable, engine := querier.New(querierConfig, dist, chunkStore)
 	api := v1.NewAPI(
 		engine,
 		queryable,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -448,8 +448,6 @@ func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest
 		}
 
 		chunk := client.Chunk{
-			//StartTimestampMs: int64(),
-			//EndTimestampMs:   int64(d.LastTime),
 			Encoding: int32(c.Encoding()),
 			Data:     make([]byte, chunk.ChunkLen, chunk.ChunkLen),
 		}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -473,6 +473,10 @@ type stream struct {
 	results []*client.QueryStreamResponse
 }
 
+func (*stream) CloseSend() error {
+	return nil
+}
+
 func (s *stream) Recv() (*client.QueryStreamResponse, error) {
 	if s.i >= len(s.results) {
 		return nil, io.EOF

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -205,10 +205,10 @@ func TestDistributorPushQuery(t *testing.T) {
 			assert.Equal(t, tc.expectedResponse, response)
 			assert.Equal(t, tc.expectedError, err)
 
-			streams, err := d.QueryStream(ctx, 0, 10, tc.matchers...)
+			series, err := d.QueryStream(ctx, 0, 10, tc.matchers...)
 			assert.Equal(t, tc.expectedError, err)
 
-			response, err = chunkcompat.StreamsToMatrix(0, 10, streams)
+			response, err = chunkcompat.SeriesChunksToMatrix(0, 10, series)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResponse.String(), response.String())
 		})
@@ -458,8 +458,12 @@ func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest
 		}
 
 		results = append(results, &client.QueryStreamResponse{
-			Labels: ts.Labels,
-			Chunks: []client.Chunk{chunk},
+			Timeseries: []client.TimeSeriesChunk{
+				{
+					Labels: ts.Labels,
+					Chunks: []client.Chunk{chunk},
+				},
+			},
 		})
 	}
 	return &stream{

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -1,0 +1,186 @@
+package distributor
+
+import (
+	"context"
+	"io"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+
+	"github.com/weaveworks/common/instrument"
+	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+	ingester_client "github.com/weaveworks/cortex/pkg/ingester/client"
+	"github.com/weaveworks/cortex/pkg/ring"
+	"github.com/weaveworks/cortex/pkg/util"
+	"github.com/weaveworks/cortex/pkg/util/extract"
+)
+
+// Query multiple ingesters and returns a Matrix of samples.
+func (d *Distributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
+	var matrix model.Matrix
+	err := instrument.TimeRequestHistogram(ctx, "Distributor.Query", queryDuration, func(ctx context.Context) error {
+		replicationSet, req, err := d.queryPrep(ctx, from, to, matchers...)
+		if err != nil {
+			return promql.ErrStorage(err)
+		}
+
+		matrix, err = d.queryIngesters(ctx, replicationSet, req)
+		if err != nil {
+			return promql.ErrStorage(err)
+		}
+		return nil
+	})
+	return matrix, err
+}
+
+// QueryStream multiple ingesters via the streaming interface and returns big ol' set of chunks.
+func (d *Distributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error) {
+	var result []*client.QueryStreamResponse
+	err := instrument.TimeRequestHistogram(ctx, "Distributor.Query", queryDuration, func(ctx context.Context) error {
+		replicationSet, req, err := d.queryPrep(ctx, from, to, matchers...)
+		if err != nil {
+			return promql.ErrStorage(err)
+		}
+
+		result, err = d.queryIngesterStream(ctx, replicationSet, req)
+		if err != nil {
+			return promql.ErrStorage(err)
+		}
+		return nil
+	})
+	return result, err
+}
+
+func (d *Distributor) queryPrep(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (ring.ReplicationSet, *client.QueryRequest, error) {
+	var replicationSet ring.ReplicationSet
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return replicationSet, nil, err
+	}
+
+	req, err := ingester_client.ToQueryRequest(from, to, matchers)
+	if err != nil {
+		return replicationSet, nil, err
+	}
+
+	// Get ingesters by metricName if one exists, otherwise get all ingesters
+	metricNameMatcher, _, ok := extract.MetricNameMatcherFromMatchers(matchers)
+	if !d.cfg.ShardByAllLabels && ok && metricNameMatcher.Type == labels.MatchEqual {
+		replicationSet, err = d.ring.Get(shardByMetricName(userID, []byte(metricNameMatcher.Value)), ring.Read)
+	} else {
+		replicationSet, err = d.ring.GetAll()
+	}
+	return replicationSet, req, err
+}
+
+// queryIngesters queries the ingesters via the older, sample-based API.
+func (d *Distributor) queryIngesters(ctx context.Context, replicationSet ring.ReplicationSet, req *client.QueryRequest) (model.Matrix, error) {
+	// Fetch samples from multiple ingesters in parallel, using the replicationSet
+	// to deal with consistency.
+	results, err := replicationSet.Do(ctx, func(ing *ring.IngesterDesc) (interface{}, error) {
+		client, err := d.ingesterPool.GetClientFor(ing.Addr)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.(ingester_client.IngesterClient).Query(ctx, req)
+		ingesterQueries.WithLabelValues(ing.Addr).Inc()
+		if err != nil {
+			ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
+			return nil, err
+		}
+
+		return ingester_client.FromQueryResponse(resp), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge the results into a single matrix.
+	fpToSampleStream := map[model.Fingerprint]*model.SampleStream{}
+	for _, result := range results {
+		for _, ss := range result.(model.Matrix) {
+			fp := ss.Metric.Fingerprint()
+			mss, ok := fpToSampleStream[fp]
+			if !ok {
+				mss = &model.SampleStream{
+					Metric: ss.Metric,
+				}
+				fpToSampleStream[fp] = mss
+			}
+			mss.Values = util.MergeSampleSets(mss.Values, ss.Values)
+		}
+	}
+	result := model.Matrix{}
+	for _, ss := range fpToSampleStream {
+		result = append(result, ss)
+	}
+
+	return result, nil
+}
+
+// queryIngesterStream queries the ingesters using the new streaming API.
+func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ring.ReplicationSet, req *client.QueryRequest) ([]*client.QueryStreamResponse, error) {
+	userID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch samples from multiple ingesters
+	results, err := replicationSet.Do(ctx, func(ing *ring.IngesterDesc) (interface{}, error) {
+		client, err := d.ingesterPool.GetClientFor(ing.Addr)
+		if err != nil {
+			return nil, err
+		}
+
+		stream, err := client.(ingester_client.IngesterClient).QueryStream(ctx, req)
+		ingesterQueries.WithLabelValues(ing.Addr).Inc()
+		if err != nil {
+			ingesterQueryFailures.WithLabelValues(ing.Addr).Inc()
+			return nil, err
+		}
+
+		var result []*ingester_client.QueryStreamResponse
+		for {
+			series, err := stream.Recv()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			result = append(result, series)
+		}
+		return result, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	hashToSeries := map[uint32]*ingester_client.QueryStreamResponse{}
+	for _, result := range results {
+		for i := range result.([]*ingester_client.QueryStreamResponse) {
+			response := result.([]*ingester_client.QueryStreamResponse)[i]
+
+			hash, err := shardByAllLabels(userID, response.Labels)
+			if err != nil {
+				return nil, err
+			}
+
+			series, ok := hashToSeries[hash]
+			if !ok {
+				hashToSeries[hash] = response
+				continue
+			}
+
+			series.Chunks = append(series.Chunks, response.Chunks...)
+		}
+	}
+	result := make([]*client.QueryStreamResponse, 0, len(hashToSeries))
+	for _, series := range hashToSeries {
+		result = append(result, series)
+	}
+
+	return result, nil
+}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -173,14 +173,3 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 	return result, nil
 }
-
-func fromLabelPairs(in []client.LabelPair) labels.Labels {
-	out := make(labels.Labels, 0, len(in))
-	for _, pair := range in {
-		out = append(out, labels.Label{
-			Name:  string(pair.Name),
-			Value: string(pair.Value),
-		})
-	}
-	return out
-}

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -38,6 +38,7 @@ func MakeIngesterClient(addr string, cfg Config) (IngesterClient, error) {
 		)),
 		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(
 			otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer()),
+			middleware.StreamClientUserHeaderInterceptor,
 			cortex_middleware.PrometheusGRPCStreamInstrumentation(ingesterClientRequestDuration),
 		)),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cfg.MaxRecvMsgSize)),

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -232,3 +232,15 @@ func FromLabelPairs(labelPairs []LabelPair) model.Metric {
 	}
 	return metric
 }
+
+// FromLabelPairsToLabels unpack a []LabelPair to a labels.Labels
+func FromLabelPairsToLabels(labelPairs []LabelPair) labels.Labels {
+	ls := make(labels.Labels, 0, len(labelPairs))
+	for _, l := range labelPairs {
+		ls = append(ls, labels.Label{
+			Name:  string(l.Name),
+			Value: string(l.Value),
+		})
+	}
+	return ls
+}

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -13,6 +13,8 @@ option (gogoproto.unmarshaler_all) = true;
 service Ingester {
   rpc Push(WriteRequest) returns (WriteResponse) {};
   rpc Query(QueryRequest) returns (QueryResponse) {};
+  rpc QueryStream(QueryRequest) returns (stream QueryStreamResponse) {};
+
   rpc LabelValues(LabelValuesRequest) returns (LabelValuesResponse) {};
   rpc UserStats(UserStatsRequest) returns (UserStatsResponse) {};
   rpc AllUserStats(UserStatsRequest) returns (UsersStatsResponse) {};
@@ -50,6 +52,13 @@ message QueryRequest {
 
 message QueryResponse {
   repeated TimeSeries timeseries = 1 [(gogoproto.nullable) = false];
+}
+
+
+// QueryStreamResponse represents all the chunks for a given timeseries.
+message QueryStreamResponse {
+  repeated LabelPair labels = 1 [(gogoproto.nullable) = false];
+  repeated Chunk chunks = 2 [(gogoproto.nullable) = false];
 }
 
 message LabelValuesRequest {

--- a/pkg/ingester/client/cortex.proto
+++ b/pkg/ingester/client/cortex.proto
@@ -54,11 +54,9 @@ message QueryResponse {
   repeated TimeSeries timeseries = 1 [(gogoproto.nullable) = false];
 }
 
-
-// QueryStreamResponse represents all the chunks for a given timeseries.
+// QueryStreamResponse contains a batch of timeseries chunks.
 message QueryStreamResponse {
-  repeated LabelPair labels = 1 [(gogoproto.nullable) = false];
-  repeated Chunk chunks = 2 [(gogoproto.nullable) = false];
+  repeated TimeSeriesChunk timeseries = 1 [(gogoproto.nullable) = false];
 }
 
 message LabelValuesRequest {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -419,7 +419,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	if len(batch) >= queryStreamBatchSize {
+	if len(batch) > 0 {
 		err = stream.Send(&client.QueryStreamResponse{
 			Timeseries: batch,
 		})

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -383,7 +383,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 	numSeries, numChunks := 0, 0
 	batch := make([]client.TimeSeriesChunk, 0, queryStreamBatchSize)
-	// We'd really like to series series in label order, not FP order, so we
+	// We'd really like to have series in label order, not FP order, so we
 	// can iteratively merge them with entries coming from the chunk store.  But
 	// that would involve locking all the series & sorting, so until we have
 	// a better solution in the ingesters I'd rather take the hit in the queriers.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -62,8 +62,9 @@ var (
 		Buckets: prometheus.ExponentialBuckets(10, 8, 8),
 	})
 	queriedChunks = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "cortex_ingester_queried_chunks",
-		Help:    "The total number of chunks returned from queries.",
+		Name: "cortex_ingester_queried_chunks",
+		Help: "The total number of chunks returned from queries.",
+		// A small number of chunks per series - 10*(4^8) = 655k.
 		Buckets: prometheus.DefBuckets,
 	})
 )

--- a/pkg/querier/chunk_queryable.go
+++ b/pkg/querier/chunk_queryable.go
@@ -16,13 +16,7 @@ type ChunkStore interface {
 }
 
 // NewQueryable creates a new Queryable for cortex.
-func NewQueryable(distributor Distributor, chunkStore ChunkStore, iterators bool) storage.Queryable {
-	dq := newDistributorQueryable(distributor)
-	cq := newChunkQueryable(chunkStore)
-	if iterators {
-		cq = newIterChunkQueryable(newChunkMergeIterator)(chunkStore)
-	}
-
+func NewQueryable(dq, cq storage.Queryable, distributor Distributor) storage.Queryable {
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		dqr, err := dq.Querier(ctx, mint, maxt)
 		if err != nil {

--- a/pkg/querier/config.go
+++ b/pkg/querier/config.go
@@ -13,9 +13,10 @@ import (
 
 // Config contains the configuration require to create a querier
 type Config struct {
-	MaxConcurrent int
-	Timeout       time.Duration
-	Iterators     bool
+	MaxConcurrent     int
+	Timeout           time.Duration
+	Iterators         bool
+	IngesterStreaming bool
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -26,11 +27,26 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		f.DurationVar(&promql.LookbackDelta, "promql.lookback-delta", promql.LookbackDelta, "Time since the last sample after which a time series is considered stale and ignored by expression evaluations.")
 	}
 	f.BoolVar(&cfg.Iterators, "querier.iterators", false, "Use iterators to execute query, as opposed to fully materialising the series in memory.")
+	f.BoolVar(&cfg.IngesterStreaming, "querier.ingester-streaming", false, "Use streaming RPCs to query ingester.")
 }
 
-// Make builds a queryable and promql engine.
-func Make(cfg Config, distributor Distributor, chunkStore ChunkStore) (storage.Queryable, *promql.Engine) {
-	queryable := NewQueryable(distributor, chunkStore, cfg.Iterators)
+// New builds a queryable and promql engine.
+func New(cfg Config, distributor Distributor, chunkStore ChunkStore) (storage.Queryable, *promql.Engine) {
+	var dq storage.Queryable
+	if cfg.IngesterStreaming {
+		dq = newIngesterStreamingQueryable(distributor)
+	} else {
+		dq = newDistributorQueryable(distributor)
+	}
+
+	var cq storage.Queryable
+	if cfg.Iterators {
+		cq = newIterChunkQueryable(newChunkMergeIterator)(chunkStore)
+	} else {
+		cq = newChunkQueryable(chunkStore)
+	}
+
+	queryable := NewQueryable(dq, cq, distributor)
 	engine := promql.NewEngine(util.Logger, prometheus.DefaultRegisterer, cfg.MaxConcurrent, cfg.Timeout)
 	return queryable, engine
 }

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -16,7 +16,7 @@ import (
 // to reduce package coupling.
 type Distributor interface {
 	Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error)
-	QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error)
+	QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]client.TimeSeriesChunk, error)
 	LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error)
 	MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error)
 }

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 
+	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/metric"
 )
 
@@ -15,6 +16,7 @@ import (
 // to reduce package coupling.
 type Distributor interface {
 	Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error)
+	QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error)
 	LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error)
 	MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error)
 }

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -52,13 +52,13 @@ func TestDistributorQuerier(t *testing.T) {
 
 type mockDistributor struct {
 	m model.Matrix
-	r []*client.QueryStreamResponse
+	r []client.TimeSeriesChunk
 }
 
 func (m *mockDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
 	return m.m, nil
 }
-func (m *mockDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error) {
+func (m *mockDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]client.TimeSeriesChunk, error) {
 	return m.r, nil
 }
 func (m *mockDistributor) LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error) {

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/metric"
 )
 
@@ -56,11 +57,12 @@ type mockDistributor struct {
 func (m *mockDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
 	return m.m, nil
 }
-
+func (m *mockDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error) {
+	return nil, nil
+}
 func (m *mockDistributor) LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error) {
 	return nil, nil
 }
-
 func (m *mockDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]metric.Metric, error) {
 	return nil, nil
 }

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -52,13 +52,14 @@ func TestDistributorQuerier(t *testing.T) {
 
 type mockDistributor struct {
 	m model.Matrix
+	r []*client.QueryStreamResponse
 }
 
 func (m *mockDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
 	return m.m, nil
 }
 func (m *mockDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) ([]*client.QueryStreamResponse, error) {
-	return nil, nil
+	return m.r, nil
 }
 func (m *mockDistributor) LabelValuesForLabelName(context.Context, model.LabelName) ([]string, error) {
 	return nil, nil

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -51,7 +51,7 @@ func (q *ingesterStreamingQuerier) Select(_ *storage.SelectParams, matchers ...*
 			return nil, promql.ErrStorage(err)
 		}
 
-		ls := fromLabelPairs(result.Labels)
+		ls := client.FromLabelPairsToLabels(result.Labels)
 		sort.Sort(ls)
 		series := &chunkSeries{
 			labels:            ls,
@@ -62,15 +62,4 @@ func (q *ingesterStreamingQuerier) Select(_ *storage.SelectParams, matchers ...*
 	}
 
 	return newConcreteSeriesSet(serieses), nil
-}
-
-func fromLabelPairs(in []client.LabelPair) labels.Labels {
-	out := make(labels.Labels, 0, len(in))
-	for _, pair := range in {
-		out = append(out, labels.Label{
-			Name:  string(pair.Name),
-			Value: string(pair.Value),
-		})
-	}
-	return out
 }

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -50,11 +51,14 @@ func (q *ingesterStreamingQuerier) Select(_ *storage.SelectParams, matchers ...*
 			return nil, promql.ErrStorage(err)
 		}
 
-		serieses = append(serieses, &chunkSeries{
-			labels:            fromLabelPairs(result.Labels),
+		ls := fromLabelPairs(result.Labels)
+		sort.Sort(ls)
+		series := &chunkSeries{
+			labels:            ls,
 			chunks:            chunks,
 			chunkIteratorFunc: q.chunkIteratorFunc,
-		})
+		}
+		serieses = append(serieses, series)
 	}
 
 	return newConcreteSeriesSet(serieses), nil

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -9,14 +9,14 @@ import (
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/weaveworks/common/user"
-	"github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/ingester/client"
-	prom_chunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+	"github.com/weaveworks/cortex/pkg/util/chunkcompat"
 )
 
 func newIngesterStreamingQueryable(distributor Distributor) storage.Queryable {
 	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 		return &ingesterStreamingQuerier{
+			chunkIteratorFunc: newChunkMergeIterator,
 			distributorQuerier: distributorQuerier{
 				distributor: distributor,
 				ctx:         ctx,
@@ -45,7 +45,7 @@ func (q *ingesterStreamingQuerier) Select(_ *storage.SelectParams, matchers ...*
 
 	serieses := make([]storage.Series, 0, len(results))
 	for _, result := range results {
-		chunks, err := fromChunks(userID, result.Chunks)
+		chunks, err := chunkcompat.FromChunks(userID, result.Chunks)
 		if err != nil {
 			return nil, promql.ErrStorage(err)
 		}
@@ -69,24 +69,4 @@ func fromLabelPairs(in []client.LabelPair) labels.Labels {
 		})
 	}
 	return out
-}
-
-func fromChunks(userID string, in []client.Chunk) ([]chunk.Chunk, error) {
-	out := make([]chunk.Chunk, 0, len(in))
-	for _, i := range in {
-		o, err := prom_chunk.NewForEncoding(prom_chunk.Encoding(byte(i.Encoding)))
-		if err != nil {
-			return nil, err
-		}
-
-		if err := o.UnmarshalFromBuf(i.Data); err != nil {
-			return nil, err
-		}
-
-		firstTime, lastTime := model.Time(i.StartTimestampMs), model.Time(i.EndTimestampMs)
-		// As the lifetime of this chunk is scopes to this request, we don't need
-		// to supply a fingerprint or
-		out = append(out, chunk.NewChunk(userID, 0, nil, o, firstTime, lastTime))
-	}
-	return out, nil
 }

--- a/pkg/querier/ingester_streaming_queryable.go
+++ b/pkg/querier/ingester_streaming_queryable.go
@@ -1,0 +1,92 @@
+package querier
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+	prom_chunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+)
+
+func newIngesterStreamingQueryable(distributor Distributor) storage.Queryable {
+	return storage.QueryableFunc(func(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+		return &ingesterStreamingQuerier{
+			distributorQuerier: distributorQuerier{
+				distributor: distributor,
+				ctx:         ctx,
+				mint:        mint,
+				maxt:        maxt,
+			},
+		}, nil
+	})
+}
+
+type ingesterStreamingQuerier struct {
+	chunkIteratorFunc chunkIteratorFunc
+	distributorQuerier
+}
+
+func (q *ingesterStreamingQuerier) Select(_ *storage.SelectParams, matchers ...*labels.Matcher) (storage.SeriesSet, error) {
+	userID, err := user.ExtractOrgID(q.ctx)
+	if err != nil {
+		return nil, promql.ErrStorage(err)
+	}
+
+	results, err := q.distributor.QueryStream(q.ctx, model.Time(q.mint), model.Time(q.maxt), matchers...)
+	if err != nil {
+		return nil, promql.ErrStorage(err)
+	}
+
+	serieses := make([]storage.Series, 0, len(results))
+	for _, result := range results {
+		chunks, err := fromChunks(userID, result.Chunks)
+		if err != nil {
+			return nil, promql.ErrStorage(err)
+		}
+
+		serieses = append(serieses, &chunkSeries{
+			labels:            fromLabelPairs(result.Labels),
+			chunks:            chunks,
+			chunkIteratorFunc: q.chunkIteratorFunc,
+		})
+	}
+
+	return newConcreteSeriesSet(serieses), nil
+}
+
+func fromLabelPairs(in []client.LabelPair) labels.Labels {
+	out := make(labels.Labels, 0, len(in))
+	for _, pair := range in {
+		out = append(out, labels.Label{
+			Name:  string(pair.Name),
+			Value: string(pair.Value),
+		})
+	}
+	return out
+}
+
+func fromChunks(userID string, in []client.Chunk) ([]chunk.Chunk, error) {
+	out := make([]chunk.Chunk, 0, len(in))
+	for _, i := range in {
+		o, err := prom_chunk.NewForEncoding(prom_chunk.Encoding(byte(i.Encoding)))
+		if err != nil {
+			return nil, err
+		}
+
+		if err := o.UnmarshalFromBuf(i.Data); err != nil {
+			return nil, err
+		}
+
+		firstTime, lastTime := model.Time(i.StartTimestampMs), model.Time(i.EndTimestampMs)
+		// As the lifetime of this chunk is scopes to this request, we don't need
+		// to supply a fingerprint or
+		out = append(out, chunk.NewChunk(userID, 0, nil, o, firstTime, lastTime))
+	}
+	return out, nil
+}

--- a/pkg/querier/ingester_streaming_queryable_test.go
+++ b/pkg/querier/ingester_streaming_queryable_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestIngesterStreaming(t *testing.T) {
 	d := &mockDistributor{
-		r: []*client.QueryStreamResponse{
+		r: []client.TimeSeriesChunk{
 			{
 				Labels: []client.LabelPair{
 					{Name: wire.Bytes("bar"), Value: wire.Bytes("baz")},

--- a/pkg/querier/ingester_streaming_queryable_test.go
+++ b/pkg/querier/ingester_streaming_queryable_test.go
@@ -1,0 +1,48 @@
+package querier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+	"github.com/weaveworks/cortex/pkg/util/wire"
+)
+
+func TestIngesterStreaming(t *testing.T) {
+	d := &mockDistributor{
+		r: []*client.QueryStreamResponse{
+			{
+				Labels: []client.LabelPair{
+					{Name: wire.Bytes("bar"), Value: wire.Bytes("baz")},
+				},
+			},
+			{
+				Labels: []client.LabelPair{
+					{Name: wire.Bytes("foo"), Value: wire.Bytes("bar")},
+				},
+			},
+		},
+	}
+	ctx := user.InjectOrgID(context.Background(), "0")
+	queryable := newIngesterStreamingQueryable(d)
+	querier, err := queryable.Querier(ctx, mint, maxt)
+	require.NoError(t, err)
+
+	seriesSet, err := querier.Select(nil)
+	require.NoError(t, err)
+
+	require.True(t, seriesSet.Next())
+	series := seriesSet.At()
+	require.Equal(t, labels.Labels{{Name: "bar", Value: "baz"}}, series.Labels())
+
+	require.True(t, seriesSet.Next())
+	series = seriesSet.At()
+	require.Equal(t, labels.Labels{{Name: "foo", Value: "bar"}}, series.Labels())
+
+	require.False(t, seriesSet.Next())
+	require.NoError(t, seriesSet.Err())
+}

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -1,0 +1,55 @@
+package ring
+
+import (
+	"context"
+)
+
+// ReplicationSet describes the ingesters to talk to for a given key, and how
+// many errors to tolerate.
+type ReplicationSet struct {
+	Ingesters []*IngesterDesc
+	MaxErrors int
+}
+
+// Do function f in parallel for all replicas in the set, erroring is we exceed
+// MaxErrors and returning early otherwise.
+func (r ReplicationSet) Do(ctx context.Context, f func(*IngesterDesc) (interface{}, error)) ([]interface{}, error) {
+	errs := make(chan error, len(r.Ingesters))
+	resultsChan := make(chan interface{}, len(r.Ingesters))
+
+	for _, ing := range r.Ingesters {
+		go func(ing *IngesterDesc) {
+			result, err := f(ing)
+			if err != nil {
+				errs <- err
+			} else {
+				resultsChan <- result
+			}
+		}(ing)
+	}
+
+	var (
+		minSuccess = len(r.Ingesters) - r.MaxErrors
+		numErrs    int
+		numSuccess int
+		results    = make([]interface{}, 0, len(r.Ingesters))
+	)
+	for numSuccess < minSuccess {
+		select {
+		case err := <-errs:
+			numErrs++
+			if numErrs > r.MaxErrors {
+				return nil, err
+			}
+
+		case result := <-resultsChan:
+			numSuccess++
+			results = append(results, result)
+
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/ring/ring.go
+++ b/pkg/ring/ring.go
@@ -34,13 +34,6 @@ type ReadRing interface {
 	ReplicationFactor() int
 }
 
-// ReplicationSet describes the ingesters to talk to for a given key, and how
-// many errors to tolerate.
-type ReplicationSet struct {
-	Ingesters []*IngesterDesc
-	MaxErrors int
-}
-
 // Operation can be Read or Write
 type Operation int
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -29,7 +29,7 @@ func newTestRuler(t *testing.T, alertmanagerURL string) *Ruler {
 	// other kinds of tests.
 
 	engine := promql.NewEngine(nil, nil, 20, 2*time.Minute)
-	queryable := querier.NewQueryable(nil, nil, false)
+	queryable := querier.NewQueryable(nil, nil, nil)
 	ruler, err := NewRuler(cfg, engine, queryable, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/util/chunkcompat/compat.go
+++ b/pkg/util/chunkcompat/compat.go
@@ -1,0 +1,60 @@
+package chunkcompat
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+	prom_chunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+	"github.com/weaveworks/cortex/pkg/util"
+)
+
+// StreamsToMatrix converts slice of QueryStreamResponse to a model.Matrix.
+func StreamsToMatrix(from, through model.Time, response []*client.QueryStreamResponse) (model.Matrix, error) {
+	if response == nil {
+		return nil, nil
+	}
+
+	result := model.Matrix{}
+	for _, stream := range response {
+		chunks, err := FromChunks("", stream.Chunks)
+		if err != nil {
+			return nil, err
+		}
+
+		samples := []model.SamplePair{}
+		for _, chunk := range chunks {
+			ss, err := chunk.Samples(from, through)
+			if err != nil {
+				return nil, err
+			}
+			samples = util.MergeSampleSets(samples, ss)
+		}
+
+		result = append(result, &model.SampleStream{
+			Metric: client.FromLabelPairs(stream.Labels),
+			Values: samples,
+		})
+	}
+	return result, nil
+}
+
+// FromChunks converts []client.Chunk to []chunk.Chunk.
+func FromChunks(userID string, in []client.Chunk) ([]chunk.Chunk, error) {
+	out := make([]chunk.Chunk, 0, len(in))
+	for _, i := range in {
+		o, err := prom_chunk.NewForEncoding(prom_chunk.Encoding(byte(i.Encoding)))
+		if err != nil {
+			return nil, err
+		}
+
+		if err := o.UnmarshalFromBuf(i.Data); err != nil {
+			return nil, err
+		}
+
+		firstTime, lastTime := model.Time(i.StartTimestampMs), model.Time(i.EndTimestampMs)
+		// As the lifetime of this chunk is scopes to this request, we don't need
+		// to supply a fingerprint or metric.
+		out = append(out, chunk.NewChunk(userID, 0, nil, o, firstTime, lastTime))
+	}
+	return out, nil
+}


### PR DESCRIPTION
Should reduce CPU load on ingesters & network load as chunks as compressed; generally allows us to do much bigger queries without risk of OOMing the ingester.

Also:
- factor out the replication/consistency handling logic onto a method of `replicationSet`.
- move distributor query methods to separate file, in preparation for removing them from the distributor all together.

Fixes #913

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>