### PR TITLE
Batch index lookups on BigTable

### DIFF
--- a/pkg/chunk/aws/storage_client.go
+++ b/pkg/chunk/aws/storage_client.go
@@ -289,8 +289,8 @@ func (a storageClient) BatchWrite(ctx context.Context, input chunk.WriteBatch) e
 	return backoff.Err()
 }
 
-func (s storageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
-	return chunk_util.DoParallelQueries(ctx, s.query, queries, callback)
+func (a storageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
+	return chunk_util.DoParallelQueries(ctx, a.query, queries, callback)
 }
 
 func (a storageClient) query(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
@@ -363,7 +363,7 @@ func (a storageClient) query(ctx context.Context, query chunk.IndexQuery, callba
 	return nil
 }
 
-func (a storageClient) queryPage(ctx context.Context, input *dynamodb.QueryInput, page dynamoDBRequest) (dynamoDBReadResponse, error) {
+func (a storageClient) queryPage(ctx context.Context, input *dynamodb.QueryInput, page dynamoDBRequest) (*dynamoDBReadResponse, error) {
 	backoff := util.NewBackoff(ctx, a.cfg.backoffConfig)
 	defer func() {
 		dynamoQueryRetryCount.WithLabelValues("queryPage").Observe(float64(backoff.NumRetries()))
@@ -393,7 +393,10 @@ func (a storageClient) queryPage(ctx context.Context, input *dynamodb.QueryInput
 		}
 
 		queryOutput := page.Data().(*dynamodb.QueryOutput)
-		return dynamoDBReadResponse(queryOutput.Items), nil
+		return &dynamoDBReadResponse{
+			i:     -1,
+			items: queryOutput.Items,
+		}, nil
 	}
 	return nil, fmt.Errorf("QueryPage error: %s for table %v, last error %v", backoff.Err(), *input.TableName, err)
 }
@@ -777,18 +780,22 @@ func (a storageClient) putS3Chunk(ctx context.Context, key string, buf []byte) e
 }
 
 // Slice of values returned; map key is attribute name
-type dynamoDBReadResponse []map[string]*dynamodb.AttributeValue
-
-func (b dynamoDBReadResponse) Len() int {
-	return len(b)
+type dynamoDBReadResponse struct {
+	i     int
+	items []map[string]*dynamodb.AttributeValue
 }
 
-func (b dynamoDBReadResponse) RangeValue(i int) []byte {
-	return b[i][rangeKey].B
+func (b *dynamoDBReadResponse) Next() bool {
+	b.i++
+	return b.i < len(b.items)
 }
 
-func (b dynamoDBReadResponse) Value(i int) []byte {
-	chunkValue, ok := b[i][valueKey]
+func (b *dynamoDBReadResponse) RangeValue() []byte {
+	return b.items[b.i][rangeKey].B
+}
+
+func (b *dynamoDBReadResponse) Value() []byte {
+	chunkValue, ok := b.items[b.i][valueKey]
 	if !ok {
 		return nil
 	}

--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/chunk/util"
 )
 
 const (
@@ -172,7 +173,11 @@ func (s *storageClient) BatchWrite(ctx context.Context, batch chunk.WriteBatch) 
 	return nil
 }
 
-func (s *storageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
+func (s *storageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) bool) error {
+	return util.DoParallelQueries(ctx, s.query, queries, callback)
+}
+
+func (s *storageClient) query(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
 	var q *gocql.Query
 
 	switch {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -412,38 +412,8 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, from, through mode
 }
 
 func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
-	incomingEntries := make(chan []IndexEntry)
-	incomingErrors := make(chan error)
-	for _, query := range queries {
-		go func(query IndexQuery) {
-			entries, err := c.lookupEntriesByQuery(ctx, query)
-			if err != nil {
-				incomingErrors <- err
-			} else {
-				incomingEntries <- entries
-			}
-		}(query)
-	}
-
-	// Combine the results into one slice
 	var entries []IndexEntry
-	var lastErr error
-	for i := 0; i < len(queries); i++ {
-		select {
-		case incoming := <-incomingEntries:
-			entries = append(entries, incoming...)
-		case err := <-incomingErrors:
-			lastErr = err
-		}
-	}
-
-	return entries, lastErr
-}
-
-func (c *store) lookupEntriesByQuery(ctx context.Context, query IndexQuery) ([]IndexEntry, error) {
-	var entries []IndexEntry
-
-	if err := c.storage.QueryPages(ctx, query, func(resp ReadBatch) (shouldContinue bool) {
+	err := c.storage.QueryPages(ctx, queries, func(query IndexQuery, resp ReadBatch) bool {
 		for i := 0; i < resp.Len(); i++ {
 			entries = append(entries, IndexEntry{
 				TableName:  query.TableName,
@@ -453,12 +423,8 @@ func (c *store) lookupEntriesByQuery(ctx context.Context, query IndexQuery) ([]I
 			})
 		}
 		return true
-	}); err != nil {
-		level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "error querying storage", "err", err)
-		return nil, err
-	}
-
-	return entries, nil
+	})
+	return entries, err
 }
 
 func (c *store) parseIndexEntries(ctx context.Context, entries []IndexEntry, matcher *labels.Matcher) ([]string, error) {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -424,6 +424,9 @@ func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery
 		}
 		return true
 	})
+	if err != nil {
+		level.Error(util.WithContext(ctx, util.Logger)).Log("msg", "error querying storage", "err", err)
+	}
 	return entries, err
 }
 

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -414,12 +414,12 @@ func (c *store) lookupChunksByMetricName(ctx context.Context, from, through mode
 func (c *store) lookupEntriesByQueries(ctx context.Context, queries []IndexQuery) ([]IndexEntry, error) {
 	var entries []IndexEntry
 	err := c.storage.QueryPages(ctx, queries, func(query IndexQuery, resp ReadBatch) bool {
-		for i := 0; i < resp.Len(); i++ {
+		for resp.Next() {
 			entries = append(entries, IndexEntry{
 				TableName:  query.TableName,
 				HashValue:  query.HashValue,
-				RangeValue: resp.RangeValue(i),
-				Value:      resp.Value(i),
+				RangeValue: resp.RangeValue(),
+				Value:      resp.Value(),
 			})
 		}
 		return true

--- a/pkg/chunk/gcp/storage_client.go
+++ b/pkg/chunk/gcp/storage_client.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	columnFamily = "f"
+	columnPrefix = columnFamily + ":"
 	column       = "c"
 	separator    = "\000"
 	maxRowReads  = 100
@@ -218,9 +219,8 @@ func (s *storageClientColumnKey) QueryPages(ctx context.Context, queries []chunk
 					}
 
 					return callback(query, &bigtableReadBatchColumnKey{
-						i:            -1,
-						items:        val,
-						columnPrefix: columnFamily + ":",
+						i:     -1,
+						items: val,
 					})
 				})
 
@@ -286,18 +286,16 @@ func (s *storageClientColumnKey) query(ctx context.Context, query chunk.IndexQue
 		val = filteredItems
 	}
 	callback(&bigtableReadBatchColumnKey{
-		i:            -1,
-		items:        val,
-		columnPrefix: columnFamily + ":",
+		i:     -1,
+		items: val,
 	})
 	return nil
 }
 
 // bigtableReadBatchColumnKey represents a batch of values read from Bigtable.
 type bigtableReadBatchColumnKey struct {
-	i            int
-	items        []bigtable.ReadItem
-	columnPrefix string
+	i     int
+	items []bigtable.ReadItem
 }
 
 func (b *bigtableReadBatchColumnKey) Next() bool {
@@ -306,7 +304,7 @@ func (b *bigtableReadBatchColumnKey) Next() bool {
 }
 
 func (b *bigtableReadBatchColumnKey) RangeValue() []byte {
-	return []byte(strings.TrimPrefix(b.items[b.i].Column, b.columnPrefix))
+	return []byte(strings.TrimPrefix(b.items[b.i].Column, columnPrefix))
 }
 
 func (b *bigtableReadBatchColumnKey) Value() []byte {

--- a/pkg/chunk/storage/caching_storage_client.go
+++ b/pkg/chunk/storage/caching_storage_client.go
@@ -1,13 +1,12 @@
 package storage
 
 import (
-	"bytes"
 	"context"
-	"strings"
 	"time"
 
 	"github.com/weaveworks/cortex/pkg/chunk"
 	"github.com/weaveworks/cortex/pkg/chunk/cache"
+	chunk_util "github.com/weaveworks/cortex/pkg/chunk/util"
 )
 
 type cachingStorageClient struct {
@@ -27,87 +26,48 @@ func newCachingStorageClient(client chunk.StorageClient, size int, validity time
 	}
 }
 
-func (s *cachingStorageClient) QueryPages(ctx context.Context, query chunk.IndexQuery, callback func(result chunk.ReadBatch) (shouldContinue bool)) error {
-	value, ok := s.cache.Get(ctx, queryKey(query))
-	if ok {
-		batches := value.([]chunk.ReadBatch)
-		filteredBatch := filterBatchByQuery(query, batches)
-		callback(filteredBatch)
+func (s *cachingStorageClient) QueryPages(ctx context.Context, queries []chunk.IndexQuery, callback func(chunk.IndexQuery, chunk.ReadBatch) (shouldContinue bool)) error {
+	// We cache the entire row, so filter client side.
+	callback = chunk_util.QueryFilter(callback)
+	cacheableMissed := []chunk.IndexQuery{}
+	missed := map[string]chunk.IndexQuery{}
 
-		return nil
+	for _, query := range queries {
+		value, ok := s.cache.Get(ctx, queryKey(query))
+		if !ok {
+			cacheableMissed = append(cacheableMissed, chunk.IndexQuery{
+				TableName: query.TableName,
+				HashValue: query.HashValue,
+			})
+			missed[queryKey(query)] = query
+			continue
+		}
+
+		for _, batch := range value.([]chunk.ReadBatch) {
+			callback(query, batch)
+		}
 	}
 
-	batches := []chunk.ReadBatch{}
-	cacheableQuery := chunk.IndexQuery{
-		TableName: query.TableName,
-		HashValue: query.HashValue,
-	} // Just reads the entire row and caches it.
-
-	err := s.StorageClient.QueryPages(ctx, cacheableQuery, copyingCallback(&batches))
+	results := map[string][]chunk.ReadBatch{}
+	err := s.StorageClient.QueryPages(ctx, cacheableMissed, func(cacheableQuery chunk.IndexQuery, r chunk.ReadBatch) bool {
+		key := queryKey(cacheableQuery)
+		results[key] = append(results[key], r)
+		return true
+	})
 	if err != nil {
 		return err
 	}
 
-	filteredBatch := filterBatchByQuery(query, batches)
-	callback(filteredBatch)
-
-	s.cache.Put(ctx, queryKey(query), batches)
-
-	return nil
-}
-
-type readBatch []cell
-
-func (b readBatch) Len() int                { return len(b) }
-func (b readBatch) RangeValue(i int) []byte { return b[i].column }
-func (b readBatch) Value(i int) []byte      { return b[i].value }
-
-type cell struct {
-	column []byte
-	value  []byte
-}
-
-func copyingCallback(readBatches *[]chunk.ReadBatch) func(chunk.ReadBatch) bool {
-	return func(result chunk.ReadBatch) bool {
-		*readBatches = append(*readBatches, result)
-		return true
+	for key, batches := range results {
+		query := missed[key]
+		for _, batch := range batches {
+			callback(query, batch)
+		}
 	}
+	return nil
 }
 
 func queryKey(q chunk.IndexQuery) string {
 	const sep = "\xff"
 	return q.TableName + sep + q.HashValue
-}
-
-func filterBatchByQuery(query chunk.IndexQuery, batches []chunk.ReadBatch) readBatch {
-	filter := func([]byte, []byte) bool { return true }
-
-	if len(query.RangeValuePrefix) != 0 {
-		filter = func(rangeValue []byte, value []byte) bool {
-			return strings.HasPrefix(string(rangeValue), string(query.RangeValuePrefix))
-		}
-	}
-	if len(query.RangeValueStart) != 0 {
-		filter = func(rangeValue []byte, value []byte) bool {
-			return string(rangeValue) >= string(query.RangeValueStart)
-		}
-	}
-	if len(query.ValueEqual) != 0 {
-		// This is on top of the existing filters.
-		existingFilter := filter
-		filter = func(rangeValue []byte, value []byte) bool {
-			return existingFilter(rangeValue, value) && bytes.Equal(value, query.ValueEqual)
-		}
-	}
-
-	finalBatch := make(readBatch, 0, len(batches)) // On the higher side for most queries. On the lower side for column key schema.
-	for _, batch := range batches {
-		for i := 0; i < batch.Len(); i++ {
-			if filter(batch.RangeValue(i), batch.Value(i)) {
-				finalBatch = append(finalBatch, cell{column: batch.RangeValue(i), value: batch.Value(i)})
-			}
-		}
-	}
-
-	return finalBatch
 }

--- a/pkg/chunk/storage/index_test.go
+++ b/pkg/chunk/storage/index_test.go
@@ -21,12 +21,14 @@ func TestIndexBasic(t *testing.T) {
 
 		// Make sure we get back the correct entries by hash value.
 		for i := 0; i < 30; i++ {
-			entry := chunk.IndexQuery{
-				TableName: tableName,
-				HashValue: fmt.Sprintf("hash%d", i),
+			entries := []chunk.IndexQuery{
+				{
+					TableName: tableName,
+					HashValue: fmt.Sprintf("hash%d", i),
+				},
 			}
 			var have []chunk.IndexEntry
-			err := client.QueryPages(context.Background(), entry, func(read chunk.ReadBatch) bool {
+			err := client.QueryPages(context.Background(), entries, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
 				for j := 0; j < read.Len(); j++ {
 					have = append(have, chunk.IndexEntry{
 						RangeValue: read.RangeValue(j),
@@ -167,7 +169,7 @@ func TestQueryPages(t *testing.T) {
 				run := true
 				for run {
 					var have []chunk.IndexEntry
-					err = client.QueryPages(context.Background(), tt.query, func(read chunk.ReadBatch) bool {
+					err = client.QueryPages(context.Background(), []chunk.IndexQuery{tt.query}, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
 						for i := 0; i < read.Len(); i++ {
 							have = append(have, chunk.IndexEntry{
 								TableName:  tt.query.TableName,

--- a/pkg/chunk/storage/index_test.go
+++ b/pkg/chunk/storage/index_test.go
@@ -29,9 +29,9 @@ func TestIndexBasic(t *testing.T) {
 			}
 			var have []chunk.IndexEntry
 			err := client.QueryPages(context.Background(), entries, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
-				for j := 0; j < read.Len(); j++ {
+				for read.Next() {
 					have = append(have, chunk.IndexEntry{
-						RangeValue: read.RangeValue(j),
+						RangeValue: read.RangeValue(),
 					})
 				}
 				return true
@@ -170,12 +170,12 @@ func TestQueryPages(t *testing.T) {
 				for run {
 					var have []chunk.IndexEntry
 					err = client.QueryPages(context.Background(), []chunk.IndexQuery{tt.query}, func(_ chunk.IndexQuery, read chunk.ReadBatch) bool {
-						for i := 0; i < read.Len(); i++ {
+						for read.Next() {
 							have = append(have, chunk.IndexEntry{
 								TableName:  tt.query.TableName,
 								HashValue:  tt.query.HashValue,
-								RangeValue: read.RangeValue(i),
-								Value:      read.Value(i),
+								RangeValue: read.RangeValue(),
+								Value:      read.Value(),
 							})
 						}
 						return true

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -9,7 +9,7 @@ type StorageClient interface {
 	BatchWrite(context.Context, WriteBatch) error
 
 	// For the read path.
-	QueryPages(ctx context.Context, query IndexQuery, callback func(result ReadBatch) (shouldContinue bool)) error
+	QueryPages(ctx context.Context, queries []IndexQuery, callback func(IndexQuery, ReadBatch) (shouldContinue bool)) error
 
 	// For storing and retrieving chunks.
 	PutChunks(ctx context.Context, chunks []Chunk) error

--- a/pkg/chunk/storage_client.go
+++ b/pkg/chunk/storage_client.go
@@ -23,7 +23,7 @@ type WriteBatch interface {
 
 // ReadBatch represents the results of a QueryPages.
 type ReadBatch interface {
-	Len() int
-	RangeValue(index int) []byte
-	Value(index int) []byte
+	Next() bool
+	RangeValue() []byte
+	Value() []byte
 }

--- a/pkg/chunk/util/util.go
+++ b/pkg/chunk/util/util.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/weaveworks/cortex/pkg/chunk"
+)
+
+// DoSingleQuery is the interface for indexes that don't support batching yet.
+type DoSingleQuery func(
+	ctx context.Context, query chunk.IndexQuery,
+	callback func(chunk.ReadBatch) bool,
+) error
+
+// DoParallelQueries translates between our interface for query batching,
+// and indexes that don't yet support batching.
+func DoParallelQueries(
+	ctx context.Context, doSingleQuery DoSingleQuery, queries []chunk.IndexQuery,
+	callback func(chunk.IndexQuery, chunk.ReadBatch) bool,
+) error {
+	incomingErrors := make(chan error)
+	for _, query := range queries {
+		go func(query chunk.IndexQuery) {
+			incomingErrors <- doSingleQuery(ctx, query, func(r chunk.ReadBatch) bool {
+				return callback(query, r)
+			})
+		}(query)
+	}
+	var lastErr error
+	for i := 0; i < len(queries); i++ {
+		err := <-incomingErrors
+		if err != nil {
+
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+type Callback func(chunk.IndexQuery, chunk.ReadBatch) bool
+
+type readBatch []cell
+
+func (b readBatch) Len() int                { return len(b) }
+func (b readBatch) RangeValue(i int) []byte { return b[i].column }
+func (b readBatch) Value(i int) []byte      { return b[i].value }
+
+type cell struct {
+	column []byte
+	value  []byte
+}
+
+func QueryFilter(callback Callback) Callback {
+	return func(query chunk.IndexQuery, batch chunk.ReadBatch) bool {
+		finalBatch := make(readBatch, 0, batch.Len())
+		for i := 0; i < batch.Len(); i++ {
+			rangeValue, value := batch.RangeValue(i), batch.Value(i)
+
+			if len(query.RangeValuePrefix) != 0 && !strings.HasPrefix(string(rangeValue), string(query.RangeValuePrefix)) {
+				continue
+			}
+			if len(query.RangeValueStart) != 0 && string(rangeValue) < string(query.RangeValueStart) {
+				continue
+			}
+			if len(query.ValueEqual) != 0 && !bytes.Equal(value, query.ValueEqual) {
+				continue
+			}
+
+			finalBatch = append(finalBatch, cell{column: rangeValue, value: value})
+		}
+		return callback(query, finalBatch)
+	}
+}


### PR DESCRIPTION
With the series index, resolving series ID to chunk IDs can issues 100s of thousands of queries to the index.  The cache does a good job of handling most of these, but we should batch the rest.

As part of this I changes the BigTable backend to only read full rows - this shouldn't impact performance, as the index cache was forcing us to only read full rows anyway.  I also changed the ReadBatch interface to be iterator-style, so we can filter it down without copies.

Fixes #969 