### PR TITLE
Cache index queries for up to 15mins

### DIFF
--- a/pkg/chunk/cache/fifo_cache.go
+++ b/pkg/chunk/cache/fifo_cache.go
@@ -1,4 +1,4 @@
-package chunk
+package cache
 
 import (
 	"context"

--- a/pkg/chunk/cache/fifo_cache_test.go
+++ b/pkg/chunk/cache/fifo_cache_test.go
@@ -1,4 +1,4 @@
-package chunk
+package cache
 
 import (
 	"context"

--- a/pkg/chunk/fifo_cache.go
+++ b/pkg/chunk/fifo_cache.go
@@ -1,9 +1,12 @@
 package chunk
 
 import (
+	"context"
 	"sync"
 	"time"
 
+	ot "github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -64,6 +67,7 @@ type FifoCache struct {
 	// indexes into entries to identify the most recent and least recent entry.
 	first, last int
 
+	name            string
 	entriesAdded    prometheus.Counter
 	entriesAddedNew prometheus.Counter
 	entriesEvicted  prometheus.Counter
@@ -87,6 +91,7 @@ func NewFifoCache(name string, size int, validity time.Duration) *FifoCache {
 		entries:  make([]cacheEntry, 0, size),
 		index:    make(map[string]int, size),
 
+		name:            name,
 		entriesAdded:    cacheEntriesAdded.WithLabelValues(name),
 		entriesAddedNew: cacheEntriesAddedNew.WithLabelValues(name),
 		entriesEvicted:  cacheEntriesEvicted.WithLabelValues(name),
@@ -97,7 +102,10 @@ func NewFifoCache(name string, size int, validity time.Duration) *FifoCache {
 }
 
 // Put stores the value against the key.
-func (c *FifoCache) Put(key string, value interface{}) {
+func (c *FifoCache) Put(ctx context.Context, key string, value interface{}) {
+	span, ctx := ot.StartSpanFromContext(ctx, c.name+"-cache-put")
+	defer span.Finish()
+
 	c.entriesAdded.Inc()
 	if c.size == 0 {
 		return
@@ -164,7 +172,10 @@ func (c *FifoCache) Put(key string, value interface{}) {
 }
 
 // Get returns the stored value against the key and when the key was last updated.
-func (c *FifoCache) Get(key string) (interface{}, bool) {
+func (c *FifoCache) Get(ctx context.Context, key string) (interface{}, bool) {
+	span, ctx := ot.StartSpanFromContext(ctx, c.name+"-cache-get")
+	defer span.Finish()
+
 	c.totalGets.Inc()
 	if c.size == 0 {
 		return nil, false
@@ -177,14 +188,17 @@ func (c *FifoCache) Get(key string) (interface{}, bool) {
 	if ok {
 		updated := c.entries[index].updated
 		if time.Now().Sub(updated) < c.validity {
+			span.LogFields(otlog.Bool("hit", true))
 			return c.entries[index].value, true
 		}
 
 		c.totalMisses.Inc()
 		c.staleGets.Inc()
+		span.LogFields(otlog.Bool("hit", false), otlog.Bool("stale", true))
 		return nil, false
 	}
 
+	span.LogFields(otlog.Bool("hit", false), otlog.Bool("stale", false))
 	c.totalMisses.Inc()
 	return nil, false
 }

--- a/pkg/chunk/fifo_cache.go
+++ b/pkg/chunk/fifo_cache.go
@@ -5,9 +5,9 @@ import (
 	"time"
 )
 
-// fifoCache is a simple string -> interface{} cache which uses a fifo slide to
+// FifoCache is a simple string -> interface{} cache which uses a fifo slide to
 // manage evictions.  O(1) inserts and updates, O(1) gets.
-type fifoCache struct {
+type FifoCache struct {
 	lock    sync.RWMutex
 	size    int
 	entries []cacheEntry
@@ -24,15 +24,17 @@ type cacheEntry struct {
 	prev, next int
 }
 
-func newFifoCache(size int) *fifoCache {
-	return &fifoCache{
+// NewFifoCache returns a new initialised FifoCache of size.
+func NewFifoCache(size int) *FifoCache {
+	return &FifoCache{
 		size:    size,
 		entries: make([]cacheEntry, 0, size),
 		index:   make(map[string]int, size),
 	}
 }
 
-func (c *fifoCache) put(key string, value interface{}) {
+// Put stores the value against the key.
+func (c *FifoCache) Put(key string, value interface{}) {
 	if c.size == 0 {
 		return
 	}
@@ -95,7 +97,8 @@ func (c *fifoCache) put(key string, value interface{}) {
 	c.index[key] = index
 }
 
-func (c *fifoCache) get(key string) (value interface{}, updated time.Time, ok bool) {
+// Get returns the stored value against the key and when the key was last updated.
+func (c *FifoCache) Get(key string) (value interface{}, updated time.Time, ok bool) {
 	if c.size == 0 {
 		return
 	}

--- a/pkg/chunk/fifo_cache_test.go
+++ b/pkg/chunk/fifo_cache_test.go
@@ -12,56 +12,56 @@ const size = 10
 const overwrite = 5
 
 func TestFifoCache(t *testing.T) {
-	c := newFifoCache(size)
+	c := NewFifoCache(size)
 
 	// Check put / get works
 	for i := 0; i < size; i++ {
-		c.put(strconv.Itoa(i), i)
+		c.Put(strconv.Itoa(i), i)
 		//c.print()
 	}
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
 	for i := 0; i < size; i++ {
-		value, _, ok := c.get(strconv.Itoa(i))
+		value, _, ok := c.Get(strconv.Itoa(i))
 		require.True(t, ok)
 		require.Equal(t, i, value.(int))
 	}
 
 	// Check evictions
 	for i := size; i < size+overwrite; i++ {
-		c.put(strconv.Itoa(i), i)
+		c.Put(strconv.Itoa(i), i)
 		//c.print()
 	}
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
 	for i := 0; i < size-overwrite; i++ {
-		_, _, ok := c.get(strconv.Itoa(i))
+		_, _, ok := c.Get(strconv.Itoa(i))
 		require.False(t, ok)
 	}
 	for i := size; i < size+overwrite; i++ {
-		value, _, ok := c.get(strconv.Itoa(i))
+		value, _, ok := c.Get(strconv.Itoa(i))
 		require.True(t, ok)
 		require.Equal(t, i, value.(int))
 	}
 
 	// Check updates work
 	for i := size; i < size+overwrite; i++ {
-		c.put(strconv.Itoa(i), i*2)
+		c.Put(strconv.Itoa(i), i*2)
 		//c.print()
 	}
 	require.Len(t, c.index, size)
 	require.Len(t, c.entries, size)
 
 	for i := size; i < size+overwrite; i++ {
-		value, _, ok := c.get(strconv.Itoa(i))
+		value, _, ok := c.Get(strconv.Itoa(i))
 		require.True(t, ok)
 		require.Equal(t, i*2, value.(int))
 	}
 }
 
-func (c *fifoCache) print() {
+func (c *FifoCache) print() {
 	fmt.Println("first", c.first, "last", c.last)
 	for i, entry := range c.entries {
 		fmt.Printf("  %d -> key: %s, value: %v, next: %d, prev: %d\n", i, entry.key, entry.value, entry.next, entry.prev)

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -22,7 +22,7 @@ var (
 // seriesStore implements Store
 type seriesStore struct {
 	store
-	cardinalityCache *fifoCache
+	cardinalityCache *FifoCache
 }
 
 func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Store, error) {
@@ -38,7 +38,7 @@ func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Stor
 			schema:       schema,
 			chunkFetcher: fetcher,
 		},
-		cardinalityCache: newFifoCache(cfg.CardinalityCacheSize),
+		cardinalityCache: NewFifoCache(cfg.CardinalityCacheSize),
 	}, nil
 }
 
@@ -182,7 +182,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	level.Debug(log).Log("queries", len(queries))
 
 	for _, query := range queries {
-		value, updated, ok := c.cardinalityCache.get(query.HashValue)
+		value, updated, ok := c.cardinalityCache.Get(query.HashValue)
 		if !ok {
 			continue
 		}
@@ -201,7 +201,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 
 	// TODO This is not correct, will overcount for queries > 24hrs
 	for _, query := range queries {
-		c.cardinalityCache.put(query.HashValue, len(entries))
+		c.cardinalityCache.Put(query.HashValue, len(entries))
 	}
 	if len(entries) > c.cfg.CardinalityLimit {
 		return nil, errCardinalityExceeded

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -181,7 +181,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 	level.Debug(log).Log("queries", len(queries))
 
 	for _, query := range queries {
-		value, ok := c.cardinalityCache.Get(query.HashValue)
+		value, ok := c.cardinalityCache.Get(ctx, query.HashValue)
 		if !ok {
 			continue
 		}
@@ -199,7 +199,7 @@ func (c *seriesStore) lookupSeriesByMetricNameMatcher(ctx context.Context, from,
 
 	// TODO This is not correct, will overcount for queries > 24hrs
 	for _, query := range queries {
-		c.cardinalityCache.Put(query.HashValue, len(entries))
+		c.cardinalityCache.Put(ctx, query.HashValue, len(entries))
 	}
 	if len(entries) > c.cfg.CardinalityLimit {
 		return nil, errCardinalityExceeded

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 
 	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/chunk/cache"
 	"github.com/weaveworks/cortex/pkg/util"
 	"github.com/weaveworks/cortex/pkg/util/extract"
 )
@@ -21,7 +22,7 @@ var (
 // seriesStore implements Store
 type seriesStore struct {
 	store
-	cardinalityCache *FifoCache
+	cardinalityCache *cache.FifoCache
 }
 
 func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Store, error) {
@@ -37,7 +38,7 @@ func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Stor
 			schema:       schema,
 			chunkFetcher: fetcher,
 		},
-		cardinalityCache: NewFifoCache("cardinality", cfg.CardinalityCacheSize, cfg.CardinalityCacheValidity),
+		cardinalityCache: cache.NewFifoCache("cardinality", cfg.CardinalityCacheSize, cfg.CardinalityCacheValidity),
 	}, nil
 }
 

--- a/pkg/chunk/storage/caching_fixtures.go
+++ b/pkg/chunk/storage/caching_fixtures.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/weaveworks/cortex/pkg/chunk/gcp"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/testutils"
+)
+
+type fixture struct {
+	fixture testutils.Fixture
+}
+
+func (f fixture) Name() string { return "caching-store" }
+func (f fixture) Clients() (chunk.StorageClient, chunk.TableClient, chunk.SchemaConfig, error) {
+	storageClient, tableClient, schemaConfig, err := f.fixture.Clients()
+	client := newCachingStorageClient(storageClient, 500, 5*time.Minute)
+	return client, tableClient, schemaConfig, err
+}
+func (f fixture) Teardown() error { return f.fixture.Teardown() }
+
+// Fixtures for unit testing the caching storage.
+var Fixtures = []testutils.Fixture{
+	fixture{gcp.Fixtures[0]},
+}

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/cache"
 )
 
 type cachingStorageClient struct {
 	chunk.StorageClient
-	cache    *chunk.FifoCache
+	cache    *cache.FifoCache
 	validity time.Duration
 }
 
@@ -22,8 +23,7 @@ func newCachingStorageClient(client chunk.StorageClient, size int, validity time
 
 	return &cachingStorageClient{
 		StorageClient: client,
-		cache:         chunk.NewFifoCache("index", size, validity),
-		validity:      validity,
+		cache:         cache.NewFifoCache("index", size, validity),
 	}
 }
 

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -1,7 +1,9 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"time"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
@@ -20,44 +22,92 @@ func newCachingStorageClient(client chunk.StorageClient, size int, validity time
 
 	return &cachingStorageClient{
 		StorageClient: client,
-		cache:         chunk.NewFifoCache(size),
+		cache:         chunk.NewFifoCache("index", size, validity),
 		validity:      validity,
 	}
 }
 
 func (s *cachingStorageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
-	value, updated, ok := s.cache.Get(queryKey(query))
-	if ok && time.Now().Sub(updated) < s.validity {
+	value, ok := s.cache.Get(queryKey(query))
+	if ok {
 		batches := value.([]chunk.ReadBatch)
-		for _, batch := range batches {
-			callback(batch)
-		}
+		filteredBatch := filterBatchByQuery(query, batches)
+		callback(filteredBatch)
 
 		return nil
 	}
 
-	readBatches := []chunk.ReadBatch{}
-	err := s.StorageClient.QueryPages(ctx, query, copyingCallback(&readBatches, callback))
+	batches := []chunk.ReadBatch{}
+	cacheableQuery := chunk.IndexQuery{
+		TableName: query.TableName,
+		HashValue: query.HashValue,
+	} // Just reads the entire row and caches it.
+
+	err := s.StorageClient.QueryPages(ctx, cacheableQuery, copyingCallback(&batches))
 	if err != nil {
 		return err
 	}
 
-	s.cache.Put(queryKey(query), readBatches)
+	filteredBatch := filterBatchByQuery(query, batches)
+	callback(filteredBatch)
+
+	s.cache.Put(queryKey(query), batches)
+
 	return nil
 }
 
-func copyingCallback(readBatches *[]chunk.ReadBatch, cb func(chunk.ReadBatch) bool) func(chunk.ReadBatch) bool {
+type readBatch []cell
+
+func (b readBatch) Len() int                { return len(b) }
+func (b readBatch) RangeValue(i int) []byte { return b[i].column }
+func (b readBatch) Value(i int) []byte      { return b[i].value }
+
+type cell struct {
+	column []byte
+	value  []byte
+}
+
+func copyingCallback(readBatches *[]chunk.ReadBatch) func(chunk.ReadBatch) bool {
 	return func(result chunk.ReadBatch) bool {
 		*readBatches = append(*readBatches, result)
-		return cb(result)
+		return true
 	}
 }
 
 func queryKey(q chunk.IndexQuery) string {
 	const sep = "\xff"
-	return q.TableName + sep +
-		q.HashValue + sep +
-		string(q.RangeValuePrefix) + sep +
-		string(q.RangeValueStart) + sep +
-		string(q.ValueEqual)
+	return q.TableName + sep + q.HashValue
+}
+
+func filterBatchByQuery(query chunk.IndexQuery, batches []chunk.ReadBatch) readBatch {
+	var filter func([]byte, []byte) bool
+
+	if len(query.RangeValuePrefix) != 0 {
+		filter = func(rangeValue []byte, value []byte) bool {
+			return strings.HasPrefix(string(rangeValue), string(query.RangeValuePrefix))
+		}
+	}
+	if len(query.RangeValueStart) != 0 {
+		filter = func(rangeValue []byte, value []byte) bool {
+			return string(rangeValue) >= string(query.RangeValueStart)
+		}
+	}
+	if len(query.ValueEqual) != 0 {
+		// This is on top of the existing filters.
+		existingFilter := filter
+		filter = func(rangeValue []byte, value []byte) bool {
+			return existingFilter(rangeValue, value) && bytes.Equal(value, query.ValueEqual)
+		}
+	}
+
+	finalBatch := make(readBatch, 0, len(batches)) // On the higher side for most queries. On the lower side for column key schema.
+	for _, batch := range batches {
+		for i := 0; i < batch.Len(); i++ {
+			if filter(batch.RangeValue(i), batch.Value(i)) {
+				finalBatch = append(finalBatch, cell{column: batch.RangeValue(i), value: batch.Value(i)})
+			}
+		}
+	}
+
+	return finalBatch
 }

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -80,7 +80,7 @@ func queryKey(q chunk.IndexQuery) string {
 }
 
 func filterBatchByQuery(query chunk.IndexQuery, batches []chunk.ReadBatch) readBatch {
-	var filter func([]byte, []byte) bool
+	filter := func([]byte, []byte) bool { return true }
 
 	if len(query.RangeValuePrefix) != 0 {
 		filter = func(rangeValue []byte, value []byte) bool {

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+type cachingStorageClient struct {
+	chunk.StorageClient
+	cache    *chunk.FifoCache
+	validity time.Duration
+}
+
+func newCachingStorageClient(client chunk.StorageClient, size int, validity time.Duration) chunk.StorageClient {
+	if size == 0 {
+		return client
+	}
+
+	return &cachingStorageClient{
+		StorageClient: client,
+		cache:         chunk.NewFifoCache(size),
+		validity:      validity,
+	}
+}
+
+func (s *cachingStorageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
+	value, updated, ok := s.cache.Get(queryKey(query))
+	if ok && time.Now().Sub(updated) < s.validity {
+		batches := value.([]chunk.ReadBatch)
+		for _, batch := range batches {
+			callback(batch)
+		}
+
+		return nil
+	}
+
+	readBatches := []chunk.ReadBatch{}
+	err := s.StorageClient.QueryPages(ctx, query, copyingCallback(&readBatches, callback))
+	if err != nil {
+		return err
+	}
+
+	s.cache.Put(queryKey(query), readBatches)
+	return nil
+}
+
+func copyingCallback(readBatches *[]chunk.ReadBatch, cb func(chunk.ReadBatch) bool) func(chunk.ReadBatch) bool {
+	return func(result chunk.ReadBatch) bool {
+		*readBatches = append(*readBatches, result)
+		return cb(result)
+	}
+}
+
+func queryKey(q chunk.IndexQuery) string {
+	const sep = "\xff"
+	return q.TableName + sep +
+		q.HashValue + sep +
+		string(q.RangeValuePrefix) + sep +
+		string(q.RangeValueStart) + sep +
+		string(q.ValueEqual)
+}

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -28,7 +28,7 @@ func newCachingStorageClient(client chunk.StorageClient, size int, validity time
 }
 
 func (s *cachingStorageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
-	value, ok := s.cache.Get(queryKey(query))
+	value, ok := s.cache.Get(ctx, queryKey(query))
 	if ok {
 		batches := value.([]chunk.ReadBatch)
 		filteredBatch := filterBatchByQuery(query, batches)
@@ -51,7 +51,7 @@ func (s *cachingStorageClient) QueryPages(ctx context.Context, query chunk.Index
 	filteredBatch := filterBatchByQuery(query, batches)
 	callback(filteredBatch)
 
-	s.cache.Put(queryKey(query), batches)
+	s.cache.Put(ctx, queryKey(query), batches)
 
 	return nil
 }

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -34,7 +34,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.CassandraStorageConfig.RegisterFlags(f)
 
 	f.IntVar(&cfg.IndexCacheSize, "store.index-cache-size", 0, "Size of in-memory index cache, 0 to disable.")
-	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 15*time.Minute, "Period for which entries in the index cache are valid.")
+	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Period for which entries in the index cache are valid. Should be no higher than -ingester.max-chunk-idle.")
 }
 
 // NewStorageClient makes a storage client based on the configuration.

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -53,7 +53,7 @@ func NewStorageClient(cfg Config, schemaCfg chunk.SchemaConfig) (client chunk.St
 	case "cassandra":
 		client, err = cassandra.NewStorageClient(cfg.CassandraStorageConfig, schemaCfg)
 	default:
-		client, err = nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, gcp, cassandra, inmemory", cfg.StorageClient)
+		return nil, fmt.Errorf("Unrecognized storage client %v, choose one of: aws, gcp, cassandra, inmemory", cfg.StorageClient)
 	}
 
 	client = newCachingStorageClient(client, cfg.IndexCacheSize, cfg.IndexCacheValidity)

--- a/pkg/chunk/storage/utils_test.go
+++ b/pkg/chunk/storage/utils_test.go
@@ -20,6 +20,7 @@ type storageClientTest func(*testing.T, chunk.StorageClient)
 
 func forAllFixtures(t *testing.T, storageClientTest storageClientTest) {
 	fixtures := append(aws.Fixtures, gcp.Fixtures...)
+	fixtures = append(fixtures, Fixtures...)
 
 	cassandraFixtures, err := cassandra.Fixtures()
 	require.NoError(t, err)


### PR DESCRIPTION
An in-process cache for index queries to accelerate queries.

Cache entries are valid for 15mins as thats how long the ingester will hold flushed chunks for.