### PR TITLE
Batch iterators

### DIFF
--- a/pkg/prom1/storage/local/chunk/chunk.go
+++ b/pkg/prom1/storage/local/chunk/chunk.go
@@ -325,22 +325,17 @@ type Iterator interface {
 	Err() error
 }
 
-// Number is samples per batch; this was choose by benchmarking all sizes from
-// 1 to 128; 51 samples happens to also be a whole number of cache lines -
-// 51*16 + 16 / 64 = 13.
-const BatchSize = 51
+// BatchSize is samples per batch; this was choose by benchmarking all sizes from
+// 1 to 128.
+const BatchSize = 48
 
-// batch is a sort set of (timestamp, value) pairs.  They are intended to be
+// Batch is a sorted set of (timestamp, value) pairs.  They are intended to be
 // small, and passed by value.
 type Batch struct {
 	Timestamps [BatchSize]int64
 	Values     [BatchSize]float64
 	Index      int
 	Length     int
-}
-
-func (b Batch) Print() {
-	fmt.Println("  ", b.Values, b.Index, b.Length)
 }
 
 // RangeValues is a utility function that retrieves all values within the given

--- a/pkg/prom1/storage/local/chunk/chunk.go
+++ b/pkg/prom1/storage/local/chunk/chunk.go
@@ -328,7 +328,7 @@ type Iterator interface {
 
 // BatchSize is samples per batch; this was choose by benchmarking all sizes from
 // 1 to 128.
-const BatchSize = 48
+const BatchSize = 12
 
 // Batch is a sorted set of (timestamp, value) pairs.  They are intended to be
 // small, and passed by value.

--- a/pkg/prom1/storage/local/chunk/chunk.go
+++ b/pkg/prom1/storage/local/chunk/chunk.go
@@ -339,6 +339,10 @@ type Batch struct {
 	Length     int
 }
 
+func (b Batch) Print() {
+	fmt.Println("  ", b.Values, b.Index, b.Length)
+}
+
 // RangeValues is a utility function that retrieves all values within the given
 // range from an Iterator.
 func RangeValues(it Iterator, in metric.Interval) ([]model.SamplePair, error) {
@@ -510,7 +514,6 @@ func (it *indexAccessingChunkIterator) Value() model.SamplePair {
 func (it *indexAccessingChunkIterator) Batch() Batch {
 	var batch Batch
 	j := 0
-	it.pos++
 	for j < BatchSize && it.pos < it.len {
 		batch.Timestamps[j] = int64(it.acc.timestampAtIndex(it.pos))
 		batch.Values[j] = float64(it.acc.sampleValueAtIndex(it.pos))

--- a/pkg/prom1/storage/local/chunk/chunk.go
+++ b/pkg/prom1/storage/local/chunk/chunk.go
@@ -318,7 +318,8 @@ type Iterator interface {
 	// of the find... methods). It returns model.ZeroSamplePair before any of
 	// those methods were called.
 	Value() model.SamplePair
-	// Batchey mcBatchFace.
+	// Returns a batch of samples; NB not idempotent!  Should only be called
+	// once per Scan/FindAtOrBefore.
 	Batch() Batch
 	// Returns the last error encountered. In general, an error signals data
 	// corruption in the chunk and requires quarantining.

--- a/pkg/prom1/storage/local/chunk/varbit.go
+++ b/pkg/prom1/storage/local/chunk/varbit.go
@@ -1087,6 +1087,19 @@ func (it *varbitChunkIterator) Value() model.SamplePair {
 	}
 }
 
+func (it *varbitChunkIterator) Batch() Batch {
+	var batch Batch
+	j := 0
+	for j < BatchSize && it.Scan() {
+		batch.Timestamps[j] = int64(it.t)
+		batch.Values[j] = float64(it.v)
+		j++
+	}
+	batch.Index = 0
+	batch.Length = j
+	return batch
+}
+
 // err implements Iterator.
 func (it *varbitChunkIterator) Err() error {
 	return it.lastError

--- a/pkg/prom1/storage/local/chunk/varbit.go
+++ b/pkg/prom1/storage/local/chunk/varbit.go
@@ -1090,10 +1090,13 @@ func (it *varbitChunkIterator) Value() model.SamplePair {
 func (it *varbitChunkIterator) Batch() Batch {
 	var batch Batch
 	j := 0
-	for j < BatchSize && it.Scan() {
+	for j < BatchSize {
 		batch.Timestamps[j] = int64(it.t)
 		batch.Values[j] = float64(it.v)
 		j++
+		if j < BatchSize && !it.Scan() {
+			break
+		}
 	}
 	batch.Index = 0
 	batch.Length = j

--- a/pkg/prom1/storage/local/chunk/varbit.go
+++ b/pkg/prom1/storage/local/chunk/varbit.go
@@ -1087,14 +1087,14 @@ func (it *varbitChunkIterator) Value() model.SamplePair {
 	}
 }
 
-func (it *varbitChunkIterator) Batch() Batch {
+func (it *varbitChunkIterator) Batch(size int) Batch {
 	var batch Batch
 	j := 0
-	for j < BatchSize {
+	for j < size {
 		batch.Timestamps[j] = int64(it.t)
 		batch.Values[j] = float64(it.v)
 		j++
-		if j < BatchSize && !it.Scan() {
+		if j < size && !it.Scan() {
 			break
 		}
 	}

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -1,33 +1,17 @@
 package batch
 
 import (
-	"fmt"
-
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/cortex/pkg/chunk"
+	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
-
-const batchSize = 128
-
-// batch is a sort set of (timestamp, value) pairs.  They are intended to be
-// small, and passed by value.
-type batch struct {
-	timestamps [batchSize]int64
-	values     [batchSize]float64
-	index      int
-	length     int
-}
-
-func (b batch) Print() {
-	fmt.Println("   ", b.timestamps, b.index, b.length)
-}
 
 // batchIterator iterate over batches.
 type batchIterator interface {
 	Seek(t int64) bool
 	Next() bool
 	AtTime() int64
-	Batch() batch
+	Batch() promchunk.Batch
 	Err() error
 }
 
@@ -39,7 +23,7 @@ func NewChunkMergeIterator(chunks []chunk.Chunk) storage.SeriesIterator {
 
 // batchIteratorAdapter turns a batchIterator into a storage.SeriesIterator.
 type batchIteratorAdapter struct {
-	curr       batch
+	curr       promchunk.Batch
 	underlying batchIterator
 }
 
@@ -51,24 +35,24 @@ func newBatchIteratorAdapter(underlying batchIterator) storage.SeriesIterator {
 
 // Seek implements storage.SeriesIterator.
 func (a *batchIteratorAdapter) Seek(t int64) bool {
-	a.curr.length = -1
+	a.curr.Length = -1
 	return a.underlying.Seek(t)
 }
 
 // Next implements storage.SeriesIterator.
 func (a *batchIteratorAdapter) Next() bool {
-	a.curr.index++
+	a.curr.Index++
 
-	for a.curr.index >= a.curr.length && a.underlying.Next() {
+	for a.curr.Index >= a.curr.Length && a.underlying.Next() {
 		a.curr = a.underlying.Batch()
 	}
 
-	return a.curr.index < a.curr.length
+	return a.curr.Index < a.curr.Length
 }
 
 // At implements storage.SeriesIterator.
 func (a *batchIteratorAdapter) At() (int64, float64) {
-	return a.curr.timestamps[a.curr.index], a.curr.values[a.curr.index]
+	return a.curr.Timestamps[a.curr.Index], a.curr.Values[a.curr.Index]
 }
 
 // Err implements storage.SeriesIterator.

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -1,6 +1,8 @@
 package batch
 
 import (
+	"fmt"
+
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
@@ -23,6 +25,10 @@ type iterator interface {
 	Batch() promchunk.Batch
 
 	Err() error
+}
+
+func print(b promchunk.Batch) {
+	fmt.Println("  ", b.Timestamps, b.Index, b.Length)
 }
 
 // NewChunkMergeIterator returns a storage.SeriesIterator that merges chunks together.
@@ -63,10 +69,10 @@ func (a *iteratorAdapter) Next() bool {
 	a.curr.Index++
 	for a.curr.Index >= a.curr.Length && a.underlying.Next(a.batchSize) {
 		a.curr = a.underlying.Batch()
-	}
-	a.batchSize = a.batchSize * 2
-	if a.batchSize > promchunk.BatchSize {
-		a.batchSize = promchunk.BatchSize
+		a.batchSize = a.batchSize * 2
+		if a.batchSize > promchunk.BatchSize {
+			a.batchSize = promchunk.BatchSize
+		}
 	}
 	return a.curr.Index < a.curr.Length
 }

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -1,0 +1,77 @@
+package batch
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/storage"
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+const batchSize = 128
+
+// batch is a sort set of (timestamp, value) pairs.  They are intended to be
+// small, and passed by value.
+type batch struct {
+	timestamps [batchSize]int64
+	values     [batchSize]float64
+	index      int
+	length     int
+}
+
+func (b batch) Print() {
+	fmt.Println("   ", b.timestamps, b.index, b.length)
+}
+
+// batchIterator iterate over batches.
+type batchIterator interface {
+	Seek(t int64) bool
+	Next() bool
+	AtTime() int64
+	Batch() batch
+	Err() error
+}
+
+// NewChunkMergeIterator returns a storage.SeriesIterator that merges chunks together.
+func NewChunkMergeIterator(chunks []chunk.Chunk) storage.SeriesIterator {
+	iter := newBatchMergeIterator(chunks)
+	return newBatchIteratorAdapter(iter)
+}
+
+// batchIteratorAdapter turns a batchIterator into a storage.SeriesIterator.
+type batchIteratorAdapter struct {
+	curr       batch
+	underlying batchIterator
+}
+
+func newBatchIteratorAdapter(underlying batchIterator) storage.SeriesIterator {
+	return &batchIteratorAdapter{
+		underlying: underlying,
+	}
+}
+
+// Seek implements storage.SeriesIterator.
+func (a *batchIteratorAdapter) Seek(t int64) bool {
+	a.curr.length = -1
+	return a.underlying.Seek(t)
+}
+
+// Next implements storage.SeriesIterator.
+func (a *batchIteratorAdapter) Next() bool {
+	a.curr.index++
+
+	for a.curr.index >= a.curr.length && a.underlying.Next() {
+		a.curr = a.underlying.Batch()
+	}
+
+	return a.curr.index < a.curr.length
+}
+
+// At implements storage.SeriesIterator.
+func (a *batchIteratorAdapter) At() (int64, float64) {
+	return a.curr.timestamps[a.curr.index], a.curr.values[a.curr.index]
+}
+
+// Err implements storage.SeriesIterator.
+func (a *batchIteratorAdapter) Err() error {
+	return nil
+}

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -9,18 +9,17 @@ import (
 // iterator iterates over batches.
 type iterator interface {
 	// Seek to the batch at (or after) time t.
-	Seek(t int64) bool
+	Seek(t int64, size int) bool
 
 	// Next moves to the next batch.
-	Next() bool
+	Next(size int) bool
 
 	// AtTime returns the start time of the next batch.  Must only be called after
 	// Seek or Next have returned true.
 	AtTime() int64
 
 	// Batch returns the current batch.  Must only be called after Seek or Next
-	// have returned true.  Must return a full batch if possible; if a partial
-	// batch is returned, subsequent Next calls must return false.
+	// have returned true.
 	Batch() promchunk.Batch
 
 	Err() error
@@ -33,13 +32,17 @@ func NewChunkMergeIterator(chunks []chunk.Chunk) storage.SeriesIterator {
 }
 
 // iteratorAdapter turns a batchIterator into a storage.SeriesIterator.
+// It fetches ever increasing batchSizes (up to promchunk.BatchSize) on each
+// call to Next; on calls to Seek, resets batch size to 1.
 type iteratorAdapter struct {
+	batchSize  int
 	curr       promchunk.Batch
 	underlying iterator
 }
 
 func newIteratorAdapter(underlying iterator) storage.SeriesIterator {
 	return &iteratorAdapter{
+		batchSize:  1,
 		underlying: underlying,
 	}
 }
@@ -47,7 +50,8 @@ func newIteratorAdapter(underlying iterator) storage.SeriesIterator {
 // Seek implements storage.SeriesIterator.
 func (a *iteratorAdapter) Seek(t int64) bool {
 	a.curr.Length = -1
-	if a.underlying.Seek(t) {
+	a.batchSize = 1
+	if a.underlying.Seek(t, a.batchSize) {
 		a.curr = a.underlying.Batch()
 		return a.curr.Index < a.curr.Length
 	}
@@ -57,8 +61,12 @@ func (a *iteratorAdapter) Seek(t int64) bool {
 // Next implements storage.SeriesIterator.
 func (a *iteratorAdapter) Next() bool {
 	a.curr.Index++
-	for a.curr.Index >= a.curr.Length && a.underlying.Next() {
+	for a.curr.Index >= a.curr.Length && a.underlying.Next(a.batchSize) {
 		a.curr = a.underlying.Batch()
+	}
+	a.batchSize = a.batchSize * 2
+	if a.batchSize > promchunk.BatchSize {
+		a.batchSize = promchunk.BatchSize
 	}
 	return a.curr.Index < a.curr.Length
 }

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -6,7 +6,8 @@ import (
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
 
-// chunkIterator implement batchIterator over a chunk.
+// chunkIterator implement batchIterator over a chunk.  Its is designed to be
+// reused by calling reset() with a fresh chunk.
 type chunkIterator struct {
 	chunk chunk.Chunk
 	it    promchunk.Iterator

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -29,21 +29,19 @@ func (i *chunkIterator) Seek(t int64) bool {
 		return false
 	}
 
-	// TODO this will call next twice.
-	next := i.it.FindAtOrAfter(model.Time(t))
-	if next {
-		i.buildNextBatch()
+	if i.it.FindAtOrAfter(model.Time(t)) {
+		i.batch = i.it.Batch()
+		return i.batch.Length > 0
 	}
-	return next
+	return false
 }
 
 func (i *chunkIterator) Next() bool {
-	i.buildNextBatch()
-	return i.batch.Length > 0
-}
-
-func (i *chunkIterator) buildNextBatch() {
-	i.batch = i.it.Batch()
+	if i.it.Scan() {
+		i.batch = i.it.Batch()
+		return i.batch.Length > 0
+	}
+	return false
 }
 
 func (i *chunkIterator) AtTime() int64 {

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -23,7 +23,7 @@ func (i *chunkIterator) reset(chunk chunk.Chunk) {
 
 // Seek advances the iterator forward to the value at or after
 // the given timestamp.
-func (i *chunkIterator) Seek(t int64) bool {
+func (i *chunkIterator) Seek(t int64, size int) bool {
 	// We assume seeks only care about a specific window; if this chunk doesn't
 	// contain samples in that window, we can shortcut.
 	if int64(i.chunk.Through) < t {
@@ -31,15 +31,15 @@ func (i *chunkIterator) Seek(t int64) bool {
 	}
 
 	if i.it.FindAtOrAfter(model.Time(t)) {
-		i.batch = i.it.Batch()
+		i.batch = i.it.Batch(size)
 		return i.batch.Length > 0
 	}
 	return false
 }
 
-func (i *chunkIterator) Next() bool {
+func (i *chunkIterator) Next(size int) bool {
 	if i.it.Scan() {
-		i.batch = i.it.Batch()
+		i.batch = i.it.Batch(size)
 		return i.batch.Length > 0
 	}
 	return false

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -1,0 +1,67 @@
+package batch
+
+import (
+	"github.com/prometheus/common/model"
+	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+// chunkIterator implement batchIterator over a chunk.
+type chunkIterator struct {
+	chunk chunk.Chunk
+	it    promchunk.Iterator
+	batch batch
+}
+
+func newChunkIterator(chunk chunk.Chunk) *chunkIterator {
+	return &chunkIterator{
+		chunk: chunk,
+		it:    chunk.Data.NewIterator(),
+	}
+}
+
+// Seek advances the iterator forward to the value at or after
+// the given timestamp.
+func (i *chunkIterator) Seek(t int64) bool {
+	// We assume seeks only care about a specific window; if this chunk doesn't
+	// contain samples in that window, we can shortcut.
+	if int64(i.chunk.Through) < t {
+		return false
+	}
+
+	// TODO this will call next twice.
+	next := i.it.FindAtOrAfter(model.Time(t))
+	if next {
+		i.buildNextBatch()
+	}
+	return next
+}
+
+func (i *chunkIterator) Next() bool {
+	i.buildNextBatch()
+	return i.batch.length > 0
+}
+
+func (i *chunkIterator) buildNextBatch() {
+	j := 0
+	for ; j < batchSize && i.it.Scan(); j++ {
+		v := i.it.Value()
+		i.batch.timestamps[j] = int64(v.Timestamp)
+		i.batch.values[j] = float64(v.Value)
+	}
+	i.batch.index = 0
+	i.batch.length = j
+}
+
+func (i *chunkIterator) AtTime() int64 {
+	return i.batch.timestamps[0]
+}
+
+func (i *chunkIterator) Batch() batch {
+	return i.batch
+}
+
+func (i *chunkIterator) Err() error {
+	return i.it.Err()
+}

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -69,7 +69,7 @@ func testSeek(t require.TestingT, points int64, iter storage.SeriesIterator) {
 		require.EqualValues(t, v, float64(ets))
 		require.NoError(t, iter.Err())
 
-		for j := i + 1; j < points; j++ {
+		for j := i + 1; j < i+points/10; j++ {
 			ets := j * int64(step/time.Millisecond)
 			require.True(t, iter.Next())
 			ts, v := iter.At()

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -23,8 +23,8 @@ func TestChunkIter(t *testing.T) {
 	chunk := mkChunk(t, 0, 100)
 	iter := &chunkIterator{}
 	iter.reset(chunk)
-	testIter(t, 100, newBatchIteratorAdapter(iter))
-	testSeek(t, 100, newBatchIteratorAdapter(iter))
+	testIter(t, 100, newIteratorAdapter(iter))
+	testSeek(t, 100, newIteratorAdapter(iter))
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int) chunk.Chunk {

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -50,7 +50,7 @@ func mkChunk(t require.TestingT, from model.Time, points int) chunk.Chunk {
 func testIter(t require.TestingT, points int, iter storage.SeriesIterator) {
 	ets := model.TimeFromUnix(0)
 	for i := 0; i < points; i++ {
-		require.True(t, iter.Next())
+		require.True(t, iter.Next(), strconv.Itoa(i))
 		ts, v := iter.At()
 		require.EqualValues(t, int64(ets), ts, strconv.Itoa(i))
 		require.EqualValues(t, float64(ets), v, strconv.Itoa(i))
@@ -59,9 +59,9 @@ func testIter(t require.TestingT, points int, iter storage.SeriesIterator) {
 	require.False(t, iter.Next())
 }
 
-func testSeek(t require.TestingT, points int64, iter storage.SeriesIterator) {
-	for i := int64(0); i < points; i += points / 10 {
-		ets := i * int64(step/time.Millisecond)
+func testSeek(t require.TestingT, points int, iter storage.SeriesIterator) {
+	for i := 0; i < points; i += points / 10 {
+		ets := int64(i * int(step/time.Millisecond))
 
 		require.True(t, iter.Seek(ets))
 		ts, v := iter.At()
@@ -70,7 +70,7 @@ func testSeek(t require.TestingT, points int64, iter storage.SeriesIterator) {
 		require.NoError(t, iter.Err())
 
 		for j := i + 1; j < i+points/10; j++ {
-			ets := j * int64(step/time.Millisecond)
+			ets := int64(j * int(step/time.Millisecond))
 			require.True(t, iter.Next())
 			ts, v := iter.At()
 			require.EqualValues(t, ets, ts)

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -1,0 +1,57 @@
+package batch
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+)
+
+const (
+	fp     = 1
+	userID = "0"
+	step   = 1 * time.Second
+)
+
+func TestChunkIter(t *testing.T) {
+	chunk := mkChunk(t, 0, 100)
+	testIter(t, 0, 100, newBatchIteratorAdapter(newChunkIterator(chunk)))
+}
+
+func mkChunk(t require.TestingT, from model.Time, points int) chunk.Chunk {
+	metric := model.Metric{
+		model.MetricNameLabel: "foo",
+	}
+	pc, err := promchunk.NewForEncoding(promchunk.DoubleDelta)
+	require.NoError(t, err)
+	ts := from
+	for i := 0; i < points; i++ {
+		pcs, err := pc.Add(model.SamplePair{
+			Timestamp: ts,
+			Value:     model.SampleValue(float64(ts)),
+		})
+		require.NoError(t, err)
+		require.Len(t, pcs, 1)
+		pc = pcs[0]
+		ts = ts.Add(step)
+	}
+	return chunk.NewChunk(userID, fp, metric, pc, model.Time(0), ts)
+}
+
+func testIter(t require.TestingT, from model.Time, points int, iter storage.SeriesIterator) {
+	ets := from
+	for i := 0; i < points; i++ {
+		require.True(t, iter.Next())
+		ts, v := iter.At()
+		require.EqualValues(t, int64(ets), ts, strconv.Itoa(i))
+		require.EqualValues(t, float64(ets), v, strconv.Itoa(i))
+		ets = ets.Add(step)
+	}
+	require.False(t, iter.Next())
+}

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -21,7 +21,9 @@ const (
 
 func TestChunkIter(t *testing.T) {
 	chunk := mkChunk(t, 0, 100)
-	testIter(t, 0, 100, newBatchIteratorAdapter(newChunkIterator(chunk)))
+	iter := &chunkIterator{}
+	iter.reset(chunk)
+	testIter(t, 0, 100, newBatchIteratorAdapter(iter))
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int) chunk.Chunk {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -1,0 +1,160 @@
+package batch
+
+import (
+	"container/heap"
+	"sort"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+type batchMergeIterator struct {
+	its []*nonOverlappingIterator
+	h   batchIteratorHeap
+
+	batches []batch
+	currErr error
+}
+
+func newBatchMergeIterator(cs []chunk.Chunk) *batchMergeIterator {
+	css := partitionChunks(cs)
+	its := make([]*nonOverlappingIterator, 0, len(css))
+	for _, cs := range css {
+		its = append(its, newNonOverlappingIterator(cs))
+	}
+
+	c := &batchMergeIterator{
+		its: its,
+		h:   make(batchIteratorHeap, 0, len(its)),
+	}
+
+	for _, iter := range c.its {
+		if iter.Next() {
+			c.h = append(c.h, iter)
+			continue
+		}
+
+		if err := iter.Err(); err != nil {
+			c.currErr = err
+		}
+	}
+
+	heap.Init(&c.h)
+	return c
+}
+
+func (c *batchMergeIterator) Seek(t int64) bool {
+	c.h = c.h[:0]
+	c.batches = c.batches[:0]
+
+	for _, iter := range c.its {
+		if iter.Seek(t) {
+			c.h = append(c.h, iter)
+			continue
+		}
+
+		if err := iter.Err(); err != nil {
+			c.currErr = err
+			return false
+		}
+	}
+
+	heap.Init(&c.h)
+	c.buildNextBatch()
+	return len(c.batches) > 0
+}
+
+func (c *batchMergeIterator) Next() bool {
+	// pop the last built batch
+	if len(c.batches) > 0 {
+		c.batches = c.batches[1:]
+	}
+
+	c.buildNextBatch()
+	return len(c.batches) > 0
+}
+
+func (c *batchMergeIterator) buildNextBatch() {
+	unique := 0
+	for i := range c.batches {
+		unique += c.batches[i].length
+	}
+	required := (((len(c.h) * batchSize) - unique) / batchSize) + 1
+	if required <= 0 {
+		return
+	}
+
+	batches := make([]batch, 0, len(c.h))
+	for len(batches) < required && len(c.h) > 0 {
+		batches = append(batches, c.h[0].Batch())
+		if c.h[0].Next() {
+			heap.Fix(&c.h, 0)
+		} else {
+			heap.Pop(&c.h)
+		}
+	}
+
+	merged := make([]batch, len(batches))
+	merged = mergeBatches(batches, merged)
+	output := make([]batch, len(c.batches)+len(merged))
+	c.batches = mergeStreams(c.batches, merged, output[:0])
+}
+
+func (c *batchMergeIterator) AtTime() int64 {
+	return c.batches[0].timestamps[0]
+}
+
+func (c *batchMergeIterator) Batch() batch {
+	return c.batches[0]
+}
+
+func (c *batchMergeIterator) Err() error {
+	return c.currErr
+}
+
+type batchIteratorHeap []batchIterator
+
+func (h *batchIteratorHeap) Len() int      { return len(*h) }
+func (h *batchIteratorHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+func (h *batchIteratorHeap) Less(i, j int) bool {
+	iT := (*h)[i].AtTime()
+	jT := (*h)[j].AtTime()
+	return iT < jT
+}
+
+func (h *batchIteratorHeap) Push(x interface{}) {
+	*h = append(*h, x.(batchIterator))
+}
+
+func (h *batchIteratorHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// Build a list of lists of non-overlapping chunks.
+func partitionChunks(cs []chunk.Chunk) [][]chunk.Chunk {
+	sort.Sort(byFrom(cs))
+
+	css := [][]chunk.Chunk{}
+outer:
+	for _, c := range cs {
+		for i, cs := range css {
+			if cs[len(cs)-1].Through.Before(c.From) {
+				css[i] = append(css[i], c)
+				continue outer
+			}
+		}
+		css = append(css, []chunk.Chunk{c})
+	}
+
+	return css
+}
+
+type byFrom []chunk.Chunk
+
+func (b byFrom) Len() int           { return len(b) }
+func (b byFrom) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b byFrom) Less(i, j int) bool { return b[i].From < b[j].From }

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -96,17 +96,12 @@ func (c *mergeIterator) buildNextBatch() {
 		required -= c.batches[i].Length - c.batches[i].Index
 	}
 
+	//fmt.Println("----")
+	//c.batches.Print()
+	//fmt.Println(required)
+
 	c.nextBatches = c.nextBatches[:0]
 	for required > 0 && len(c.h) > 0 {
-		// Optimisation: if we have at least one batches, and the next batch starts
-		// after the last batch we have, we have no overlaps and can break early.
-		if len(c.nextBatches) > 0 {
-			last := &c.nextBatches[len(c.nextBatches)-1]
-			if last.Timestamps[last.Length-1] < c.h[0].AtTime() {
-				break
-			}
-		}
-
 		b := c.h[0].Batch()
 		required -= b.Length
 		c.nextBatches = append(c.nextBatches, b)
@@ -118,11 +113,15 @@ func (c *mergeIterator) buildNextBatch() {
 	}
 
 	if len(c.nextBatches) > 0 {
+		//c.nextBatches.Print()
+
 		c.nextBatchesBuf = mergeBatches(c.nextBatches, c.nextBatchesBuf[:len(c.nextBatches)])
 		c.batchesBuf = mergeStreams(c.batches, c.nextBatchesBuf, c.batchesBuf)
 		copy(c.batches[:len(c.batchesBuf)], c.batchesBuf)
 		c.batches = c.batches[:len(c.batchesBuf)]
 	}
+
+	//c.batches.Print()
 }
 
 func (c *mergeIterator) AtTime() int64 {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -8,9 +8,9 @@ import (
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
 
-type batchMergeIterator struct {
+type mergeIterator struct {
 	its []*nonOverlappingIterator
-	h   batchIteratorHeap
+	h   iteratorHeap
 
 	// Store the current sorted batchStream
 	batches batchStream
@@ -23,16 +23,16 @@ type batchMergeIterator struct {
 	currErr error
 }
 
-func newBatchMergeIterator(cs []chunk.Chunk) *batchMergeIterator {
+func newMergeIterator(cs []chunk.Chunk) *mergeIterator {
 	css := partitionChunks(cs)
 	its := make([]*nonOverlappingIterator, 0, len(css))
 	for _, cs := range css {
 		its = append(its, newNonOverlappingIterator(cs))
 	}
 
-	c := &batchMergeIterator{
+	c := &mergeIterator{
 		its: its,
-		h:   make(batchIteratorHeap, 0, len(its)),
+		h:   make(iteratorHeap, 0, len(its)),
 
 		// TODO its 2x # iterators guaranteed to be enough?
 		batches:        make(batchStream, 0, len(its)*2),
@@ -56,7 +56,7 @@ func newBatchMergeIterator(cs []chunk.Chunk) *batchMergeIterator {
 	return c
 }
 
-func (c *batchMergeIterator) Seek(t int64) bool {
+func (c *mergeIterator) Seek(t int64) bool {
 	c.h = c.h[:0]
 	c.batches = c.batches[:0]
 
@@ -77,7 +77,7 @@ func (c *batchMergeIterator) Seek(t int64) bool {
 	return len(c.batches) > 0
 }
 
-func (c *batchMergeIterator) Next() bool {
+func (c *mergeIterator) Next() bool {
 	// Pop the last built batch in a way that doesn't extend the slice.
 	if len(c.batches) > 0 {
 		copy(c.batches, c.batches[1:])
@@ -88,7 +88,7 @@ func (c *batchMergeIterator) Next() bool {
 	return len(c.batches) > 0
 }
 
-func (c *batchMergeIterator) buildNextBatch() {
+func (c *mergeIterator) buildNextBatch() {
 	// Must always consider #iters * batchsize samples, to ensure
 	// we have the opportunity to dedupe samples without missing any.
 	required := len(c.h) * promchunk.BatchSize
@@ -100,12 +100,12 @@ func (c *batchMergeIterator) buildNextBatch() {
 	for required > 0 && len(c.h) > 0 {
 		// Optimisation: if we have at least one batches, and the next batch starts
 		// after the last batch we have, we have no overlaps and can break early.
-		// if len(c.batches) > 0 {
-		// 	last := &c.batches[len(c.batches)-1]
-		// 	if last.timestamps[last.length-1] < c.h[0].AtTime() {
-		// 		break
-		// 	}
-		// }
+		if len(c.nextBatches) > 0 {
+			last := &c.nextBatches[len(c.nextBatches)-1]
+			if last.Timestamps[last.Length-1] < c.h[0].AtTime() {
+				break
+			}
+		}
 
 		b := c.h[0].Batch()
 		required -= b.Length
@@ -125,34 +125,34 @@ func (c *batchMergeIterator) buildNextBatch() {
 	}
 }
 
-func (c *batchMergeIterator) AtTime() int64 {
+func (c *mergeIterator) AtTime() int64 {
 	return c.batches[0].Timestamps[0]
 }
 
-func (c *batchMergeIterator) Batch() promchunk.Batch {
+func (c *mergeIterator) Batch() promchunk.Batch {
 	return c.batches[0]
 }
 
-func (c *batchMergeIterator) Err() error {
+func (c *mergeIterator) Err() error {
 	return c.currErr
 }
 
-type batchIteratorHeap []batchIterator
+type iteratorHeap []iterator
 
-func (h *batchIteratorHeap) Len() int      { return len(*h) }
-func (h *batchIteratorHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+func (h *iteratorHeap) Len() int      { return len(*h) }
+func (h *iteratorHeap) Swap(i, j int) { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
 
-func (h *batchIteratorHeap) Less(i, j int) bool {
+func (h *iteratorHeap) Less(i, j int) bool {
 	iT := (*h)[i].AtTime()
 	jT := (*h)[j].AtTime()
 	return iT < jT
 }
 
-func (h *batchIteratorHeap) Push(x interface{}) {
-	*h = append(*h, x.(batchIterator))
+func (h *iteratorHeap) Push(x interface{}) {
+	*h = append(*h, x.(iterator))
 }
 
-func (h *batchIteratorHeap) Pop() interface{} {
+func (h *iteratorHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -14,5 +14,6 @@ func TestMergeIter(t *testing.T) {
 	chunk4 := mkChunk(t, model.TimeFromUnix(75), 100)
 	chunk5 := mkChunk(t, model.TimeFromUnix(100), 100)
 	iter := newBatchMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 0, 200, newBatchIteratorAdapter(iter))
+	testIter(t, 200, newBatchIteratorAdapter(iter))
+	testSeek(t, 200, newBatchIteratorAdapter(iter))
 }

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -13,7 +13,7 @@ func TestMergeIter(t *testing.T) {
 	chunk3 := mkChunk(t, model.TimeFromUnix(50), 100)
 	chunk4 := mkChunk(t, model.TimeFromUnix(75), 100)
 	chunk5 := mkChunk(t, model.TimeFromUnix(100), 100)
-	iter := newBatchMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 200, newBatchIteratorAdapter(iter))
-	testSeek(t, 200, newBatchIteratorAdapter(iter))
+	iter := newMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testIter(t, 200, newIteratorAdapter(iter))
+	testSeek(t, 200, newIteratorAdapter(iter))
 }

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/weaveworks/cortex/pkg/chunk"
@@ -16,4 +17,21 @@ func TestMergeIter(t *testing.T) {
 	iter := newMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 	testIter(t, 200, newIteratorAdapter(iter))
 	testSeek(t, 200, newIteratorAdapter(iter))
+}
+
+func TestMergeHarder(t *testing.T) {
+	var (
+		numChunks = 24 * 15
+		chunks    = make([]chunk.Chunk, 0)
+		from      = model.Time(0)
+		offset    = 30
+		samples   = 100
+	)
+	for i := 0; i < numChunks; i++ {
+		chunks = append(chunks, mkChunk(t, from, samples))
+		from = from.Add(time.Duration(offset) * time.Second)
+	}
+	iter := newMergeIterator(chunks)
+	testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(iter))
+	testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(iter))
 }

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -1,0 +1,18 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+func TestMergeIter(t *testing.T) {
+	chunk1 := mkChunk(t, 0, 100)
+	chunk2 := mkChunk(t, model.TimeFromUnix(25), 100)
+	chunk3 := mkChunk(t, model.TimeFromUnix(50), 100)
+	chunk4 := mkChunk(t, model.TimeFromUnix(75), 100)
+	chunk5 := mkChunk(t, model.TimeFromUnix(100), 100)
+	iter := newBatchMergeIterator([]chunk.Chunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testIter(t, 0, 200, newBatchIteratorAdapter(iter))
+}

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -1,8 +1,6 @@
 package batch
 
 import (
-	"fmt"
-
 	"github.com/weaveworks/cortex/pkg/chunk"
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
@@ -22,119 +20,49 @@ type nonOverlappingIterator struct {
 func newNonOverlappingIterator(chunks []chunk.Chunk) *nonOverlappingIterator {
 	it := &nonOverlappingIterator{
 		chunks: chunks,
-		input:  make(batchStream, 0, bufferBatches),
-		output: make(batchStream, 0, bufferBatches),
 	}
 	it.iter.reset(it.chunks[0])
 	return it
 }
 
-func (it *nonOverlappingIterator) Seek(t int64) bool {
-	//fmt.Println("SEEK", t, it.curr)
-
-	// Seek only ever goes forward in PromQL; but as we consume more than one
-	// batch, we may have gone too far.  Therefore rewind by bufferBatches.
-	it.curr -= bufferBatches
-	if it.curr < 0 {
-		it.curr = 0
-	}
-	it.iter.reset(it.chunks[it.curr])
-	it.input = it.input[:0]
-
-	for ; it.curr < len(it.chunks); it.next() {
-		if it.iter.Seek(t) {
-			//fmt.Println("  seeked", it.curr)
-			return it.buildNextBatch()
+func (it *nonOverlappingIterator) Seek(t int64, size int) bool {
+	for {
+		if it.iter.Seek(t, size) {
+			return true
 		} else if it.iter.Err() != nil {
+			return false
+		} else if !it.next() {
 			return false
 		}
 	}
-
-	return false
 }
 
-func (it *nonOverlappingIterator) Next() bool {
-	// Drop the first cached batch in the queue.
-	if len(it.input) > 0 {
-		copy(it.input, it.input[1:])
-		it.input = it.input[:len(it.input)-1]
-	}
-
-	for ; it.curr < len(it.chunks); it.next() {
-		if it.iter.Next() {
-			return it.buildNextBatch()
+func (it *nonOverlappingIterator) Next(size int) bool {
+	for {
+		if it.iter.Next(size) {
+			return true
 		} else if it.iter.Err() != nil {
+			return false
+		} else if !it.next() {
 			return false
 		}
 	}
-
-	return len(it.input) > 0
 }
 
-func (it *nonOverlappingIterator) buildNextBatch() bool {
-	//fmt.Println("  buildNextBatch")
-
-	// When this function is called the iterator has already been next'd.
-	// We need to leave the iterator un-next'd, so it can be next'd or seek'd again.
-
-	// Need to ensure we build a batch size worth of samples which may mean we
-	// have to consume many batches, for instance if we hit chunks with only a
-	// few samples in them.
-	required := promchunk.BatchSize
-	for _, batch := range it.input {
-		required -= batch.Length
-	}
-
-	for required > 0 && it.curr < len(it.chunks) {
-		batch := it.iter.Batch()
-		//print(batch)
-		required -= batch.Length
-		it.input = append(it.input, batch)
-
-		// If we have all the samples we need then leave the current iterator
-		// un-next'd to preserver the invariants at the top of this function.
-		if required <= 0 {
-			break
-		}
-
-		for !it.iter.Next() && it.curr < len(it.chunks) {
-			if it.iter.Err() != nil {
-				return false
-			}
-			it.next()
-		}
-	}
-
-	// We have to return full batches, otherwise the implementation of merge iterator
-	// becomes harder & slower.  But in some cases we can skip it.
-	if len(it.input) > 0 && it.input[0].Length == promchunk.BatchSize {
-		return true
-	}
-
-	it.output = mergeBatches(it.input, it.output[:bufferBatches])
-	copy(it.input[:len(it.output)], it.output)
-	it.input = it.input[:len(it.output)]
-	return len(it.input) > 0
-}
-
-func print(batch promchunk.Batch) {
-	fmt.Println("  ", batch.Values, batch.Index, batch.Length)
-}
-
-func (it *nonOverlappingIterator) next() {
-	//fmt.Println("  next")
+func (it *nonOverlappingIterator) next() bool {
 	it.curr++
 	if it.curr < len(it.chunks) {
 		it.iter.reset(it.chunks[it.curr])
 	}
+	return it.curr < len(it.chunks)
 }
 
 func (it *nonOverlappingIterator) AtTime() int64 {
-	return it.input[0].Timestamps[0]
+	return it.iter.AtTime()
 }
 
 func (it *nonOverlappingIterator) Batch() promchunk.Batch {
-	return it.input[0]
+	return it.iter.Batch()
 }
 
 func (it *nonOverlappingIterator) Err() error {

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -5,6 +5,8 @@ import (
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
 
+const bufferBatches = 4
+
 type nonOverlappingIterator struct {
 	curr   int
 	chunks []chunk.Chunk
@@ -16,68 +18,96 @@ type nonOverlappingIterator struct {
 // newNonOverlappingIterator returns a single iterator over an slice of sorted,
 // non-overlapping iterators.
 func newNonOverlappingIterator(chunks []chunk.Chunk) *nonOverlappingIterator {
-	i := &nonOverlappingIterator{
+	it := &nonOverlappingIterator{
 		chunks: chunks,
-		input:  make(batchStream, 0, 2),
-		output: make(batchStream, 0, 2),
+		input:  make(batchStream, 0, bufferBatches),
+		output: make(batchStream, 0, bufferBatches),
 	}
-	i.iter.reset(chunks[0])
-	return i
+	it.iter.reset(it.chunks[0])
+	return it
+}
+
+func (it *nonOverlappingIterator) Seek(t int64) bool {
+	it.input = it.input[:0]
+	it.curr = 0
+	it.iter.reset(it.chunks[0])
+
+	for ; it.curr < len(it.chunks); it.next() {
+		if it.iter.Seek(t) {
+			return it.buildNextBatch()
+		} else if it.iter.Err() != nil {
+			return false
+		}
+	}
+
+	return false
+}
+
+func (it *nonOverlappingIterator) Next() bool {
+	// Drop the first cached batch in the queue.
+	if len(it.input) > 0 {
+		copy(it.input, it.input[1:])
+		it.input = it.input[:len(it.input)-1]
+	}
+
+	for ; it.curr < len(it.chunks); it.next() {
+		if it.iter.Next() {
+			return it.buildNextBatch()
+		} else if it.iter.Err() != nil {
+			return false
+		}
+	}
+
+	return len(it.input) > 0
+}
+
+func (it *nonOverlappingIterator) buildNextBatch() bool {
+	// When this function is called the iterator has already been next'd.
+	// We need to leave the iterator un-next'd, so it can be next'd or seek'd again.
+
+	// Need to ensure we build a batch size worth of samples which may mean we
+	// have to consume many batches, for instance if we hit chunks with only a
+	// few samples in them.
+	required := promchunk.BatchSize
+	for _, batch := range it.input {
+		required -= batch.Length
+	}
+
+	for required > 0 && it.curr < len(it.chunks) {
+		batch := it.iter.Batch()
+		required -= batch.Length
+		it.input = append(it.input, batch)
+
+		// If we have all the samples we need then leave the current iterator
+		// un-next'd to preserver the invariants at the top of this function.
+		if required <= 0 {
+			break
+		}
+
+		for !it.iter.Next() && it.curr < len(it.chunks) {
+			if it.iter.Err() != nil {
+				return false
+			}
+			it.next()
+		}
+	}
+
+	// We have to return full batches, otherwise the implementation of merge iterator
+	// becomes harder & slower.  But in some cases we can skip it.
+	if len(it.input) > 0 && it.input[0].Length == promchunk.BatchSize {
+		return true
+	}
+
+	it.output = mergeBatches(it.input, it.output[:bufferBatches])
+	copy(it.input[:len(it.output)], it.output)
+	it.input = it.input[:len(it.output)]
+	return len(it.input) > 0
 }
 
 func (it *nonOverlappingIterator) next() {
 	it.curr++
 	if it.curr < len(it.chunks) {
 		it.iter.reset(it.chunks[it.curr])
-	}
-}
-
-func (it *nonOverlappingIterator) Seek(t int64) bool {
-	for it.curr < len(it.chunks) {
-		if it.iter.Seek(t) {
-			return true
-		} else if it.iter.Err() != nil {
-			return false
-		} else {
-			it.next()
-		}
-	}
-	return false
-}
-
-func (it *nonOverlappingIterator) Next() bool {
-	switch len(it.input) {
-	case 1:
-		it.input = it.input[:0]
-	case 2:
-		it.input[0] = it.input[1]
-		it.input = it.input[:1]
-	}
-	it.buildNextBatch()
-	return len(it.input) > 0
-}
-
-func (it *nonOverlappingIterator) buildNextBatch() {
-	// We have to return full batches, otherwise the implementation of merge iterator
-	// becomes harder & slower.  But in most cases, we can skip it.
-
-	for len(it.input) < 2 && it.curr < len(it.chunks) {
-		if it.iter.Next() {
-			it.input = append(it.input, it.iter.Batch())
-		} else if it.iter.Err() != nil {
-			return
-		} else {
-			it.next()
-		}
-		if len(it.input) > 0 && it.input[0].Length == promchunk.BatchSize {
-			return
-		}
-	}
-
-	if len(it.input) > 1 {
-		it.output = mergeBatches(it.input, it.output[:2])
-		copy(it.input[:len(it.output)], it.output)
-		it.input = it.input[:len(it.output)]
 	}
 }
 

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -1,0 +1,81 @@
+package batch
+
+import (
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+type nonOverlappingIterator struct {
+	curr   int
+	chunks []*chunkIterator
+	input  batchStream
+	output batchStream
+}
+
+// newNonOverlappingIterator returns a single iterator over an slice of sorted,
+// non-overlapping iterators.
+func newNonOverlappingIterator(chunks []chunk.Chunk) *nonOverlappingIterator {
+	its := make([]*chunkIterator, 0, len(chunks))
+	for _, c := range chunks {
+		its = append(its, newChunkIterator(c))
+	}
+
+	return &nonOverlappingIterator{
+		chunks: its,
+		input:  make(batchStream, 0, 2),
+		output: make(batchStream, 0, 2),
+	}
+}
+
+func (it *nonOverlappingIterator) Seek(t int64) bool {
+	for ; it.curr < len(it.chunks); it.curr++ {
+		if it.chunks[it.curr].Seek(t) {
+			return true
+		} else if it.chunks[it.curr].Err() != nil {
+			return false
+		}
+	}
+
+	return false
+}
+
+func (it *nonOverlappingIterator) Next() bool {
+	switch len(it.input) {
+	case 1:
+		it.input = it.input[:0]
+	case 2:
+		it.input[0] = it.input[1]
+		it.input = it.input[:1]
+	}
+	it.buildNextBatch()
+	return len(it.input) > 0
+}
+
+func (it *nonOverlappingIterator) buildNextBatch() {
+	for len(it.input) < 2 && it.curr < len(it.chunks) {
+		if it.chunks[it.curr].Next() {
+			it.input = append(it.input, it.chunks[it.curr].Batch())
+		} else if it.chunks[it.curr].Err() != nil {
+			return
+		} else {
+			it.curr++
+		}
+	}
+	it.output = mergeBatches(it.input, it.output[:2])
+	copy(it.input[:len(it.output)], it.output)
+	it.input = it.input[:len(it.output)]
+}
+
+func (it *nonOverlappingIterator) AtTime() int64 {
+	return it.input[0].timestamps[0]
+}
+
+func (it *nonOverlappingIterator) Batch() batch {
+	return it.input[0]
+}
+
+func (it *nonOverlappingIterator) Err() error {
+	if it.curr < len(it.chunks) {
+		return it.chunks[it.curr].Err()
+	}
+	return nil
+}

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -1,0 +1,17 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+func TestNonOverlappingIter(t *testing.T) {
+	cs := []chunk.Chunk{}
+	for i := int64(0); i < 100; i++ {
+		cs = append(cs, mkChunk(t, model.TimeFromUnix(i*100), 100))
+	}
+	iter := newNonOverlappingIterator(cs)
+	testIter(t, 0, 100*100, newBatchIteratorAdapter(iter))
+}

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -12,8 +12,8 @@ func TestNonOverlappingIter(t *testing.T) {
 	for i := int64(0); i < 100; i++ {
 		cs = append(cs, mkChunk(t, model.TimeFromUnix(i*10), 10))
 	}
-	testIter(t, 10*100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
-	testSeek(t, 10*100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
+	testIter(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)))
+	testSeek(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)))
 }
 
 func TestNonOverlappingIterSparse(t *testing.T) {
@@ -25,6 +25,6 @@ func TestNonOverlappingIterSparse(t *testing.T) {
 		mkChunk(t, model.TimeFromUnix(95), 1),
 		mkChunk(t, model.TimeFromUnix(96), 4),
 	}
-	testIter(t, 100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
-	testSeek(t, 100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
+	testIter(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)))
+	testSeek(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)))
 }

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -10,8 +10,21 @@ import (
 func TestNonOverlappingIter(t *testing.T) {
 	cs := []chunk.Chunk{}
 	for i := int64(0); i < 100; i++ {
-		cs = append(cs, mkChunk(t, model.TimeFromUnix(i*100), 100))
+		cs = append(cs, mkChunk(t, model.TimeFromUnix(i*10), 10))
 	}
-	iter := newNonOverlappingIterator(cs)
-	testIter(t, 0, 100*100, newBatchIteratorAdapter(iter))
+	testIter(t, 10*100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
+	testSeek(t, 10*100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
+}
+
+func TestNonOverlappingIterSparse(t *testing.T) {
+	cs := []chunk.Chunk{
+		mkChunk(t, model.TimeFromUnix(0), 1),
+		mkChunk(t, model.TimeFromUnix(1), 3),
+		mkChunk(t, model.TimeFromUnix(4), 1),
+		mkChunk(t, model.TimeFromUnix(5), 90),
+		mkChunk(t, model.TimeFromUnix(95), 1),
+		mkChunk(t, model.TimeFromUnix(96), 4),
+	}
+	testIter(t, 100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
+	testSeek(t, 100, newBatchIteratorAdapter(newNonOverlappingIterator(cs)))
 }

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -1,6 +1,8 @@
 package batch
 
 import (
+	"fmt"
+
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
 
@@ -8,6 +10,14 @@ import (
 // and building new slices of non-overlapping batches.  Designed to be used
 // without allocations.
 type batchStream []promchunk.Batch
+
+func (bs batchStream) Print() {
+	fmt.Println("[")
+	for _, b := range bs {
+		print(b)
+	}
+	fmt.Println("]")
+}
 
 // append, reset, hasNext, next, atTime etc are all inlined in go1.11.
 // append isn't a pointer receiver as that was causing bs to escape to the heap.

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -1,0 +1,108 @@
+package batch
+
+import "fmt"
+
+// batchStream deals with iteratoring through multiple, non-overlapping batches,
+// and building new slices of non-overlapping batches.
+type batchStream []batch
+
+func (bs batchStream) Print() {
+	fmt.Println("[")
+	for _, b := range bs {
+		b.Print()
+	}
+	fmt.Println("]")
+}
+
+func (bs *batchStream) append(t int64, v float64) {
+	if len(*bs) == 0 || (*bs)[len(*bs)-1].index == batchSize {
+		*bs = append(*bs, batch{})
+	}
+	b := &(*bs)[len(*bs)-1]
+	b.timestamps[b.index] = t
+	b.values[b.index] = v
+	b.index++
+	b.length++
+}
+
+func (bs *batchStream) reset() {
+	for i := range *bs {
+		(*bs)[i].index = 0
+	}
+}
+
+func (bs *batchStream) hasNext() bool {
+	return len(*bs) > 0
+}
+
+func (bs *batchStream) next() {
+	(*bs)[0].index++
+	if (*bs)[0].index >= (*bs)[0].length {
+		*bs = (*bs)[1:]
+	}
+}
+
+// destructively iterate through the stream of batches.
+func (bs *batchStream) at() (int64, float64) {
+	b := &(*bs)[0]
+	return b.timestamps[b.index], b.values[b.index]
+}
+
+func (bs batchStream) len() int {
+	result := 0
+	for i := range bs {
+		result += (bs)[i].length
+	}
+	return result
+}
+
+func mergeBatches(batches batchStream, result batchStream) batchStream {
+	switch len(batches) {
+	case 0:
+		return nil
+	case 1:
+		copy(result[:1], batches)
+		return result[:1]
+	case 2:
+		return mergeStreams(batches[0:1], batches[1:2], result)
+	default:
+		n := len(batches) / 2
+		left := mergeBatches(batches[n:], result[n:])
+		right := mergeBatches(batches[:n], result[:n])
+
+		batches = mergeStreams(left, right, batches)
+		result = result[:len(batches)]
+		copy(result, batches)
+
+		return result[:len(batches)]
+	}
+}
+
+func mergeStreams(left, right batchStream, result batchStream) batchStream {
+	result.reset()
+	result = result[:0]
+
+	for left.hasNext() && right.hasNext() {
+		t1, v1 := left.at()
+		t2, v2 := right.at()
+		if t1 < t2 {
+			result.append(t1, v1)
+			left.next()
+		} else if t1 > t2 {
+			result.append(t2, v2)
+			right.next()
+		} else {
+			result.append(t1, v1)
+			left.next()
+			right.next()
+		}
+	}
+	for ; left.hasNext(); left.next() {
+		result.append(left.at())
+	}
+	for ; right.hasNext(); right.next() {
+		result.append(right.at())
+	}
+	result.reset()
+	return result
+}

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -45,7 +45,7 @@ func TestStream(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			result := make(batchStream, len(tc.input))
-			result = mergeBatches(tc.input, result)
+			result = mergeBatches(tc.input, result, promchunk.BatchSize)
 			require.Equal(t, batchStream(tc.output), result)
 		})
 	}

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -1,0 +1,61 @@
+package batch
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStream(t *testing.T) {
+	for i, tc := range []struct {
+		input  []batch
+		output batchStream
+	}{
+		{
+			input:  []batch{mkBatch(0)},
+			output: []batch{mkBatch(0)},
+		},
+
+		{
+			input:  []batch{mkBatch(0), mkBatch(0)},
+			output: []batch{mkBatch(0)},
+		},
+
+		{
+			input:  []batch{mkBatch(0), mkBatch(batchSize)},
+			output: []batch{mkBatch(0), mkBatch(batchSize)},
+		},
+
+		{
+			input:  []batch{mkBatch(0), mkBatch(batchSize), mkBatch(0), mkBatch(batchSize)},
+			output: []batch{mkBatch(0), mkBatch(batchSize)},
+		},
+
+		{
+			input:  []batch{mkBatch(0), mkBatch(batchSize / 2), mkBatch(batchSize)},
+			output: []batch{mkBatch(0), mkBatch(batchSize)},
+		},
+
+		{
+			input:  []batch{mkBatch(0), mkBatch(batchSize / 2), mkBatch(batchSize), mkBatch(3 * batchSize / 2), mkBatch(2 * batchSize)},
+			output: []batch{mkBatch(0), mkBatch(batchSize), mkBatch(2 * batchSize)},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			result := make(batchStream, len(tc.input))
+			result = mergeBatches(tc.input, result)
+			require.Equal(t, batchStream(tc.output), result)
+		})
+	}
+}
+
+func mkBatch(from int64) batch {
+	var result batch
+	for i := int64(0); i < batchSize; i++ {
+		result.timestamps[i] = from + i
+		result.values[i] = float64(from + i)
+	}
+	result.length = batchSize
+	return result
+}

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -5,41 +5,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
 
 func TestStream(t *testing.T) {
 	for i, tc := range []struct {
-		input  []batch
+		input  []promchunk.Batch
 		output batchStream
 	}{
 		{
-			input:  []batch{mkBatch(0)},
-			output: []batch{mkBatch(0)},
+			input:  []promchunk.Batch{mkBatch(0)},
+			output: []promchunk.Batch{mkBatch(0)},
 		},
 
 		{
-			input:  []batch{mkBatch(0), mkBatch(0)},
-			output: []batch{mkBatch(0)},
+			input:  []promchunk.Batch{mkBatch(0), mkBatch(0)},
+			output: []promchunk.Batch{mkBatch(0)},
 		},
 
 		{
-			input:  []batch{mkBatch(0), mkBatch(batchSize)},
-			output: []batch{mkBatch(0), mkBatch(batchSize)},
+			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
+			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
 		},
 
 		{
-			input:  []batch{mkBatch(0), mkBatch(batchSize), mkBatch(0), mkBatch(batchSize)},
-			output: []batch{mkBatch(0), mkBatch(batchSize)},
+			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(0), mkBatch(promchunk.BatchSize)},
+			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
 		},
 
 		{
-			input:  []batch{mkBatch(0), mkBatch(batchSize / 2), mkBatch(batchSize)},
-			output: []batch{mkBatch(0), mkBatch(batchSize)},
+			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize / 2), mkBatch(promchunk.BatchSize)},
+			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize)},
 		},
 
 		{
-			input:  []batch{mkBatch(0), mkBatch(batchSize / 2), mkBatch(batchSize), mkBatch(3 * batchSize / 2), mkBatch(2 * batchSize)},
-			output: []batch{mkBatch(0), mkBatch(batchSize), mkBatch(2 * batchSize)},
+			input:  []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize / 2), mkBatch(promchunk.BatchSize), mkBatch(3 * promchunk.BatchSize / 2), mkBatch(2 * promchunk.BatchSize)},
+			output: []promchunk.Batch{mkBatch(0), mkBatch(promchunk.BatchSize), mkBatch(2 * promchunk.BatchSize)},
 		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -50,12 +51,12 @@ func TestStream(t *testing.T) {
 	}
 }
 
-func mkBatch(from int64) batch {
-	var result batch
-	for i := int64(0); i < batchSize; i++ {
-		result.timestamps[i] = from + i
-		result.values[i] = float64(from + i)
+func mkBatch(from int64) promchunk.Batch {
+	var result promchunk.Batch
+	for i := int64(0); i < promchunk.BatchSize; i++ {
+		result.Timestamps[i] = from + i
+		result.Values[i] = float64(from + i)
 	}
-	result.length = batchSize
+	result.Length = promchunk.BatchSize
 	return result
 }

--- a/pkg/querier/benchmark_test.go
+++ b/pkg/querier/benchmark_test.go
@@ -10,10 +10,10 @@ import (
 var result *promql.Result
 
 func BenchmarkChunkQueryable(b *testing.B) {
-	for _, queryable := range queryables {
+	for _, query := range queries {
 		for _, encoding := range encodings {
-			for _, query := range queries {
-				b.Run(fmt.Sprintf("%s/%s/%s", queryable.name, encoding.name, query.query), func(b *testing.B) {
+			for _, queryable := range queryables {
+				b.Run(fmt.Sprintf("%s/step_%s/%s/%s/", query.query, query.step, encoding.name, queryable.name), func(b *testing.B) {
 					store, from := makeMockChunkStore(b, 24*30, encoding.e)
 					b.ResetTimer()
 

--- a/pkg/querier/benchmark_test.go
+++ b/pkg/querier/benchmark_test.go
@@ -10,13 +10,13 @@ import (
 var result *promql.Result
 
 func BenchmarkChunkQueryable(b *testing.B) {
-	for _, encoding := range encodings {
-		store, from := makeMockChunkStore(b, 24*30, encoding.e)
-		b.ResetTimer()
-
-		for _, queryable := range queryables {
+	for _, queryable := range queryables {
+		for _, encoding := range encodings {
 			for _, query := range queries {
 				b.Run(fmt.Sprintf("%s/%s/%s", queryable.name, encoding.name, query.query), func(b *testing.B) {
+					store, from := makeMockChunkStore(b, 24*30, encoding.e)
+					b.ResetTimer()
+
 					var r *promql.Result
 					for n := 0; n < b.N; n++ {
 						r = testQuery(b, queryable.f(store), from, query)

--- a/pkg/querier/chunk_iterator.go
+++ b/pkg/querier/chunk_iterator.go
@@ -2,17 +2,9 @@ package querier
 
 import (
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
-
-func NewChunkIterator(c chunk.Chunk) storage.SeriesIterator {
-	return &chunkIterator{
-		Chunk: c,
-		it:    c.Data.NewIterator(),
-	}
-}
 
 type chunkIterator struct {
 	chunk.Chunk

--- a/pkg/querier/chunk_iterator.go
+++ b/pkg/querier/chunk_iterator.go
@@ -2,9 +2,17 @@ package querier
 
 import (
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/cortex/pkg/chunk"
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 )
+
+func NewChunkIterator(c chunk.Chunk) storage.SeriesIterator {
+	return &chunkIterator{
+		Chunk: c,
+		it:    c.Data.NewIterator(),
+	}
+}
 
 type chunkIterator struct {
 	chunk.Chunk

--- a/pkg/querier/chunk_merge_iterator.go
+++ b/pkg/querier/chunk_merge_iterator.go
@@ -3,15 +3,10 @@ package querier
 import (
 	"container/heap"
 	"sort"
-	"time"
 
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/cortex/pkg/chunk"
 )
-
-// Limit on the window size of seeks.
-const window = 24 * time.Hour
-const chunkSize = 12 * time.Hour
 
 type chunkMergeIterator struct {
 	its []*nonOverlappingIterator

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ var (
 		name string
 		e    promchunk.Encoding
 	}{
-		{"DoubleDelta", promchunk.DoubleDelta},
+		//{"DoubleDelta", promchunk.DoubleDelta},
 		{"Varbit", promchunk.Varbit},
 	}
 
@@ -182,10 +183,10 @@ func testQuery(t require.TestingT, queryable storage.Queryable, end model.Time, 
 	require.Equal(t, q.labels, series.Metric)
 	require.Equal(t, q.samples(from, through, step), len(series.Points))
 	var ts int64
-	for _, point := range series.Points {
+	for i, point := range series.Points {
 		expectedTime, expectedValue := q.expected(ts)
-		require.EqualValues(t, expectedTime, point.T)
-		require.EqualValues(t, expectedValue, point.V)
+		require.Equal(t, expectedTime, point.T, strconv.Itoa(i))
+		require.Equal(t, expectedValue, point.V, strconv.Itoa(i))
 		ts += int64(step / time.Millisecond)
 	}
 	return r

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -32,6 +32,7 @@ type query struct {
 	labels   labels.Labels
 	samples  func(from, through time.Time, step time.Duration) int
 	expected func(t int64) (int64, float64)
+	step     time.Duration
 }
 
 var (
@@ -53,8 +54,25 @@ var (
 	}
 
 	queries = []query{
+		// Windowed rates with small step;  This will cause BufferedIterator to read
+		// all the samples.
+		{
+			query:  "rate(foo[1m])",
+			step:   sampleRate * 4,
+			labels: labels.Labels{},
+			samples: func(from, through time.Time, step time.Duration) int {
+				return int(through.Sub(from) / step)
+			},
+			expected: func(t int64) (int64, float64) {
+				return t + int64((sampleRate*4)/time.Millisecond), 1000.0
+			},
+		},
+
+		// Very simple single-point gets, with low step.  Performance should be
+		// similar to above.
 		{
 			query: "foo",
+			step:  sampleRate * 4,
 			labels: labels.Labels{
 				labels.Label{"__name__", "foo"},
 			},
@@ -66,14 +84,31 @@ var (
 			},
 		},
 
+		// Rates with large step; excersise everything.
 		{
 			query:  "rate(foo[1m])",
+			step:   sampleRate * 4 * 10,
 			labels: labels.Labels{},
 			samples: func(from, through time.Time, step time.Duration) int {
 				return int(through.Sub(from) / step)
 			},
 			expected: func(t int64) (int64, float64) {
-				return t + int64((sampleRate*4)/time.Millisecond), 1000.0
+				return t + int64((sampleRate*4)/time.Millisecond)*10, 1000.0
+			},
+		},
+
+		// Single points gets with large step; excersise Seek performance.
+		{
+			query: "foo",
+			step:  sampleRate * 4 * 10,
+			labels: labels.Labels{
+				labels.Label{"__name__", "foo"},
+			},
+			samples: func(from, through time.Time, step time.Duration) int {
+				return int(through.Sub(from)/step) + 1
+			},
+			expected: func(t int64) (int64, float64) {
+				return t, float64(t)
 			},
 		},
 	}
@@ -83,7 +118,7 @@ func TestChunkQueryable(t *testing.T) {
 	for _, queryable := range queryables {
 		for _, encoding := range encodings {
 			for _, query := range queries {
-				t.Run(fmt.Sprintf("%s/%s/%s", queryable.name, encoding.name, query.query), func(t *testing.T) {
+				t.Run(fmt.Sprintf("%s/%s/%s (%s step)", queryable.name, encoding.name, query.query, query.step), func(t *testing.T) {
 					store, from := makeMockChunkStore(t, 24*15, encoding.e)
 					queryable := queryable.f(store)
 					testQuery(t, queryable, from, query)
@@ -133,7 +168,7 @@ func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, enco
 }
 
 func testQuery(t require.TestingT, queryable storage.Queryable, end model.Time, q query) *promql.Result {
-	from, through, step := time.Unix(0, 0), end.Time(), sampleRate*4
+	from, through, step := time.Unix(0, 0), end.Time(), q.step
 	engine := promql.NewEngine(util.Logger, nil, 10, 1*time.Minute)
 	query, err := engine.NewRangeQuery(queryable, q.query, from, through, step)
 	require.NoError(t, err)
@@ -149,8 +184,8 @@ func testQuery(t require.TestingT, queryable storage.Queryable, end model.Time, 
 	var ts int64
 	for _, point := range series.Points {
 		expectedTime, expectedValue := q.expected(ts)
-		require.Equal(t, expectedTime, point.T)
-		require.Equal(t, expectedValue, point.V)
+		require.EqualValues(t, expectedTime, point.T)
+		require.EqualValues(t, expectedValue, point.V)
 		ts += int64(step / time.Millisecond)
 	}
 	return r

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -50,22 +50,22 @@ var (
 		e    promchunk.Encoding
 	}{
 		{"DoubleDelta", promchunk.DoubleDelta},
-		//		{"Varbit", promchunk.Varbit},
+		{"Varbit", promchunk.Varbit},
 	}
 
 	queries = []query{
-		//		{
-		//			query: "foo",
-		//			labels: labels.Labels{
-		//				labels.Label{"__name__", "foo"},
-		//			},
-		//			samples: func(from, through time.Time, step time.Duration) int {
-		//				return int(through.Sub(from)/step) + 1
-		//			},
-		//			expected: func(t int64) (int64, float64) {
-		//				return t, float64(t)
-		//			},
-		//		},
+		{
+			query: "foo",
+			labels: labels.Labels{
+				labels.Label{"__name__", "foo"},
+			},
+			samples: func(from, through time.Time, step time.Duration) int {
+				return int(through.Sub(from)/step) + 1
+			},
+			expected: func(t int64) (int64, float64) {
+				return t, float64(t)
+			},
+		},
 
 		{
 			query:  "rate(foo[1m])",

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/weaveworks/cortex/pkg/chunk"
 	promchunk "github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
+	"github.com/weaveworks/cortex/pkg/querier/batch"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -41,6 +42,7 @@ var (
 	}{
 		{"matrixes", newChunkQueryable},
 		{"iterators", newIterChunkQueryable(newChunkMergeIterator)},
+		{"batches", newIterChunkQueryable(batch.NewChunkMergeIterator)},
 	}
 
 	encodings = []struct {
@@ -48,22 +50,22 @@ var (
 		e    promchunk.Encoding
 	}{
 		{"DoubleDelta", promchunk.DoubleDelta},
-		{"Varbit", promchunk.Varbit},
+		//		{"Varbit", promchunk.Varbit},
 	}
 
 	queries = []query{
-		{
-			query: "foo",
-			labels: labels.Labels{
-				labels.Label{"__name__", "foo"},
-			},
-			samples: func(from, through time.Time, step time.Duration) int {
-				return int(through.Sub(from)/step) + 1
-			},
-			expected: func(t int64) (int64, float64) {
-				return t, float64(t)
-			},
-		},
+		//		{
+		//			query: "foo",
+		//			labels: labels.Labels{
+		//				labels.Label{"__name__", "foo"},
+		//			},
+		//			samples: func(from, through time.Time, step time.Duration) int {
+		//				return int(through.Sub(from)/step) + 1
+		//			},
+		//			expected: func(t int64) (int64, float64) {
+		//				return t, float64(t)
+		//			},
+		//		},
 
 		{
 			query:  "rate(foo[1m])",
@@ -144,13 +146,13 @@ func testQuery(t require.TestingT, queryable storage.Queryable, end model.Time, 
 	require.Len(t, m, 1)
 	series := m[0]
 	assert.Equal(t, q.labels, series.Metric)
-	assert.Equal(t, q.samples(from, through, step), len(series.Points))
-	var ts int64
-	for _, point := range series.Points {
-		expectedTime, expectedValue := q.expected(ts)
-		assert.Equal(t, expectedTime, point.T)
-		assert.Equal(t, expectedValue, point.V)
-		ts += int64(step / time.Millisecond)
-	}
+	//assert.Equal(t, q.samples(from, through, step), len(series.Points))
+	//var ts int64
+	//for _, point := range series.Points {
+	//	expectedTime, expectedValue := q.expected(ts)
+	//	//assert.Equal(t, expectedTime, point.T)
+	//	//assert.Equal(t, expectedValue, point.V)
+	//	ts += int64(step / time.Millisecond)
+	//}
 	return r
 }

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -120,7 +120,7 @@ func TestChunkQueryable(t *testing.T) {
 		for _, encoding := range encodings {
 			for _, query := range queries {
 				t.Run(fmt.Sprintf("%s/%s/%s (%s step)", queryable.name, encoding.name, query.query, query.step), func(t *testing.T) {
-					store, from := makeMockChunkStore(t, 24*15, encoding.e)
+					store, from := makeMockChunkStore(t, 24*2, encoding.e)
 					queryable := queryable.f(store)
 					testQuery(t, queryable, from, query)
 				})

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -50,7 +50,7 @@ var (
 		name string
 		e    promchunk.Encoding
 	}{
-		//{"DoubleDelta", promchunk.DoubleDelta},
+		{"DoubleDelta", promchunk.DoubleDelta},
 		{"Varbit", promchunk.Varbit},
 	}
 

--- a/pkg/querier/chunk_queryable_test.go
+++ b/pkg/querier/chunk_queryable_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
@@ -145,14 +144,14 @@ func testQuery(t require.TestingT, queryable storage.Queryable, end model.Time, 
 
 	require.Len(t, m, 1)
 	series := m[0]
-	assert.Equal(t, q.labels, series.Metric)
-	//assert.Equal(t, q.samples(from, through, step), len(series.Points))
-	//var ts int64
-	//for _, point := range series.Points {
-	//	expectedTime, expectedValue := q.expected(ts)
-	//	//assert.Equal(t, expectedTime, point.T)
-	//	//assert.Equal(t, expectedValue, point.V)
-	//	ts += int64(step / time.Millisecond)
-	//}
+	require.Equal(t, q.labels, series.Metric)
+	require.Equal(t, q.samples(from, through, step), len(series.Points))
+	var ts int64
+	for _, point := range series.Points {
+		expectedTime, expectedValue := q.expected(ts)
+		require.Equal(t, expectedTime, point.T)
+		require.Equal(t, expectedValue, point.V)
+		ts += int64(step / time.Millisecond)
+	}
 	return r
 }


### PR DESCRIPTION
The idea here is that instead of fetching 1 sample per iteration, fetch N.  This should reduce the amount of work we have to do in the heap etc.  The tradeoff is you have to fetch and repeatedly merge/dedupe "a bunch" of batches each time round.

To find the "optimal" batch size I ran `BenchmarkChunkQueryable/batches/DoubleDelta/foo-4` for all sizes between 1 and 128 (three runs, blue&red with go1.10 and yellow with go1.11):

<img width="599" alt="screen shot 2018-08-27 at 13 12 50" src="https://user-images.githubusercontent.com/444037/44659097-eee98680-a9fa-11e8-9fd4-166aaa4e29d1.png">

The batches themselves are designs to be passed by value; the various helpers we use to merge them are designs to be used in such a way that doesn't require any allocations.  Various optimisations have been put in place, such as pushing the building of the batch into the chunk iterator.  See changesets for more details.

```
$ go test -v -run BenchmarkChunkQueryable  -bench . -benchmem  ./pkg/querier
goos: darwin
goarch: amd64
pkg: github.com/weaveworks/cortex/pkg/querier
BenchmarkChunkQueryable/matrixes/DoubleDelta/foo-4         	              30	  36926014 ns/op	65185358 B/op	  183176 allocs/op
BenchmarkChunkQueryable/matrixes/DoubleDelta/rate(foo[1m])-4         	      30	  43569770 ns/op	65186988 B/op	  183204 allocs/op
BenchmarkChunkQueryable/matrixes/Varbit/foo-4                        	      30	  35299491 ns/op	65185008 B/op	  182455 allocs/op
BenchmarkChunkQueryable/matrixes/Varbit/rate(foo[1m])-4              	      30	  47907959 ns/op	65187004 B/op	  182484 allocs/op
BenchmarkChunkQueryable/iterators/DoubleDelta/foo-4                  	      30	  56106730 ns/op	 2896774 B/op	  176738 allocs/op
BenchmarkChunkQueryable/iterators/DoubleDelta/rate(foo[1m])-4        	      20	  59507487 ns/op	 2897760 B/op	  176763 allocs/op
BenchmarkChunkQueryable/iterators/Varbit/foo-4                       	      30	  53194401 ns/op	 2896438 B/op	  176017 allocs/op
BenchmarkChunkQueryable/iterators/Varbit/rate(foo[1m])-4             	      20	  57777478 ns/op	 2897912 B/op	  176044 allocs/op
BenchmarkChunkQueryable/batches/DoubleDelta/foo-4                    	      50	  28638027 ns/op	 2986621 B/op	  176005 allocs/op
BenchmarkChunkQueryable/batches/DoubleDelta/rate(foo[1m])-4          	      50	  35413291 ns/op	 2988053 B/op	  176032 allocs/op
BenchmarkChunkQueryable/batches/Varbit/foo-4                         	      50	  31568996 ns/op	 2986538 B/op	  175281 allocs/op
BenchmarkChunkQueryable/batches/Varbit/rate(foo[1m])-4               	      50	  35227848 ns/op	 2987903 B/op	  175308 allocs/op
PASS
ok  	github.com/weaveworks/cortex/pkg/querier	21.112s
```

For doubledelta, the batch iterators are ~20% faster that the "big bang" merge, and ~50% faster than samples-by-sample iterators (ie twice the speed), all while using almost the same memory and allocations as the samples-by-sample iterators.
