### PR TITLE
Remove v7 & v8 deprecated schemas.

### DIFF
--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -37,8 +37,6 @@ var schemas = []struct {
 	{"v4 schema", v4Schema, newStore, true},
 	{"v5 schema", v5Schema, newStore, true},
 	{"v6 schema", v6Schema, newStore, true},
-	{"v7 schema", v7Schema, newStore, true},
-	{"v8 schema", v8Schema, newStore, false},
 	{"v9 schema", v9Schema, newSeriesStore, true},
 }
 

--- a/pkg/chunk/composite_store.go
+++ b/pkg/chunk/composite_store.go
@@ -93,24 +93,6 @@ func SchemaOpts(cfg StoreConfig, schemaCfg SchemaConfig) []SchemaOpt {
 		})
 	}
 
-	if schemaCfg.V7SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V7SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v7Schema(schemaCfg), storage)
-			},
-		})
-	}
-
-	if schemaCfg.V8SchemaFrom.IsSet() {
-		opts = append(opts, SchemaOpt{
-			From: schemaCfg.V8SchemaFrom.Time,
-			NewStore: func(storage StorageClient) (Store, error) {
-				return newStore(cfg, v8Schema(schemaCfg), storage)
-			},
-		})
-	}
-
 	if schemaCfg.V9SchemaFrom.IsSet() {
 		opts = append(opts, SchemaOpt{
 			From: schemaCfg.V9SchemaFrom.Time,

--- a/pkg/chunk/schema_config.go
+++ b/pkg/chunk/schema_config.go
@@ -28,8 +28,6 @@ type SchemaConfig struct {
 	V4SchemaFrom          util.DayValue
 	V5SchemaFrom          util.DayValue
 	V6SchemaFrom          util.DayValue
-	V7SchemaFrom          util.DayValue
-	V8SchemaFrom          util.DayValue
 	V9SchemaFrom          util.DayValue
 	BigtableColumnKeyFrom util.DayValue
 
@@ -59,8 +57,6 @@ func (cfg *SchemaConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.V4SchemaFrom, "dynamodb.v4-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v4 schema.")
 	f.Var(&cfg.V5SchemaFrom, "dynamodb.v5-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v5 schema.")
 	f.Var(&cfg.V6SchemaFrom, "dynamodb.v6-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v6 schema.")
-	f.Var(&cfg.V7SchemaFrom, "dynamodb.v7-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v7 schema (Deprecated).")
-	f.Var(&cfg.V8SchemaFrom, "dynamodb.v8-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v8 schema (Deprecated).")
 	f.Var(&cfg.V9SchemaFrom, "dynamodb.v9-schema-from", "The date (in the format YYYY-MM-DD) after which we enable v9 schema (Series indexing).")
 	f.Var(&cfg.BigtableColumnKeyFrom, "bigtable.column-key-from", "The date (in the format YYYY-MM-DD) after which we use bigtable column keys.")
 

--- a/pkg/chunk/schema_test.go
+++ b/pkg/chunk/schema_test.go
@@ -2,9 +2,7 @@ package chunk
 
 import (
 	"bytes"
-	"crypto/sha1"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -195,19 +193,12 @@ func TestSchemaRangeKey(t *testing.T) {
 		labelBuckets  = v4Schema(cfg)
 		tsRangeKeys   = v5Schema(cfg)
 		v6RangeKeys   = v6Schema(cfg)
-		v7RangeKeys   = v7Schema(cfg)
-		v8RangeKeys   = v8Schema(cfg)
 		metric        = model.Metric{
 			model.MetricNameLabel: metricName,
 			"bar": "bary",
 			"baz": "bazy",
 		}
-		fooSha1Hash = sha1.Sum([]byte("foo"))
 	)
-
-	seriesID := metricSeriesID(metric)
-	metricBytes, err := json.Marshal(metric)
-	require.NoError(t, err)
 
 	mkEntries := func(hashKey string, callback func(labelName model.LabelName, labelValue model.LabelValue) ([]byte, []byte)) []IndexEntry {
 		result := []IndexEntry{}
@@ -293,62 +284,6 @@ func TestSchemaRangeKey(t *testing.T) {
 		{
 			v6RangeKeys,
 			[]IndexEntry{
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x003\x00"),
-				},
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo:bar",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
-					Value:      []byte("bary"),
-				},
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo:baz",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
-					Value:      []byte("bazy"),
-				},
-			},
-		},
-		{
-			v7RangeKeys,
-			[]IndexEntry{
-				{
-					TableName:  table,
-					HashValue:  "userid:d0",
-					RangeValue: append(encodeBase64Bytes(fooSha1Hash[:]), []byte("\x00\x00\x006\x00")...),
-					Value:      []byte("foo"),
-				},
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x003\x00"),
-				},
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo:bar",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
-					Value:      []byte("bary"),
-				},
-				{
-					TableName:  table,
-					HashValue:  "userid:d0:foo:baz",
-					RangeValue: []byte("0036ee7f\x00\x00chunkID\x005\x00"),
-					Value:      []byte("bazy"),
-				},
-			},
-		},
-		{
-			v8RangeKeys,
-			[]IndexEntry{
-				{
-					TableName:  table,
-					HashValue:  "userid:d0",
-					RangeValue: append([]byte(seriesID), []byte("\x00\x00\x007\x00")...),
-					Value:      metricBytes,
-				},
 				{
 					TableName:  table,
 					HashValue:  "userid:d0:foo",


### PR DESCRIPTION
As discussed in the community call ~a month ago.  Removed the flags as well, so the jobs won't start if you are using these schemas.

Fixes #876

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>