### PR TITLE
Don't succeed a transfer if no series are received.

### DIFF
--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -170,7 +170,7 @@ func TestIngesterBadTransfer(t *testing.T) {
 	stream, err := client.TransferChunks(context.Background())
 	require.NoError(t, err)
 	_, err = stream.CloseAndRecv()
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	// Check the ingester is still waiting.
 	require.Equal(t, ring.PENDING, ing.lifecycler.GetState())

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -150,13 +150,38 @@ func TestIngesterTransfer(t *testing.T) {
 	}, response)
 }
 
+func TestIngesterBadTransfer(t *testing.T) {
+	// Start ingester in PENDING.
+	cfg := defaultIngesterTestConfig()
+	cfg.LifecyclerConfig.ID = "ingester1"
+	cfg.LifecyclerConfig.Addr = "ingester1"
+	cfg.LifecyclerConfig.ClaimOnRollout = true
+	cfg.LifecyclerConfig.JoinAfter = 100 * time.Second
+	cfg.SearchPendingFor = 1 * time.Second
+	ing, err := New(cfg, nil)
+	require.NoError(t, err)
+
+	poll(t, 100*time.Millisecond, ring.PENDING, func() interface{} {
+		return ing.lifecycler.GetState()
+	})
+
+	// Now transfer 0 series to this ingester, ensure it errors.
+	client := ingesterClientAdapater{ingester: ing}
+	stream, err := client.TransferChunks(context.Background())
+	require.NoError(t, err)
+	_, err = stream.CloseAndRecv()
+	require.NotNil(t, err)
+
+	// Check the ingester is still waiting.
+	require.Equal(t, ring.PENDING, ing.lifecycler.GetState())
+}
+
 func numTokens(c ring.KVClient, name string) int {
 	ringDesc, err := c.Get(context.Background(), ring.ConsulKey)
 	if err != nil {
 		level.Error(util.Logger).Log("msg", "error reading consul", "err", err)
 		return 0
 	}
-
 	count := 0
 	for _, token := range ringDesc.(*ring.Desc).Tokens {
 		if token.Ingester == name {

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -109,7 +109,7 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 	}
 
 	if fromIngesterID == "" {
-		level.Error(util.Logger).Log("msg", "received TransferChunks request with no from ingester ID")
+		level.Error(util.Logger).Log("msg", "received TransferChunks request with no ID from ingester")
 		return fmt.Errorf("no ingester id")
 	}
 


### PR DESCRIPTION
Fixes #954

We don't know how we got in this state initially, but I suspect it was caused by an ingester being killed quickly - it started a transfer, but didn't actually get a chance to send any series.  This triggered the EOF break, and the new ingester joined the ring with 0 tokens.  

These checks should cause the new ingester to reject the transfer request if it doesn't receive a ingester ID or any series, leaving the ingester to join the ring itself.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>