### PR TITLE
Reduce size of TestChunkQueryable so it doesn't intermittently timeout.

### DIFF
--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -83,7 +83,7 @@ func TestChunkQueryable(t *testing.T) {
 		for _, encoding := range encodings {
 			for _, query := range queries {
 				t.Run(fmt.Sprintf("%s/%s/%s", queryable.name, encoding.name, query.query), func(t *testing.T) {
-					store, from := makeMockChunkStore(t, 24*30, encoding.e)
+					store, from := makeMockChunkStore(t, 24*15, encoding.e)
 					queryable := queryable.f(store)
 					testQuery(t, queryable, from, query)
 				})


### PR DESCRIPTION
Fixes #935 

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>