### PR TITLE
Ingester: defer converting labelPairs to Metric until flush

### DIFF
--- a/pkg/chunk/chunk_test.go
+++ b/pkg/chunk/chunk_test.go
@@ -198,26 +198,7 @@ func TestChunksToMatrix(t *testing.T) {
 }
 
 func benchmarkChunk(now model.Time) Chunk {
-	// This is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
-	return dummyChunkFor(now, model.Metric{
-		model.MetricNameLabel:              "container_cpu_usage_seconds_total",
-		"beta_kubernetes_io_arch":          "amd64",
-		"beta_kubernetes_io_instance_type": "c3.somesize",
-		"beta_kubernetes_io_os":            "linux",
-		"container_name":                   "some-name",
-		"cpu":                              "cpu01",
-		"failure_domain_beta_kubernetes_io_region": "somewhere-1",
-		"failure_domain_beta_kubernetes_io_zone":   "somewhere-1b",
-		"id":       "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28",
-		"image":    "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506",
-		"instance": "ip-111-11-1-11.ec2.internal",
-		"job":      "kubernetes-cadvisor",
-		"kubernetes_io_hostname": "ip-111-11-1-11",
-		"monitor":                "prod",
-		"name":                   "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
-		"namespace":              "kube-system",
-		"pod_name":               "some-other-name-5j8s8",
-	})
+	return dummyChunkFor(now, BenchmarkMetric)
 }
 
 func BenchmarkEncode(b *testing.B) {

--- a/pkg/chunk/fixtures.go
+++ b/pkg/chunk/fixtures.go
@@ -1,0 +1,24 @@
+package chunk
+
+import "github.com/prometheus/common/model"
+
+// BenchmarkMetric is a real example from Kubernetes' embedded cAdvisor metrics, lightly obfuscated
+var BenchmarkMetric = model.Metric{
+	model.MetricNameLabel:              "container_cpu_usage_seconds_total",
+	"beta_kubernetes_io_arch":          "amd64",
+	"beta_kubernetes_io_instance_type": "c3.somesize",
+	"beta_kubernetes_io_os":            "linux",
+	"container_name":                   "some-name",
+	"cpu":                              "cpu01",
+	"failure_domain_beta_kubernetes_io_region": "somewhere-1",
+	"failure_domain_beta_kubernetes_io_zone":   "somewhere-1b",
+	"id":       "/kubepods/burstable/pod6e91c467-e4c5-11e7-ace3-0a97ed59c75e/a3c8498918bd6866349fed5a6f8c643b77c91836427fb6327913276ebc6bde28",
+	"image":    "registry/organisation/name@sha256:dca3d877a80008b45d71d7edc4fd2e44c0c8c8e7102ba5cbabec63a374d1d506",
+	"instance": "ip-111-11-1-11.ec2.internal",
+	"job":      "kubernetes-cadvisor",
+	"kubernetes_io_hostname": "ip-111-11-1-11",
+	"monitor":                "prod",
+	"name":                   "k8s_some-name_some-other-name-5j8s8_kube-system_6e91c467-e4c5-11e7-ace3-0a97ed59c75e_0",
+	"namespace":              "kube-system",
+	"pod_name":               "some-other-name-5j8s8",
+}

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -245,16 +245,6 @@ func FromLabelPairsToLabels(labelPairs []LabelPair) labels.Labels {
 	return ls
 }
 
-// ValueFromLabelPairs gets one value for a name
-func ValueFromLabelPairs(labels []LabelPair, name string) []byte {
-	for _, label := range labels {
-		if label.Name.Equal([]byte(name)) {
-			return label.Value
-		}
-	}
-	return nil
-}
-
 // FastFingerprint runs the same algorithm as Prometheus labelSetToFastFingerprint()
 func FastFingerprint(labelPairs []LabelPair) model.Fingerprint {
 	if len(labelPairs) == 0 {

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -140,19 +140,6 @@ func FromMetricsForLabelMatchersRequest(req *MetricsForLabelMatchersRequest) (mo
 	return from, to, matchersSet, nil
 }
 
-// ToMetricsForLabelMatchersResponse builds a MetricsForLabelMatchersResponse proto
-func ToMetricsForLabelMatchersResponse(metrics []model.Metric) *MetricsForLabelMatchersResponse {
-	resp := &MetricsForLabelMatchersResponse{
-		Metric: make([]*Metric, 0, len(metrics)),
-	}
-	for _, metric := range metrics {
-		resp.Metric = append(resp.Metric, &Metric{
-			Labels: ToLabelPairs(metric),
-		})
-	}
-	return resp
-}
-
 // FromMetricsForLabelMatchersResponse unpacks a MetricsForLabelMatchersResponse proto
 func FromMetricsForLabelMatchersResponse(resp *MetricsForLabelMatchersResponse) []model.Metric {
 	metrics := []model.Metric{}

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -244,3 +244,30 @@ func FromLabelPairsToLabels(labelPairs []LabelPair) labels.Labels {
 	}
 	return ls
 }
+
+// ValueFromLabelPairs gets one value for a name
+func ValueFromLabelPairs(labels []LabelPair, name string) []byte {
+	for _, label := range labels {
+		if label.Name.Equal([]byte(name)) {
+			return label.Value
+		}
+	}
+	return nil
+}
+
+// FastFingerprint runs the same algorithm as Prometheus labelSetToFastFingerprint()
+func FastFingerprint(labelPairs []LabelPair) model.Fingerprint {
+	if len(labelPairs) == 0 {
+		return model.Metric(nil).FastFingerprint()
+	}
+
+	var result uint64
+	for _, pair := range labelPairs {
+		sum := hashNew()
+		sum = hashAdd(sum, string(pair.Name))
+		sum = hashAddByte(sum, model.SeparatorByte)
+		sum = hashAdd(sum, string(pair.Value))
+		result ^= sum
+	}
+	return model.Fingerprint(result)
+}

--- a/pkg/ingester/client/fnv.go
+++ b/pkg/ingester/client/fnv.go
@@ -1,0 +1,43 @@
+// Copied from github.com/prometheus/common/model/fnv.go
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// Inline and byte-free variant of hash/fnv's fnv64a.
+
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+// hashNew initializies a new fnv64a hash value.
+func hashNew() uint64 {
+	return offset64
+}
+
+// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+func hashAdd(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}
+
+// hashAddByte adds a byte to a fnv64a hash value, returning the updated hash.
+func hashAddByte(h uint64, b byte) uint64 {
+	h ^= uint64(b)
+	h *= prime64
+	return h
+}

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -241,7 +241,7 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 	series.chunkDescs = series.chunkDescs[len(chunks):]
 	memoryChunks.Sub(float64(len(chunks)))
 	if len(series.chunkDescs) == 0 {
-		userState.removeSeries(fp, series.metric)
+		userState.removeSeries(fp, series.labels())
 	}
 	userState.fpLocker.Unlock(fp)
 	return nil

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/weaveworks/common/user"
 	"github.com/weaveworks/cortex/pkg/chunk"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/util"
 )
 
@@ -227,7 +228,7 @@ func (i *Ingester) flushUserSeries(flushQueueIndex int, userID string, fp model.
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
 
 	util.Event().Log("msg", "flush chunks", "userID", userID, "reason", reason, "numChunks", len(chunks), "firstTime", chunks[0].FirstTime, "fp", fp, "series", series.metric, "queue", flushQueueIndex)
-	err := i.flushChunks(ctx, fp, series.metric, chunks)
+	err := i.flushChunks(ctx, fp, client.FromLabelPairs(series.metric), chunks)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingester/index.go
+++ b/pkg/ingester/index.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
-
-	"github.com/weaveworks/cortex/pkg/ingester/client"
 )
 
 const indexShards = 32
@@ -129,7 +127,7 @@ func (shard *indexShard) lookupLabelValues(name model.LabelName) model.LabelValu
 	return results
 }
 
-func (ii *invertedIndex) delete(labels []client.LabelPair, fp model.Fingerprint) {
+func (ii *invertedIndex) delete(labels labelPairs, fp model.Fingerprint) {
 	i := &ii.shards[hashFP(fp)%indexShards]
 	i.mtx.Lock()
 	defer i.mtx.Unlock()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -482,7 +482,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 	for _, matchers := range matchersSet {
 		if err := state.forSeriesMatching(matchers, func(fp model.Fingerprint, series *memorySeries) error {
 			if _, ok := metrics[fp]; !ok {
-				metrics[fp] = series.metric
+				metrics[fp] = series.labels()
 			}
 			return nil
 		}); err != nil {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -265,8 +265,6 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 	return &client.WriteResponse{}, lastPartialErr
 }
 
-type labelPairs []client.LabelPair
-
 func (i *Ingester) append(ctx context.Context, labels labelPairs, timestamp model.Time, value model.SampleValue, source client.WriteRequest_SourceEnum) error {
 	for i, pair := range labels {
 		if len(pair.Value) == 0 {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -266,11 +266,7 @@ func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.
 }
 
 func (i *Ingester) append(ctx context.Context, labels labelPairs, timestamp model.Time, value model.SampleValue, source client.WriteRequest_SourceEnum) error {
-	for i, pair := range labels {
-		if len(pair.Value) == 0 {
-			labels = append(labels[:i], labels[i:]...)
-		}
-	}
+	labels.removeBlanks()
 
 	i.stopLock.RLock()
 	defer i.stopLock.RUnlock()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -469,7 +469,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return client.ToMetricsForLabelMatchersResponse(nil), nil
+		return &client.MetricsForLabelMatchersResponse{}, nil
 	}
 
 	// TODO Right now we ignore start and end.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -241,33 +241,36 @@ func (i *Ingester) StopIncomingRequests() {
 // Push implements client.IngesterServer
 func (i *Ingester) Push(ctx old_ctx.Context, req *client.WriteRequest) (*client.WriteResponse, error) {
 	var lastPartialErr error
-	samples := client.FromWriteRequest(req)
 
-	for j := range samples {
-		err := i.append(ctx, &samples[j], req.Source)
-		if err == nil {
-			continue
-		}
-
-		ingestedSamplesFail.Inc()
-		if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
-			switch httpResp.Code {
-			case http.StatusBadRequest, http.StatusTooManyRequests:
-				lastPartialErr = err
+	for _, ts := range req.Timeseries {
+		for _, s := range ts.Samples {
+			err := i.append(ctx, ts.Labels, model.Time(s.TimestampMs), model.SampleValue(s.Value), req.Source)
+			if err == nil {
 				continue
 			}
-		}
 
-		return nil, err
+			ingestedSamplesFail.Inc()
+			if httpResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				switch httpResp.Code {
+				case http.StatusBadRequest, http.StatusTooManyRequests:
+					lastPartialErr = err
+					continue
+				}
+			}
+
+			return nil, err
+		}
 	}
 
 	return &client.WriteResponse{}, lastPartialErr
 }
 
-func (i *Ingester) append(ctx context.Context, sample *model.Sample, source client.WriteRequest_SourceEnum) error {
-	for ln, lv := range sample.Metric {
-		if len(lv) == 0 {
-			delete(sample.Metric, ln)
+type labelPairs []client.LabelPair
+
+func (i *Ingester) append(ctx context.Context, labels labelPairs, timestamp model.Time, value model.SampleValue, source client.WriteRequest_SourceEnum) error {
+	for i, pair := range labels {
+		if len(pair.Value) == 0 {
+			labels = append(labels[:i], labels[i:]...)
 		}
 	}
 
@@ -279,7 +282,7 @@ func (i *Ingester) append(ctx context.Context, sample *model.Sample, source clie
 
 	i.userStatesMtx.RLock()
 	defer i.userStatesMtx.RUnlock()
-	state, fp, series, err := i.userStates.getOrCreateSeries(ctx, sample.Metric)
+	state, fp, series, err := i.userStates.getOrCreateSeries(ctx, labels)
 	if err != nil {
 		return err
 	}
@@ -289,8 +292,8 @@ func (i *Ingester) append(ctx context.Context, sample *model.Sample, source clie
 
 	prevNumChunks := len(series.chunkDescs)
 	if err := series.add(model.SamplePair{
-		Value:     sample.Value,
-		Timestamp: sample.Timestamp,
+		Value:     value,
+		Timestamp: timestamp,
 	}); err != nil {
 		if mse, ok := err.(*memorySeriesError); ok {
 			validation.DiscardedSamples.WithLabelValues(mse.errorType, state.userID).Inc()
@@ -337,7 +340,7 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 		return &client.QueryResponse{}, nil
 	}
 
-	result := model.Matrix{}
+	result := &client.QueryResponse{}
 	numSeries, numSamples := 0, 0
 	maxSamplesPerQuery := i.limits.MaxSamplesPerQuery(userID)
 	err = state.forSeriesMatching(matchers, func(_ model.Fingerprint, series *memorySeries) error {
@@ -355,15 +358,22 @@ func (i *Ingester) Query(ctx old_ctx.Context, req *client.QueryRequest) (*client
 			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "exceeded maximum number of samples in a query (%d)", maxSamplesPerQuery)
 		}
 
-		result = append(result, &model.SampleStream{
-			Metric: series.metric,
-			Values: values,
-		})
+		ts := client.TimeSeries{
+			Labels:  series.metric,
+			Samples: make([]client.Sample, 0, len(values)),
+		}
+		for _, s := range values {
+			ts.Samples = append(ts.Samples, client.Sample{
+				Value:       float64(s.Value),
+				TimestampMs: int64(s.Timestamp),
+			})
+		}
+		result.Timeseries = append(result.Timeseries, ts)
 		return nil
 	})
 	queriedSeries.Observe(float64(numSeries))
 	queriedSamples.Observe(float64(numSamples))
-	return client.ToQueryResponse(result), err
+	return result, err
 }
 
 // QueryStream implements service.IngesterServer
@@ -406,7 +416,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 		numChunks += len(wireChunks)
 		batch = append(batch, client.TimeSeriesChunk{
-			Labels: client.ToLabelPairs(series.metric),
+			Labels: series.metric,
 			Chunks: wireChunks,
 		})
 
@@ -468,7 +478,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 		return nil, err
 	}
 
-	metrics := map[model.Fingerprint]model.Metric{}
+	metrics := map[model.Fingerprint]labelPairs{}
 	for _, matchers := range matchersSet {
 		if err := state.forSeriesMatching(matchers, func(fp model.Fingerprint, series *memorySeries) error {
 			if _, ok := metrics[fp]; !ok {
@@ -480,12 +490,14 @@ func (i *Ingester) MetricsForLabelMatchers(ctx old_ctx.Context, req *client.Metr
 		}
 	}
 
-	result := []model.Metric{}
+	result := &client.MetricsForLabelMatchersResponse{
+		Metric: make([]*client.Metric, 0, len(metrics)),
+	}
 	for _, metric := range metrics {
-		result = append(result, metric)
+		result.Metric = append(result.Metric, &client.Metric{Labels: metric})
 	}
 
-	return client.ToMetricsForLabelMatchersResponse(result), nil
+	return result, nil
 }
 
 // UserStats returns ingestion statistics for the current user.

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -399,6 +399,7 @@ func BenchmarkIngesterPush(b *testing.B) {
 		})
 	}
 	ctx := user.InjectOrgID(context.Background(), "1")
+	b.ResetTimer()
 	for iter := 0; iter < b.N; iter++ {
 		_, ing := newTestStore(b, cfg)
 		// Bump the timestamp on each of our test samples each time round the loop

--- a/pkg/ingester/label_pairs.go
+++ b/pkg/ingester/label_pairs.go
@@ -56,6 +56,20 @@ func (s sortedLabelPairs) String() string {
 	return labelPairs(s).String()
 }
 
+// Remove any label where the value is "" - Prometheus 2+ will remove these
+// before sending, but other clients such as Prometheus 1.x might send us blanks.
+func (a *labelPairs) removeBlanks() {
+	for i := 0; i < len(*a); {
+		if len((*a)[i].Value) == 0 {
+			// Delete by swap with the value at the end of the slice
+			(*a)[i] = (*a)[len(*a)-1]
+			(*a) = (*a)[:len(*a)-1]
+			continue // go round and check the data that is now at position i
+		}
+		i++
+	}
+}
+
 func (a labelPairs) copyValuesAndSort() sortedLabelPairs {
 	c := make(sortedLabelPairs, len(a))
 	// Since names and values may point into a much larger buffer,

--- a/pkg/ingester/label_pairs.go
+++ b/pkg/ingester/label_pairs.go
@@ -1,0 +1,102 @@
+package ingester
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/weaveworks/cortex/pkg/ingester/client"
+	"github.com/weaveworks/cortex/pkg/util/extract"
+)
+
+// A series is uniquely identified by its set of label name/value
+// pairs, which may arrive in any order over the wire
+type labelPairs []client.LabelPair
+
+// We sort the set for faster lookup, and use a separate type to let
+// the compiler check usage.
+type sortedLabelPairs []client.LabelPair
+
+func (s sortedLabelPairs) Len() int           { return len(s) }
+func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }
+func (s sortedLabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+var labelNameBytes = []byte(model.MetricNameLabel)
+
+func (a labelPairs) String() string {
+	var b strings.Builder
+
+	metricName, err := extract.MetricNameFromLabelPairs(a)
+	numLabels := len(a) - 1
+	if err != nil {
+		numLabels = len(a)
+	}
+	b.Write(metricName)
+	b.WriteByte('{')
+	count := 0
+	for _, pair := range a {
+		if !pair.Name.Equal(labelNameBytes) {
+			b.Write(pair.Name)
+			b.WriteString("=\"")
+			b.Write(pair.Value)
+			b.WriteByte('"')
+			count++
+			if count < numLabels {
+				b.WriteByte(',')
+			}
+		}
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (s sortedLabelPairs) String() string {
+	return labelPairs(s).String()
+}
+
+func (a labelPairs) copyValuesAndSort() sortedLabelPairs {
+	c := make(sortedLabelPairs, len(a))
+	// Since names and values may point into a much larger buffer,
+	// make a copy of all the names and values, in one block for efficiency
+	totalLength := 0
+	for _, pair := range a {
+		totalLength += len(pair.Name) + len(pair.Value)
+	}
+	copyBytes := make([]byte, totalLength)
+	pos := 0
+	copyByteSlice := func(val []byte) []byte {
+		start := pos
+		pos += copy(copyBytes[pos:], val)
+		return copyBytes[start:pos]
+	}
+	for i, pair := range a {
+		c[i].Name = copyByteSlice(pair.Name)
+		c[i].Value = copyByteSlice(pair.Value)
+	}
+	sort.Sort(c)
+	return c
+}
+
+func (s sortedLabelPairs) valueForName(name []byte) []byte {
+	pos := sort.Search(len(s), func(i int) bool { return bytes.Compare(s[i].Name, name) >= 0 })
+	if pos == len(s) || !bytes.Equal(s[pos].Name, name) {
+		return nil
+	}
+	return s[pos].Value
+}
+
+// Check if s and b contain the same name/value pairs
+func (s sortedLabelPairs) equal(b labelPairs) bool {
+	if len(s) != len(b) {
+		return false
+	}
+	for _, pair := range b {
+		found := s.valueForName(pair.Name)
+		if found == nil || !bytes.Equal(found, pair.Value) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -47,19 +47,20 @@ func newFPMapper(fpToSeries *seriesMap) *fpMapper {
 //
 // If an error is encountered, it is returned together with the unchanged raw
 // fingerprint.
-func (m *fpMapper) mapFP(fp model.Fingerprint, metric model.Metric) model.Fingerprint {
+func (m *fpMapper) mapFP(fp model.Fingerprint, metric labelPairs) model.Fingerprint {
 	// First check if we are in the reserved FP space, in which case this is
 	// automatically a collision that has to be mapped.
 	if fp <= maxMappedFP {
 		return m.maybeAddMapping(fp, metric)
 	}
 
+	ms := metricToUniqueString(metric)
 	// Then check the most likely case: This fp belongs to a series that is
 	// already in memory.
 	s, ok := m.fpToSeries.get(fp)
 	if ok {
 		// FP exists in memory, but is it for the same metric?
-		if metric.Equal(s.metric) {
+		if ms == metricToUniqueString(s.metric) {
 			// Yupp. We are done.
 			return fp
 		}
@@ -73,7 +74,6 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric model.Metric) model.Finger
 	m.mtx.RUnlock()
 	if fpAlreadyMapped {
 		// We indeed have mapped fp historically.
-		ms := metricToUniqueString(metric)
 		// fp is locked by the caller, so no further locking of
 		// 'collisions' required (it is specific to fp).
 		mappedFP, ok := mappedFPs[ms]
@@ -90,7 +90,7 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric model.Metric) model.Finger
 // truly unique fingerprint for the colliding metric.
 func (m *fpMapper) maybeAddMapping(
 	fp model.Fingerprint,
-	collidingMetric model.Metric,
+	collidingMetric labelPairs,
 ) model.Fingerprint {
 	ms := metricToUniqueString(collidingMetric)
 	m.mtx.RLock()
@@ -143,10 +143,10 @@ func (m *fpMapper) nextMappedFP() model.Fingerprint {
 // FastFingerprint function, and its result is not suitable as a key for maps
 // and indexes as it might become really large, causing a lot of hashing effort
 // in maps and a lot of storage overhead in indexes.
-func metricToUniqueString(m model.Metric) string {
+func metricToUniqueString(m labelPairs) string {
 	parts := make([]string, 0, len(m))
-	for ln, lv := range m {
-		parts = append(parts, string(ln)+separatorString+string(lv))
+	for _, pair := range m {
+		parts = append(parts, string(pair.Name)+separatorString+string(pair.Value))
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, separatorString)

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -54,13 +54,12 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric labelPairs) model.Fingerpr
 		return m.maybeAddMapping(fp, metric)
 	}
 
-	ms := metricToUniqueString(metric)
 	// Then check the most likely case: This fp belongs to a series that is
 	// already in memory.
 	s, ok := m.fpToSeries.get(fp)
 	if ok {
 		// FP exists in memory, but is it for the same metric?
-		if ms == metricToUniqueString(s.metric) {
+		if s.metric.equal(metric) {
 			// Yupp. We are done.
 			return fp
 		}
@@ -74,6 +73,7 @@ func (m *fpMapper) mapFP(fp model.Fingerprint, metric labelPairs) model.Fingerpr
 	m.mtx.RUnlock()
 	if fpAlreadyMapped {
 		// We indeed have mapped fp historically.
+		ms := metricToUniqueString(metric)
 		// fp is locked by the caller, so no further locking of
 		// 'collisions' required (it is specific to fp).
 		mappedFP, ok := mappedFPs[ms]

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -54,12 +54,12 @@ func TestFPMapper(t *testing.T) {
 
 	// cm11 is in sm. Adding cm11 should do nothing. Mapping cm12 should resolve
 	// the collision.
-	sm.put(fp1, &memorySeries{metric: cm11})
+	sm.put(fp1, &memorySeries{metric: cm11.sort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 
 	// The mapped cm12 is added to sm, too. That should not change the outcome.
-	sm.put(model.Fingerprint(1), &memorySeries{metric: cm12})
+	sm.put(model.Fingerprint(1), &memorySeries{metric: cm12.sort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 
@@ -68,27 +68,27 @@ func TestFPMapper(t *testing.T) {
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm13), model.Fingerprint(2))
 
 	// Add cm13 to sm. Should not change anything.
-	sm.put(model.Fingerprint(2), &memorySeries{metric: cm13})
+	sm.put(model.Fingerprint(2), &memorySeries{metric: cm13.sort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm13), model.Fingerprint(2))
 
 	// Now add cm21 and cm22 in the same way, checking the mapped FPs.
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
-	sm.put(fp2, &memorySeries{metric: cm21})
+	sm.put(fp2, &memorySeries{metric: cm21.sort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm22), model.Fingerprint(3))
-	sm.put(model.Fingerprint(3), &memorySeries{metric: cm22})
+	sm.put(model.Fingerprint(3), &memorySeries{metric: cm22.sort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm22), model.Fingerprint(3))
 
 	// Map cm31, resulting in a mapping straight away.
 	assertFingerprintEqual(t, mapper.mapFP(fp3, cm31), model.Fingerprint(4))
-	sm.put(model.Fingerprint(4), &memorySeries{metric: cm31})
+	sm.put(model.Fingerprint(4), &memorySeries{metric: cm31.sort()})
 
 	// Map cm32, which is now mapped for two reasons...
 	assertFingerprintEqual(t, mapper.mapFP(fp3, cm32), model.Fingerprint(5))
-	sm.put(model.Fingerprint(5), &memorySeries{metric: cm32})
+	sm.put(model.Fingerprint(5), &memorySeries{metric: cm32.sort()})
 
 	// Now check ALL the mappings, just to be sure.
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -54,12 +54,12 @@ func TestFPMapper(t *testing.T) {
 
 	// cm11 is in sm. Adding cm11 should do nothing. Mapping cm12 should resolve
 	// the collision.
-	sm.put(fp1, &memorySeries{metric: cm11.sort()})
+	sm.put(fp1, &memorySeries{metric: cm11.copyValuesAndSort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 
 	// The mapped cm12 is added to sm, too. That should not change the outcome.
-	sm.put(model.Fingerprint(1), &memorySeries{metric: cm12.sort()})
+	sm.put(model.Fingerprint(1), &memorySeries{metric: cm12.copyValuesAndSort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 
@@ -68,27 +68,27 @@ func TestFPMapper(t *testing.T) {
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm13), model.Fingerprint(2))
 
 	// Add cm13 to sm. Should not change anything.
-	sm.put(model.Fingerprint(2), &memorySeries{metric: cm13.sort()})
+	sm.put(model.Fingerprint(2), &memorySeries{metric: cm13.copyValuesAndSort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm12), model.Fingerprint(1))
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm13), model.Fingerprint(2))
 
 	// Now add cm21 and cm22 in the same way, checking the mapped FPs.
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
-	sm.put(fp2, &memorySeries{metric: cm21.sort()})
+	sm.put(fp2, &memorySeries{metric: cm21.copyValuesAndSort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm22), model.Fingerprint(3))
-	sm.put(model.Fingerprint(3), &memorySeries{metric: cm22.sort()})
+	sm.put(model.Fingerprint(3), &memorySeries{metric: cm22.copyValuesAndSort()})
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm21), fp2)
 	assertFingerprintEqual(t, mapper.mapFP(fp2, cm22), model.Fingerprint(3))
 
 	// Map cm31, resulting in a mapping straight away.
 	assertFingerprintEqual(t, mapper.mapFP(fp3, cm31), model.Fingerprint(4))
-	sm.put(model.Fingerprint(4), &memorySeries{metric: cm31.sort()})
+	sm.put(model.Fingerprint(4), &memorySeries{metric: cm31.copyValuesAndSort()})
 
 	// Map cm32, which is now mapped for two reasons...
 	assertFingerprintEqual(t, mapper.mapFP(fp3, cm32), model.Fingerprint(5))
-	sm.put(model.Fingerprint(5), &memorySeries{metric: cm32.sort()})
+	sm.put(model.Fingerprint(5), &memorySeries{metric: cm32.copyValuesAndSort()})
 
 	// Now check ALL the mappings, just to be sure.
 	assertFingerprintEqual(t, mapper.mapFP(fp1, cm11), fp1)

--- a/pkg/ingester/mapper_test.go
+++ b/pkg/ingester/mapper_test.go
@@ -16,30 +16,30 @@ var (
 	fp1  = model.Fingerprint(maxMappedFP + 1)
 	fp2  = model.Fingerprint(maxMappedFP + 2)
 	fp3  = model.Fingerprint(1)
-	cm11 = model.Metric{
-		"foo":   "bar",
-		"dings": "bumms",
+	cm11 = labelPairs{
+		{Name: []byte("foo"), Value: []byte("bar")},
+		{Name: []byte("dings"), Value: []byte("bumms")},
 	}
-	cm12 = model.Metric{
-		"bar": "foo",
+	cm12 = labelPairs{
+		{Name: []byte("bar"), Value: []byte("foo")},
 	}
-	cm13 = model.Metric{
-		"foo": "bar",
+	cm13 = labelPairs{
+		{Name: []byte("foo"), Value: []byte("bar")},
 	}
-	cm21 = model.Metric{
-		"foo":   "bumms",
-		"dings": "bar",
+	cm21 = labelPairs{
+		{Name: []byte("foo"), Value: []byte("bumms")},
+		{Name: []byte("dings"), Value: []byte("bar")},
 	}
-	cm22 = model.Metric{
-		"dings": "foo",
-		"bar":   "bumms",
+	cm22 = labelPairs{
+		{Name: []byte("dings"), Value: []byte("foo")},
+		{Name: []byte("bar"), Value: []byte("bumms")},
 	}
-	cm31 = model.Metric{
-		"bumms": "dings",
+	cm31 = labelPairs{
+		{Name: []byte("bumms"), Value: []byte("dings")},
 	}
-	cm32 = model.Metric{
-		"bumms": "dings",
-		"bar":   "foo",
+	cm32 = labelPairs{
+		{Name: []byte("bumms"), Value: []byte("dings")},
+		{Name: []byte("bar"), Value: []byte("foo")},
 	}
 )
 

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/metric"
 )
@@ -23,7 +24,13 @@ func init() {
 	prometheus.MustRegister(createdChunks)
 }
 
-type sortedLabelPairs labelPairs
+// A series is uniquely identified by its set of label name/value
+// pairs, which may arrive in any order over the wire
+type labelPairs []client.LabelPair
+
+// We sort the set for faster lookup, and use a separate type to let
+// the compiler check usage.
+type sortedLabelPairs []client.LabelPair
 
 func (s sortedLabelPairs) Len() int           { return len(s) }
 func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -25,32 +25,32 @@ func init() {
 
 type sortedLabelPairs labelPairs
 
-func (m sortedLabelPairs) Len() int           { return len(m) }
-func (m sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(m[i].Name, m[j].Name) < 0 }
-func (m sortedLabelPairs) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (s sortedLabelPairs) Len() int           { return len(s) }
+func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }
+func (s sortedLabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-func (m labelPairs) sort() sortedLabelPairs {
-	c := make(sortedLabelPairs, len(m))
-	copy(c, m)
+func (s labelPairs) sort() sortedLabelPairs {
+	c := make(sortedLabelPairs, len(s))
+	copy(c, s)
 	sort.Sort(c)
 	return c
 }
 
-func (a sortedLabelPairs) valueForName(name []byte) []byte {
-	pos := sort.Search(len(a), func(i int) bool { return bytes.Compare(a[i].Name, name) >= 0 })
-	if pos == len(a) || !bytes.Equal(a[pos].Name, name) {
+func (s sortedLabelPairs) valueForName(name []byte) []byte {
+	pos := sort.Search(len(s), func(i int) bool { return bytes.Compare(s[i].Name, name) >= 0 })
+	if pos == len(s) || !bytes.Equal(s[pos].Name, name) {
 		return nil
 	}
-	return a[pos].Value
+	return s[pos].Value
 }
 
-// Check if a and b contain the same name/value pairs
-func (a sortedLabelPairs) equal(b labelPairs) bool {
-	if len(a) != len(b) {
+// Check if s and b contain the same name/value pairs
+func (s sortedLabelPairs) equal(b labelPairs) bool {
+	if len(s) != len(b) {
 		return false
 	}
 	for _, pair := range b {
-		found := a.valueForName(pair.Name)
+		found := s.valueForName(pair.Name)
 		if found == nil || !bytes.Equal(found, pair.Value) {
 			return false
 		}

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -1,14 +1,12 @@
 package ingester
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
-	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/local/chunk"
 	"github.com/weaveworks/cortex/pkg/prom1/storage/metric"
 )
@@ -22,63 +20,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(createdChunks)
-}
-
-// A series is uniquely identified by its set of label name/value
-// pairs, which may arrive in any order over the wire
-type labelPairs []client.LabelPair
-
-// We sort the set for faster lookup, and use a separate type to let
-// the compiler check usage.
-type sortedLabelPairs []client.LabelPair
-
-func (s sortedLabelPairs) Len() int           { return len(s) }
-func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }
-func (s sortedLabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
-func (a labelPairs) copyValuesAndSort() sortedLabelPairs {
-	c := make(sortedLabelPairs, len(a))
-	// Since names and values may point into a much larger buffer,
-	// make a copy of all the names and values, in one block for efficiency
-	totalLength := 0
-	for _, pair := range a {
-		totalLength += len(pair.Name) + len(pair.Value)
-	}
-	copyBytes := make([]byte, totalLength)
-	pos := 0
-	copyByteSlice := func(val []byte) []byte {
-		start := pos
-		pos += copy(copyBytes[pos:], val)
-		return copyBytes[start:pos]
-	}
-	for i, pair := range a {
-		c[i].Name = copyByteSlice(pair.Name)
-		c[i].Value = copyByteSlice(pair.Value)
-	}
-	sort.Sort(c)
-	return c
-}
-
-func (s sortedLabelPairs) valueForName(name []byte) []byte {
-	pos := sort.Search(len(s), func(i int) bool { return bytes.Compare(s[i].Name, name) >= 0 })
-	if pos == len(s) || !bytes.Equal(s[pos].Name, name) {
-		return nil
-	}
-	return s[pos].Value
-}
-
-// Check if s and b contain the same name/value pairs
-func (s sortedLabelPairs) equal(b labelPairs) bool {
-	if len(s) != len(b) {
-		return false
-	}
-	for _, pair := range b {
-		found := s.valueForName(pair.Name)
-		if found == nil || !bytes.Equal(found, pair.Value) {
-			return false
-		}
-	}
-	return true
 }
 
 type memorySeries struct {

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -29,9 +29,25 @@ func (s sortedLabelPairs) Len() int           { return len(s) }
 func (s sortedLabelPairs) Less(i, j int) bool { return bytes.Compare(s[i].Name, s[j].Name) < 0 }
 func (s sortedLabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
-func (s labelPairs) sort() sortedLabelPairs {
-	c := make(sortedLabelPairs, len(s))
-	copy(c, s)
+func (a labelPairs) copyValuesAndSort() sortedLabelPairs {
+	c := make(sortedLabelPairs, len(a))
+	// Since names and values may point into a much larger buffer,
+	// make a copy of all the names and values, in one block for efficiency
+	totalLength := 0
+	for _, pair := range a {
+		totalLength += len(pair.Name) + len(pair.Value)
+	}
+	copyBytes := make([]byte, totalLength)
+	pos := 0
+	copyByteSlice := func(val []byte) []byte {
+		start := pos
+		pos += copy(copyBytes[pos:], val)
+		return copyBytes[start:pos]
+	}
+	for i, pair := range a {
+		c[i].Name = copyByteSlice(pair.Name)
+		c[i].Value = copyByteSlice(pair.Value)
+	}
 	sort.Sort(c)
 	return c
 }
@@ -88,7 +104,7 @@ func (error *memorySeriesError) Error() string {
 // given metric.
 func newMemorySeries(m labelPairs) *memorySeries {
 	return &memorySeries{
-		metric:   m.sort(),
+		metric:   m.copyValuesAndSort(),
 		lastTime: model.Earliest,
 	}
 }

--- a/pkg/ingester/series.go
+++ b/pkg/ingester/series.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 type memorySeries struct {
-	metric model.Metric
+	metric labelPairs
 
 	// Sorted by start time, overlapping chunk ranges are forbidden.
 	chunkDescs []*desc
@@ -50,7 +50,7 @@ func (error *memorySeriesError) Error() string {
 
 // newMemorySeries returns a pointer to a newly allocated memorySeries for the
 // given metric.
-func newMemorySeries(m model.Metric) *memorySeries {
+func newMemorySeries(m labelPairs) *memorySeries {
 	return &memorySeries{
 		metric:   m,
 		lastTime: model.Earliest,

--- a/pkg/ingester/transfer.go
+++ b/pkg/ingester/transfer.go
@@ -84,14 +84,13 @@ func (i *Ingester) TransferChunks(stream client.Ingester_TransferChunksServer) e
 			fromIngesterID = wireSeries.FromIngesterId
 			level.Info(util.Logger).Log("msg", "processing TransferChunks request", "from_ingester", fromIngesterID)
 		}
-		metric := client.FromLabelPairs(wireSeries.Labels)
 		userCtx := user.InjectOrgID(stream.Context(), wireSeries.UserId)
 		descs, err := fromWireChunks(wireSeries.Chunks)
 		if err != nil {
 			return err
 		}
 
-		state, fp, series, err := userStates.getOrCreateSeries(userCtx, metric)
+		state, fp, series, err := userStates.getOrCreateSeries(userCtx, wireSeries.Labels)
 		if err != nil {
 			return err
 		}
@@ -222,7 +221,7 @@ func (i *Ingester) TransferOut(ctx context.Context) error {
 			err = stream.Send(&client.TimeSeriesChunk{
 				FromIngesterId: i.lifecycler.ID,
 				UserId:         userID,
-				Labels:         client.ToLabelPairs(pair.series.metric),
+				Labels:         pair.series.metric,
 				Chunks:         chunks,
 			})
 			state.fpLocker.Unlock(pair.fp)

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -117,7 +117,7 @@ func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, erro
 	return state, ok, nil
 }
 
-func (us *userStates) getOrCreateSeries(ctx context.Context, labels []client.LabelPair) (*userState, model.Fingerprint, *memorySeries, error) {
+func (us *userStates) getOrCreateSeries(ctx context.Context, labels labelPairs) (*userState, model.Fingerprint, *memorySeries, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("no user id")

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -261,7 +261,7 @@ outer:
 		}
 
 		for _, filter := range filters {
-			if !filter.Matches(string(client.ValueFromLabelPairs(series.metric, filter.Name))) {
+			if !filter.Matches(string(series.metric.valueForName([]byte(filter.Name)))) {
 				u.fpLocker.Unlock(fp)
 				continue outer
 			}

--- a/pkg/ingester/user_state.go
+++ b/pkg/ingester/user_state.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/cortex/pkg/ingester/client"
 	"github.com/weaveworks/cortex/pkg/util"
 	"github.com/weaveworks/cortex/pkg/util/extract"
 	"github.com/weaveworks/cortex/pkg/util/validation"
@@ -61,7 +62,7 @@ const metricCounterShards = 128
 
 type metricCounterShard struct {
 	mtx sync.Mutex
-	m   map[model.LabelValue]int
+	m   map[string]int
 }
 
 func newUserStates(limits *validation.Overrides, cfg Config) *userStates {
@@ -116,7 +117,7 @@ func (us *userStates) getViaContext(ctx context.Context) (*userState, bool, erro
 	return state, ok, nil
 }
 
-func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric) (*userState, model.Fingerprint, *memorySeries, error) {
+func (us *userStates) getOrCreateSeries(ctx context.Context, labels []client.LabelPair) (*userState, model.Fingerprint, *memorySeries, error) {
 	userID, err := user.ExtractOrgID(ctx)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("no user id")
@@ -128,7 +129,7 @@ func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric
 		seriesInMetric := make([]metricCounterShard, 0, metricCounterShards)
 		for i := 0; i < metricCounterShards; i++ {
 			seriesInMetric = append(seriesInMetric, metricCounterShard{
-				m: map[model.LabelValue]int{},
+				m: map[string]int{},
 			})
 		}
 
@@ -153,12 +154,12 @@ func (us *userStates) getOrCreateSeries(ctx context.Context, metric model.Metric
 		state = stored.(*userState)
 	}
 
-	fp, series, err := state.getSeries(metric)
+	fp, series, err := state.getSeries(labels)
 	return state, fp, series, err
 }
 
-func (u *userState) getSeries(metric model.Metric) (model.Fingerprint, *memorySeries, error) {
-	rawFP := metric.FastFingerprint()
+func (u *userState) getSeries(metric labelPairs) (model.Fingerprint, *memorySeries, error) {
+	rawFP := client.FastFingerprint(metric)
 	u.fpLocker.Lock(rawFP)
 	fp := u.mapper.mapFP(rawFP, metric)
 	if fp != rawFP {
@@ -181,13 +182,13 @@ func (u *userState) getSeries(metric model.Metric) (model.Fingerprint, *memorySe
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-user series limit (%d) exceeded", u.limits.MaxSeriesPerUser(u.userID))
 	}
 
-	metricName, err := extract.MetricNameFromMetric(metric)
+	metricName, err := extract.MetricNameFromLabelPairs(metric)
 	if err != nil {
 		u.fpLocker.Unlock(fp)
 		return fp, nil, err
 	}
 
-	if !u.canAddSeriesFor(metricName) {
+	if !u.canAddSeriesFor(string(metricName)) {
 		u.fpLocker.Unlock(fp)
 		return fp, nil, httpgrpc.Errorf(http.StatusTooManyRequests, "per-metric series limit (%d) exceeded for %s: %s", u.limits.MaxSeriesPerMetric(u.userID), metricName, metric)
 	}
@@ -203,7 +204,7 @@ func (u *userState) getSeries(metric model.Metric) (model.Fingerprint, *memorySe
 	return fp, series, nil
 }
 
-func (u *userState) canAddSeriesFor(metric model.LabelValue) bool {
+func (u *userState) canAddSeriesFor(metric string) bool {
 	shard := &u.seriesInMetric[hashFP(model.Fingerprint(fnv1a.HashString64(string(metric))))%metricCounterShards]
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
@@ -215,16 +216,17 @@ func (u *userState) canAddSeriesFor(metric model.LabelValue) bool {
 	return true
 }
 
-func (u *userState) removeSeries(fp model.Fingerprint, metric model.Metric) {
+func (u *userState) removeSeries(fp model.Fingerprint, metric labelPairs) {
 	u.fpToSeries.del(fp)
 	u.index.delete(metric, fp)
 
-	metricName, err := extract.MetricNameFromMetric(metric)
+	metricNameB, err := extract.MetricNameFromLabelPairs(metric)
 	if err != nil {
 		// Series without a metric name should never be able to make it into
 		// the ingester's memory storage.
 		panic(err)
 	}
+	metricName := string(metricNameB)
 
 	shard := &u.seriesInMetric[hashFP(model.Fingerprint(fnv1a.HashString64(string(metricName))))%metricCounterShards]
 	shard.mtx.Lock()
@@ -259,7 +261,7 @@ outer:
 		}
 
 		for _, filter := range filters {
-			if !filter.Matches(string(series.metric[model.LabelName(filter.Name)])) {
+			if !filter.Matches(string(client.ValueFromLabelPairs(series.metric, filter.Name))) {
 				u.fpLocker.Unlock(fp)
 				continue outer
 			}


### PR DESCRIPTION
Another go at #997 , in which the code to delete blank labels was wrong.
I have added a unit test with ~a blank label~ _two_ blank labels, since I got it wrong for that case the second and third attempt.
Also added a `String()` function so `labelPairs` print out like Metrics.