### PR TITLE
Clean up Timer objects quicker on ingester calls

### DIFF
--- a/pkg/ring/replication_set.go
+++ b/pkg/ring/replication_set.go
@@ -30,11 +30,13 @@ func (r ReplicationSet) Do(ctx context.Context, delay time.Duration, f func(*Ing
 		go func(i int, ing *IngesterDesc) {
 			// wait to send extra requests
 			if i >= minSuccess && delay > 0 {
+				after := time.NewTimer(delay)
+				defer after.Stop()
 				select {
 				case <-done:
 					return
 				case <-forceStart:
-				case <-time.After(delay):
+				case <-after.C:
 				}
 			}
 			result, err := f(ing)


### PR DESCRIPTION
As it says in the comment on [`time.After`](https://golang.org/pkg/time/#After):

```
// The underlying Timer is not recovered by the garbage collector
// until the timer fires. If efficiency is a concern, use NewTimer
// instead and call Timer.Stop if the timer is no longer needed.
```

(not a major concern, considering the rate at which we do queries, but it's only two lines)