### PR TITLE
Delay more than the minimum ingester queries

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -12,6 +12,9 @@
 
    **Upgrade notes**: As this flag also makes all queries always read from all ingesters, the upgrade path is pretty trivial; just enable the flag. When you do enable it, you'll see a spike in the number of active series as the writes are "reshuffled" amongst the ingesters, but over the next stale period all the old series will be flushed, and you should end up with much better load balancing. With this flag enabled in the queriers, reads will always catch all the data from all ingesters.
 
+- `-distributor.extra-query-delay`
+   This is used by a component with an embedded distributor (Querier and Ruler) to control how long to wait until sending more than the minimum amount of queries needed for a successful response.
+
 ## Ingester, Distributor & Querier limits.
 
 Cortex implements various limits on the requests it can process, in order to prevent a single tenant overwhelming the cluster.  There are various default global limits which apply to all tenants which can be set on the command line.  These limits can also be overridden on a per-tenant basis, using a configuration file.  Specify the filename for the override configuration file using the `-limits.per-user-override-config=<filename>` flag.  The override file will be re-read every 10 seconds by default - this can also be controlled using the `-limits.per-user-override-period=10s` flag.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -122,7 +122,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&cfg.EnableBilling, "distributor.enable-billing", false, "Report number of ingested samples to billing system.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
-	f.DurationVar(&cfg.ExtraQueryDelay, "distributor.extra-query-delay", 50*time.Millisecond, "Time to wait before sending more than the minimum successful query requests.")
+	f.DurationVar(&cfg.ExtraQueryDelay, "distributor.extra-query-delay", 0, "Time to wait before sending more than the minimum successful query requests.")
 	f.BoolVar(&cfg.ShardByAllLabels, "distributor.shard-by-all-labels", false, "Distribute samples based on all labels, as opposed to solely by user and metric name.")
 }
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -79,7 +79,7 @@ func (d *Distributor) queryPrep(ctx context.Context, from, to model.Time, matche
 func (d *Distributor) queryIngesters(ctx context.Context, replicationSet ring.ReplicationSet, req *client.QueryRequest) (model.Matrix, error) {
 	// Fetch samples from multiple ingesters in parallel, using the replicationSet
 	// to deal with consistency.
-	results, err := replicationSet.Do(ctx, func(ing *ring.IngesterDesc) (interface{}, error) {
+	results, err := replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, func(ing *ring.IngesterDesc) (interface{}, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err
@@ -124,7 +124,7 @@ func (d *Distributor) queryIngesters(ctx context.Context, replicationSet ring.Re
 // queryIngesterStream queries the ingesters using the new streaming API.
 func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ring.ReplicationSet, req *client.QueryRequest) ([]client.TimeSeriesChunk, error) {
 	// Fetch samples from multiple ingesters
-	results, err := replicationSet.Do(ctx, func(ing *ring.IngesterDesc) (interface{}, error) {
+	results, err := replicationSet.Do(ctx, d.cfg.ExtraQueryDelay, func(ing *ring.IngesterDesc) (interface{}, error) {
 		client, err := d.ingesterPool.GetClientFor(ing.Addr)
 		if err != nil {
 			return nil, err

--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -15,11 +15,13 @@ type ReplicationSet struct {
 // Do function f in parallel for all replicas in the set, erroring is we exceed
 // MaxErrors and returning early otherwise.
 func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(*IngesterDesc) (interface{}, error)) ([]interface{}, error) {
-	errs := make(chan error, len(r.Ingesters))
-	resultsChan := make(chan interface{}, len(r.Ingesters))
-	minSuccess := len(r.Ingesters) - r.MaxErrors
-	done := make(chan struct{})
-	forceStart := make(chan struct{}, r.MaxErrors)
+	var (
+		errs        = make(chan error, len(r.Ingesters))
+		resultsChan = make(chan interface{}, len(r.Ingesters))
+		minSuccess  = len(r.Ingesters) - r.MaxErrors
+		done        = make(chan struct{})
+		forceStart  = make(chan struct{}, r.MaxErrors)
+	)
 	defer func() {
 		close(done)
 	}()


### PR DESCRIPTION
If one of the initial queries fails, or takes a long time, then the extra queries will be executed.
Will also reduce the number of context cancelled "errors" we get in traces/logs.

Implements the query side of: https://github.com/weaveworks/cortex/issues/100

Signed-off-by: Chris Marchbanks <csmarchbanks@gmail.com>